### PR TITLE
announce releases on discord

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -139,6 +139,8 @@ jobs:
           MACOS_P12_BASE64: ${{ secrets.MACOS_P12_BASE64 }}
           MACOS_P12_PASSWORD: ${{ secrets.MACOS_P12_PASSWORD }}
           KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+          DISCORD_WEBHOOK_ID: ${{ secrets.DISCORD_WEBHOOK_ID }}
+          DISCORD_WEBHOOK_TOKEN: ${{ secrets.DISCORD_WEBHOOK_TOKEN }}
 
       - name: Notarize macOS app
         shell: bash

--- a/src/.goreleaser.yml
+++ b/src/.goreleaser.yml
@@ -84,3 +84,7 @@ changelog:
     exclude:
       # Ignore messages like "defang: v0.5.3 -> v0.5.4" (which are actually for the previous version)
       - "^defang: v[0-9]+\\.[0-9]+\\.[0-9]+ -> v[0-9]+\\.[0-9]+\\.[0-9]+$"
+
+announce:
+  discord:
+    enabled: true


### PR DESCRIPTION
This relies on `DISCORD_WEBHOOK_ID` and `DISCORD_WEBHOOK_TOKEN` action secrets, which I got from creating a hook in Discord: 

![image](https://github.com/DefangLabs/defang/assets/591860/0f4f8193-a918-4583-acc4-6d978e6e13f0)
