### PR TITLE
track implicit login/terms events

### DIFF
--- a/src/cmd/cli/command/track.go
+++ b/src/cmd/cli/command/track.go
@@ -39,15 +39,19 @@ func FlushAllTracking() {
 	trackWG.Wait()
 }
 
+func IsCompletionCommand(cmd *cobra.Command) bool {
+	return cmd.Name() == cobra.ShellCompRequestCmd || (cmd.Parent() != nil && cmd.Parent().Name() == "completion")
+}
+
 // trackCmd sends a tracking event for a Cobra command and its arguments.
 func trackCmd(cmd *cobra.Command, verb string, props ...P) {
-	command := "Unknown"
+	command := "Implicit"
 	if cmd != nil {
-		command = cmd.Name()
 		// Ignore tracking for shell completion requests
-		if command == cobra.ShellCompRequestCmd {
+		if IsCompletionCommand(cmd) {
 			return
 		}
+		command = cmd.Name()
 		calledAs := cmd.CalledAs()
 		cmd.VisitParents(func(c *cobra.Command) {
 			calledAs = c.CalledAs() + " " + calledAs


### PR DESCRIPTION
our analytics has many "Compose-Up" events without "Terms" and/or "Login" events, causing weird results in our dashboard. This is because we do login/terms interactively when needed and these were not tracked.

New events are called "Implicit Login" and "Implicit Terms" (compare with "Login Invoked" and "Terms Invoked" for the explicit ones)

![image](https://github.com/DefangLabs/defang/assets/591860/3d8e4298-34f7-4248-9c54-34e5d50d68b4)

