### PR TITLE
Handle ECS events from cloudwatch logs

### DIFF
--- a/src/pkg/cli/client/byoc/aws/byoc.go
+++ b/src/pkg/cli/client/byoc/aws/byoc.go
@@ -476,6 +476,8 @@ func (b *ByocAws) Tail(ctx context.Context, req *defangv1.TailRequest) (client.S
 		term.Debug(" - Tailing kaniko logs", kanikoTail.LogGroupARN)
 		servicesTail := ecs.LogGroupInput{LogGroupARN: b.driver.MakeARN("logs", "log-group:"+b.stackDir("logs"))} // must match logic in ecs/common.ts
 		term.Debug(" - Tailing services logs", servicesTail.LogGroupARN)
+		ecsTail := ecs.LogGroupInput{LogGroupARN: b.driver.MakeARN("logs", "log-group:"+b.stackDir("ecs"))} // must match logic in ecs/common.ts
+		term.Debug(" - Tailing ecs events logs", ecsTail.LogGroupARN)
 		cdTail := ecs.LogGroupInput{LogGroupARN: b.driver.LogGroupARN}
 		taskArn = b.cdTasks[etag]
 		if taskArn != nil {
@@ -483,7 +485,7 @@ func (b *ByocAws) Tail(ctx context.Context, req *defangv1.TailRequest) (client.S
 			cdTail.LogStreamNames = []string{ecs.GetLogStreamForTaskID(ecs.GetTaskID(taskArn))}
 		}
 		term.Debug(" - Tailing CD logs", cdTail.LogGroupARN, cdTail.LogStreamNames)
-		eventStream, err = ecs.TailLogGroups(ctx, req.Since.AsTime(), cdTail, kanikoTail, servicesTail)
+		eventStream, err = ecs.TailLogGroups(ctx, req.Since.AsTime(), cdTail, kanikoTail, servicesTail, ecsTail)
 	}
 	if err != nil {
 		return nil, annotateAwsError(err)

--- a/src/pkg/cli/client/byoc/aws/stream.go
+++ b/src/pkg/cli/client/byoc/aws/stream.go
@@ -5,8 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
-	"net/http"
 	"path"
 	"strings"
 	"time"
@@ -17,7 +15,6 @@ import (
 	"github.com/DefangLabs/defang/src/pkg/clouds/aws/ecs"
 	"github.com/DefangLabs/defang/src/pkg/logs"
 	defangv1 "github.com/DefangLabs/defang/src/protos/io/defang/v1"
-	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -30,6 +27,8 @@ type byocServerStream struct {
 	response *defangv1.TailResponse
 	service  string
 	stream   ecs.EventStream
+
+	remaining []ecs.LogEvent
 }
 
 func newByocServerStream(ctx context.Context, stream ecs.EventStream, etag, service string) *byocServerStream {
@@ -69,39 +68,45 @@ type hasErrCh interface {
 }
 
 func (bs *byocServerStream) Receive() bool {
-	select {
-	case e := <-bs.stream.Events(): // blocking
-		entries, err := bs.parseEvents(e)
-		if err != nil {
+	var evts = bs.remaining
+	if len(evts) == 0 {
+		select {
+		case e := <-bs.stream.Events(): // blocking
+			var err error
+			evts, err = ecs.GetLogEvents(e)
+			if err != nil {
+				bs.err = err
+				return false
+			}
+		case err := <-bs.errCh: // blocking (if not nil)
 			bs.err = err
+			return false // abort on first error?
+
+		case <-bs.ctx.Done(): // blocking (if not nil)
+			bs.err = context.Cause(bs.ctx)
 			return false
 		}
-		bs.response.Entries = entries
-		return true
-
-	case err := <-bs.errCh: // blocking (if not nil)
+	}
+	entries, remaining, err := bs.parseEvents(evts)
+	if err != nil {
 		bs.err = err
-		return false // abort on first error?
-
-	case <-bs.ctx.Done(): // blocking (if not nil)
-		bs.err = context.Cause(bs.ctx)
 		return false
 	}
+	bs.response.Entries = entries
+	bs.remaining = remaining
+	return true
 }
 
-func (bs *byocServerStream) parseEvents(e types.StartLiveTailResponseStream) ([]*defangv1.LogEntry, error) {
-	events, err := ecs.GetLogEvents(e)
-	if err != nil {
-		return nil, err
-	}
+func (bs *byocServerStream) parseEvents(events []ecs.LogEvent) ([]*defangv1.LogEntry, []ecs.LogEvent, error) {
 	bs.response = &defangv1.TailResponse{}
 	if len(events) == 0 {
 		// The original gRPC/connect server stream would never send an empty response.
 		// We could loop around the select, but returning an empty response updates the spinner.
-		return nil, nil
+		return nil, nil, nil
 	}
 	var record logs.FirelensMessage
 	parseFirelensRecords := false
+	parseECSEventRecords := false
 	// Get the Etag/Host/Service from the first event (should be the same for all events in this batch)
 	event := events[0]
 	if parts := strings.Split(*event.LogStreamName, "/"); len(parts) == 3 {
@@ -116,7 +121,7 @@ func (bs *byocServerStream) parseEvents(e types.StartLiveTailResponseStream) ([]
 			parts = strings.Split(parts[1], "_")
 			if len(parts) != 2 || !pkg.IsValidRandomID(parts[1]) {
 				// skip, ignore sidecar logs (like route53-sidecar or fluentbit)
-				return nil, nil
+				return nil, nil, nil
 			}
 			service, etag := parts[0], parts[1]
 			bs.response.Etag = etag
@@ -131,48 +136,55 @@ func (bs *byocServerStream) parseEvents(e types.StartLiveTailResponseStream) ([]
 			parseFirelensRecords = true
 		}
 	} else if strings.HasSuffix(*event.LogGroupIdentifier, "/ecs") || strings.HasSuffix(*event.LogGroupIdentifier, "/ecs:*") {
-		fmt.Printf("ECS: LogGroupIdentifier: %s\n", *event.LogGroupIdentifier)
 		var ecsEvt ecs.Event
 		if err := json.Unmarshal([]byte(*event.Message), &ecsEvt); err != nil {
-			return nil, err
+			return nil, events[1:], fmt.Errorf("error unmarshaling ECS Event: %w", err)
 		}
-
+		parseECSEventRecords = true
 		switch ecsEvt.DetailType {
 		case "ECS Task State Change":
 			var detail ecs.ECSTaskStateChange
 			if err := json.Unmarshal(ecsEvt.Detail, &detail); err != nil {
-				return nil, fmt.Errorf("error unmarshaling ECS task state change: %w", err)
+				return nil, events[1:], fmt.Errorf("error unmarshaling ECS task state change: %w", err)
 			}
-
+			if len(detail.Containers) < 1 {
+				return nil, events[1:], fmt.Errorf("error parsing ECS task state change: missing containers section")
+			}
+			i := strings.LastIndex(detail.Containers[0].Name, "_")
+			if i < 0 {
+				return nil, events[1:], fmt.Errorf("error parsing ECS task state change: invalid container name %q", detail.Containers[0].Name)
+			}
+			bs.response.Etag = detail.Containers[0].Name[i+1:]
+			bs.response.Service = detail.Containers[0].Name[:i]
+			bs.response.Host = path.Base(ecsEvt.Resources[0])
 		case "ECS Service Action", "ECS Deployment State Change": // pretty much the same JSON structure for both
-			// Parse the service ARN to extract the ECS service name.
-			ecsService := path.Base(ecsEvt.Resources[0])
-
 			var detail ecs.ECSDeploymentStateChange
 			if err := json.Unmarshal(ecsEvt.Detail, &detail); err != nil {
-				return nil, fmt.Errorf("error unmarshaling ECS service/deployment event: %v", err)
+				return nil, events[1:], fmt.Errorf("error unmarshaling ECS service/deployment event: %v", err)
 			}
+			ecsSvcName := path.Base(ecsEvt.Resources[0])
+			// TODO: etag is not available at service and deployment level, find a possible correlation, possibly task definition revision using the deploymentId
+			// bs.response.Etag =
+			snStart := strings.LastIndex(ecsSvcName, "_") // ecsSvcName is in the format "project_service-random", our validation does not allow '_' in service names
+			snEnd := strings.LastIndex(ecsSvcName, "-")
+			if snStart < 0 || snEnd < 0 {
+				return nil, events[1:], fmt.Errorf("error parsing ECS service action: invalid service name %q", ecsEvt.Resources[0])
+			}
+			bs.response.Service = ecsSvcName[snStart+1 : snEnd]
+			bs.response.Host = detail.DeploymentId
 
-			status := detail.EventName // eg. SERVICE_TASK_PLACEMENT_FAILURE or SERVICE_STEADY_STATE
-			if detail.Reason != "" && status != "SERVICE_DEPLOYMENT_COMPLETED" {
-				status += " " + detail.Reason // eg. "RESOURCE:FARGATE" or "ECS deployment ecs-svc/77495883616404538 completed."
-			}
-
-			fqn := getQualifiedNameFromEcsName(ecsService)
-			// Don't return an error if the status update fails, or ECS will resend the event overwriting newer status; TODO: get etag from service/deployment
-			if err := f.updateServiceStatus(fqn, status, ""); err != nil {
-				log.Printf("dropped service status update: %v\n", err)
-			}
 		default:
-			rw.WriteHeader(http.StatusBadRequest) // no retry; EventBridge only retries on 5xx/429
-			return
+			bs.response.Etag = bs.etag // TODO: Is it possible to filter by etag?
+			bs.response.Service = "ecs"
+			bs.response.Host = path.Base(ecsEvt.Resources[0]) // TODO: Verify this is the service name
 		}
 	}
+
 	if bs.etag != "" && bs.etag != bs.response.Etag {
-		return nil, nil // TODO: filter these out using the AWS StartLiveTail API
+		return nil, nil, nil // TODO: filter these out using the AWS StartLiveTail API
 	}
 	if bs.service != "" && bs.service != bs.response.Service {
-		return nil, nil // TODO: filter these out using the AWS StartLiveTail API
+		return nil, nil, nil // TODO: filter these out using the AWS StartLiveTail API
 	}
 	entries := make([]*defangv1.LogEntry, len(events))
 	for i, event := range events {
@@ -187,6 +199,16 @@ func (bs *byocServerStream) parseEvents(e types.StartLiveTailResponseStream) ([]
 					stderr = record.Source == logs.SourceStderr
 				}
 			}
+		} else if parseECSEventRecords {
+			var err error
+			if message, err = parseECSEventRecord(event); err != nil {
+				return nil, events[1:], err
+			}
+			return []*defangv1.LogEntry{{
+				Message:   message,
+				Stderr:    stderr,
+				Timestamp: timestamppb.New(time.UnixMilli(*event.Timestamp)),
+			}}, events[1:], nil
 		} else if bs.response.Service == "cd" && strings.HasPrefix(message, " ** ") {
 			stderr = true
 		}
@@ -196,5 +218,47 @@ func (bs *byocServerStream) parseEvents(e types.StartLiveTailResponseStream) ([]
 			Timestamp: timestamppb.New(time.UnixMilli(*event.Timestamp)),
 		}
 	}
-	return entries, nil
+	return entries, nil, nil
+}
+
+func parseECSEventRecord(event ecs.LogEvent) (string, error) {
+	var ecsEvt ecs.Event
+	if err := json.Unmarshal([]byte(*event.Message), &ecsEvt); err != nil {
+		return "", fmt.Errorf("error unmarshaling ECS event: %w", err)
+	}
+
+	var buf strings.Builder
+	fmt.Fprintf(&buf, "%s %s ", ecsEvt.DetailType, path.Base(ecsEvt.Resources[0]))
+	switch ecsEvt.DetailType {
+	case "ECS Task State Change":
+		var detail ecs.ECSTaskStateChange
+		if err := json.Unmarshal(ecsEvt.Detail, &detail); err != nil {
+			return "", fmt.Errorf("error unmarshaling ECS task state change: %w", err)
+		}
+		fmt.Fprintf(&buf, "%s %s", path.Base(detail.ClusterArn), detail.LastStatus)
+		if detail.StoppedReason != "" {
+			fmt.Fprintf(&buf, " : %s", detail.StoppedReason)
+		}
+
+	case "ECS Service Action", "ECS Deployment State Change": // pretty much the same JSON structure for both
+		var detail ecs.ECSDeploymentStateChange
+		if err := json.Unmarshal(ecsEvt.Detail, &detail); err != nil {
+			return "", fmt.Errorf("error unmarshaling ECS service/deployment event: %v", err)
+		}
+		fmt.Fprintf(&buf, "%s", detail.EventName)
+		if detail.Reason != "" {
+			fmt.Fprintf(&buf, " : %s", detail.Reason)
+		}
+		// raw, err := json.MarshalIndent(ecsEvt, "", "  ")
+		// if err == nil {
+		// 	log.Printf("ECS Event: %s\n", raw)
+		// }
+	default:
+		raw, err := json.MarshalIndent(ecsEvt.Detail, "", "  ")
+		if err != nil {
+			return "", fmt.Errorf("error marshaling ECS event detail: %w", err)
+		}
+		fmt.Fprintf(&buf, "\n%s", raw)
+	}
+	return buf.String(), nil
 }

--- a/src/pkg/cli/tail.go
+++ b/src/pkg/cli/tail.go
@@ -223,6 +223,7 @@ func Tail(ctx context.Context, client client.Client, params TailOptions) error {
 		isInternal := msg.Service == "cd" || msg.Service == "ci" || msg.Service == "kaniko" || msg.Service == "fabric" || msg.Host == "kaniko" || msg.Host == "fabric"
 		onlyErrors := !DoVerbose && isInternal
 		for _, e := range msg.Entries {
+			fmt.Printf("Service: %s, Host: %s, Message: %s\n", msg.Service, msg.Host, e.Message)
 			if onlyErrors && !e.Stderr {
 				if params.EndEventDetectFunc != nil && params.EndEventDetectFunc(msg.Service, msg.Host, e.Message) {
 					return nil

--- a/src/pkg/cli/tail.go
+++ b/src/pkg/cli/tail.go
@@ -223,7 +223,6 @@ func Tail(ctx context.Context, client client.Client, params TailOptions) error {
 		isInternal := msg.Service == "cd" || msg.Service == "ci" || msg.Service == "kaniko" || msg.Service == "fabric" || msg.Host == "kaniko" || msg.Host == "fabric"
 		onlyErrors := !DoVerbose && isInternal
 		for _, e := range msg.Entries {
-			fmt.Printf("Service: %s, Host: %s, Message: %s\n", msg.Service, msg.Host, e.Message)
 			if onlyErrors && !e.Stderr {
 				if params.EndEventDetectFunc != nil && params.EndEventDetectFunc(msg.Service, msg.Host, e.Message) {
 					return nil

--- a/src/pkg/clouds/aws/ecs/ecsserviceaction/aws_event.go
+++ b/src/pkg/clouds/aws/ecs/ecsserviceaction/aws_event.go
@@ -1,0 +1,54 @@
+package ecsserviceaction
+
+import (
+    "time"
+)
+
+
+type AWSEvent struct {
+    Detail ECSServiceAction `json:"detail"`
+    Account string `json:"account"`
+    DetailType string `json:"detail-type"`
+    Id string `json:"id"`
+    Region string `json:"region"`
+    Resources []string `json:"resources"`
+    Source string `json:"source"`
+    Time time.Time `json:"time"`
+    Version string `json:"version"`
+}
+
+func (a *AWSEvent) SetDetail(detail ECSServiceAction) {
+    a.Detail = detail
+}
+
+func (a *AWSEvent) SetAccount(account string) {
+    a.Account = account
+}
+
+func (a *AWSEvent) SetDetailType(detailType string) {
+    a.DetailType = detailType
+}
+
+func (a *AWSEvent) SetId(id string) {
+    a.Id = id
+}
+
+func (a *AWSEvent) SetRegion(region string) {
+    a.Region = region
+}
+
+func (a *AWSEvent) SetResources(resources []string) {
+    a.Resources = resources
+}
+
+func (a *AWSEvent) SetSource(source string) {
+    a.Source = source
+}
+
+func (a *AWSEvent) SetTime(time time.Time) {
+    a.Time = time
+}
+
+func (a *AWSEvent) SetVersion(version string) {
+    a.Version = version
+}

--- a/src/pkg/clouds/aws/ecs/ecsserviceaction/ecs_service_action.go
+++ b/src/pkg/clouds/aws/ecs/ecsserviceaction/ecs_service_action.go
@@ -1,0 +1,84 @@
+package ecsserviceaction
+
+import (
+    "time"
+)
+
+
+type ECSServiceAction struct {
+    CapacityProviderArns []string `json:"capacityProviderArns,omitempty"`
+    ClusterArn string `json:"clusterArn"`
+    CreatedAt time.Time `json:"createdAt,omitempty"`
+    EventName string `json:"eventName"`
+    EventType string `json:"eventType"`
+    Reason string `json:"reason,omitempty"`
+    DesiredCount float64 `json:"desiredCount,omitempty"`
+    ContainerPort float64 `json:"containerPort,omitempty"`
+    TaskArns []string `json:"taskArns,omitempty"`
+    TaskSetArns []string `json:"taskSetArns,omitempty"`
+    ContainerInstanceArns []string `json:"containerInstanceArns,omitempty"`
+    Ec2InstanceIds []string `json:"ec2InstanceIds,omitempty"`
+    TargetGroupArns []string `json:"targetGroupArns,omitempty"`
+    ServiceRegistryArns []string `json:"serviceRegistryArns,omitempty"`
+    Targets []string `json:"targets,omitempty"`
+}
+
+func (e *ECSServiceAction) SetCapacityProviderArns(capacityProviderArns []string) {
+    e.CapacityProviderArns = capacityProviderArns
+}
+
+func (e *ECSServiceAction) SetClusterArn(clusterArn string) {
+    e.ClusterArn = clusterArn
+}
+
+func (e *ECSServiceAction) SetCreatedAt(createdAt time.Time) {
+    e.CreatedAt = createdAt
+}
+
+func (e *ECSServiceAction) SetEventName(eventName string) {
+    e.EventName = eventName
+}
+
+func (e *ECSServiceAction) SetEventType(eventType string) {
+    e.EventType = eventType
+}
+
+func (e *ECSServiceAction) SetReason(reason string) {
+    e.Reason = reason
+}
+
+func (e *ECSServiceAction) SetDesiredCount(desiredCount float64) {
+    e.DesiredCount = desiredCount
+}
+
+func (e *ECSServiceAction) SetContainerPort(containerPort float64) {
+    e.ContainerPort = containerPort
+}
+
+func (e *ECSServiceAction) SetTaskArns(taskArns []string) {
+    e.TaskArns = taskArns
+}
+
+func (e *ECSServiceAction) SetTaskSetArns(taskSetArns []string) {
+    e.TaskSetArns = taskSetArns
+}
+
+func (e *ECSServiceAction) SetContainerInstanceArns(containerInstanceArns []string) {
+    e.ContainerInstanceArns = containerInstanceArns
+}
+
+func (e *ECSServiceAction) SetEc2InstanceIds(ec2InstanceIds []string) {
+    e.Ec2InstanceIds = ec2InstanceIds
+}
+
+func (e *ECSServiceAction) SetTargetGroupArns(targetGroupArns []string) {
+    e.TargetGroupArns = targetGroupArns
+}
+
+func (e *ECSServiceAction) SetServiceRegistryArns(serviceRegistryArns []string) {
+    e.ServiceRegistryArns = serviceRegistryArns
+}
+
+func (e *ECSServiceAction) SetTargets(targets []string) {
+    e.Targets = targets
+}

--- a/src/pkg/clouds/aws/ecs/ecsserviceaction/marshaller.go
+++ b/src/pkg/clouds/aws/ecs/ecsserviceaction/marshaller.go
@@ -1,0 +1,34 @@
+package ecsserviceaction
+
+import (
+    "encoding/json"
+)
+
+func Marshal(inputEvent interface{}) ([]byte, error) {
+    outputStream, err := json.Marshal(inputEvent)
+    if err != nil {
+        return nil, err
+    }
+
+    return outputStream, nil
+}
+
+func Unmarshal(inputStream []byte) (map[string]interface{}, error) {
+    var outputEvent map[string]interface{}
+    err := json.Unmarshal(inputStream, &outputEvent)
+    if err != nil {
+        return nil, err
+    }
+
+    return outputEvent, nil
+}
+
+func UnmarshalEvent(inputStream []byte) (AWSEvent, error) {
+    var outputEvent AWSEvent
+    err := json.Unmarshal(inputStream, &outputEvent)
+    if err != nil {
+        return AWSEvent{}, err
+    }
+
+    return outputEvent, nil
+}

--- a/src/pkg/clouds/aws/ecs/ecstaskstatechange/attachment_details.go
+++ b/src/pkg/clouds/aws/ecs/ecstaskstatechange/attachment_details.go
@@ -1,0 +1,24 @@
+package ecstaskstatechange
+
+type AttachmentDetails struct {
+	Id                    string                      `json:"id,omitempty"`
+	AttachmentDetailsType string                      `json:"type,omitempty"`
+	Status                string                      `json:"status,omitempty"`
+	Details               []AttachmentDetails_details `json:"details,omitempty"`
+}
+
+func (a *AttachmentDetails) SetId(id string) {
+	a.Id = id
+}
+
+func (a *AttachmentDetails) SetAttachmentDetailsType(attachmentDetailsType string) {
+	a.AttachmentDetailsType = attachmentDetailsType
+}
+
+func (a *AttachmentDetails) SetStatus(status string) {
+	a.Status = status
+}
+
+func (a *AttachmentDetails) SetDetails(details []AttachmentDetails_details) {
+	a.Details = details
+}

--- a/src/pkg/clouds/aws/ecs/ecstaskstatechange/attachment_details_details.go
+++ b/src/pkg/clouds/aws/ecs/ecstaskstatechange/attachment_details_details.go
@@ -1,0 +1,14 @@
+package ecstaskstatechange
+
+type AttachmentDetails_details struct {
+    Name string `json:"name,omitempty"`
+    Value string `json:"value,omitempty"`
+}
+
+func (a *AttachmentDetails_details) SetName(name string) {
+    a.Name = name
+}
+
+func (a *AttachmentDetails_details) SetValue(value string) {
+    a.Value = value
+}

--- a/src/pkg/clouds/aws/ecs/ecstaskstatechange/attributes_details.go
+++ b/src/pkg/clouds/aws/ecs/ecstaskstatechange/attributes_details.go
@@ -1,0 +1,14 @@
+package ecstaskstatechange
+
+type AttributesDetails struct {
+    Name string `json:"name,omitempty"`
+    Value string `json:"value,omitempty"`
+}
+
+func (a *AttributesDetails) SetName(name string) {
+    a.Name = name
+}
+
+func (a *AttributesDetails) SetValue(value string) {
+    a.Value = value
+}

--- a/src/pkg/clouds/aws/ecs/ecstaskstatechange/aws_event.go
+++ b/src/pkg/clouds/aws/ecs/ecstaskstatechange/aws_event.go
@@ -1,0 +1,54 @@
+package ecstaskstatechange
+
+import (
+    "time"
+)
+
+
+type AWSEvent struct {
+    Detail ECSTaskStateChange `json:"detail"`
+    DetailType string `json:"detail-type"`
+    Resources []string `json:"resources"`
+    Id string `json:"id"`
+    Source string `json:"source"`
+    Time time.Time `json:"time"`
+    Region string `json:"region"`
+    Version string `json:"version"`
+    Account string `json:"account"`
+}
+
+func (a *AWSEvent) SetDetail(detail ECSTaskStateChange) {
+    a.Detail = detail
+}
+
+func (a *AWSEvent) SetDetailType(detailType string) {
+    a.DetailType = detailType
+}
+
+func (a *AWSEvent) SetResources(resources []string) {
+    a.Resources = resources
+}
+
+func (a *AWSEvent) SetId(id string) {
+    a.Id = id
+}
+
+func (a *AWSEvent) SetSource(source string) {
+    a.Source = source
+}
+
+func (a *AWSEvent) SetTime(time time.Time) {
+    a.Time = time
+}
+
+func (a *AWSEvent) SetRegion(region string) {
+    a.Region = region
+}
+
+func (a *AWSEvent) SetVersion(version string) {
+    a.Version = version
+}
+
+func (a *AWSEvent) SetAccount(account string) {
+    a.Account = account
+}

--- a/src/pkg/clouds/aws/ecs/ecstaskstatechange/container_details.go
+++ b/src/pkg/clouds/aws/ecs/ecstaskstatechange/container_details.go
@@ -1,0 +1,79 @@
+package ecstaskstatechange
+
+type ContainerDetails struct {
+    Image string `json:"image,omitempty"`
+    ImageDigest string `json:"imageDigest,omitempty"`
+    NetworkInterfaces []NetworkInterfaceDetails `json:"networkInterfaces,omitempty"`
+    NetworkBindings []NetworkBindingDetails `json:"networkBindings,omitempty"`
+    Memory string `json:"memory,omitempty"`
+    MemoryReservation string `json:"memoryReservation,omitempty"`
+    TaskArn string `json:"taskArn"`
+    Name string `json:"name"`
+    ExitCode float64 `json:"exitCode,omitempty"`
+    Cpu string `json:"cpu,omitempty"`
+    ContainerArn string `json:"containerArn"`
+    LastStatus string `json:"lastStatus"`
+    RuntimeId string `json:"runtimeId,omitempty"`
+    Reason string `json:"reason,omitempty"`
+    GpuIds []string `json:"gpuIds,omitempty"`
+}
+
+func (c *ContainerDetails) SetImage(image string) {
+    c.Image = image
+}
+
+func (c *ContainerDetails) SetImageDigest(imageDigest string) {
+    c.ImageDigest = imageDigest
+}
+
+func (c *ContainerDetails) SetNetworkInterfaces(networkInterfaces []NetworkInterfaceDetails) {
+    c.NetworkInterfaces = networkInterfaces
+}
+
+func (c *ContainerDetails) SetNetworkBindings(networkBindings []NetworkBindingDetails) {
+    c.NetworkBindings = networkBindings
+}
+
+func (c *ContainerDetails) SetMemory(memory string) {
+    c.Memory = memory
+}
+
+func (c *ContainerDetails) SetMemoryReservation(memoryReservation string) {
+    c.MemoryReservation = memoryReservation
+}
+
+func (c *ContainerDetails) SetTaskArn(taskArn string) {
+    c.TaskArn = taskArn
+}
+
+func (c *ContainerDetails) SetName(name string) {
+    c.Name = name
+}
+
+func (c *ContainerDetails) SetExitCode(exitCode float64) {
+    c.ExitCode = exitCode
+}
+
+func (c *ContainerDetails) SetCpu(cpu string) {
+    c.Cpu = cpu
+}
+
+func (c *ContainerDetails) SetContainerArn(containerArn string) {
+    c.ContainerArn = containerArn
+}
+
+func (c *ContainerDetails) SetLastStatus(lastStatus string) {
+    c.LastStatus = lastStatus
+}
+
+func (c *ContainerDetails) SetRuntimeId(runtimeId string) {
+    c.RuntimeId = runtimeId
+}
+
+func (c *ContainerDetails) SetReason(reason string) {
+    c.Reason = reason
+}
+
+func (c *ContainerDetails) SetGpuIds(gpuIds []string) {
+    c.GpuIds = gpuIds
+}

--- a/src/pkg/clouds/aws/ecs/ecstaskstatechange/ecs_task_state_change.go
+++ b/src/pkg/clouds/aws/ecs/ecstaskstatechange/ecs_task_state_change.go
@@ -1,0 +1,159 @@
+package ecstaskstatechange
+
+import (
+    "time"
+)
+
+
+type ECSTaskStateChange struct {
+    Overrides Overrides `json:"overrides"`
+    ExecutionStoppedAt time.Time `json:"executionStoppedAt,omitempty"`
+    Memory string `json:"memory,omitempty"`
+    Attachments []AttachmentDetails `json:"attachments,omitempty"`
+    Attributes []AttributesDetails `json:"attributes,omitempty"`
+    PullStartedAt time.Time `json:"pullStartedAt,omitempty"`
+    TaskArn string `json:"taskArn"`
+    StartedAt time.Time `json:"startedAt,omitempty"`
+    CreatedAt time.Time `json:"createdAt"`
+    ClusterArn string `json:"clusterArn"`
+    Connectivity string `json:"connectivity,omitempty"`
+    PlatformVersion string `json:"platformVersion,omitempty"`
+    ContainerInstanceArn string `json:"containerInstanceArn,omitempty"`
+    LaunchType string `json:"launchType,omitempty"`
+    Group string `json:"group,omitempty"`
+    UpdatedAt time.Time `json:"updatedAt"`
+    StopCode string `json:"stopCode,omitempty"`
+    PullStoppedAt time.Time `json:"pullStoppedAt,omitempty"`
+    ConnectivityAt time.Time `json:"connectivityAt,omitempty"`
+    StartedBy string `json:"startedBy,omitempty"`
+    Cpu string `json:"cpu,omitempty"`
+    Version float64 `json:"version"`
+    StoppingAt time.Time `json:"stoppingAt,omitempty"`
+    StoppedAt time.Time `json:"stoppedAt,omitempty"`
+    TaskDefinitionArn string `json:"taskDefinitionArn"`
+    StoppedReason string `json:"stoppedReason,omitempty"`
+    Containers []ContainerDetails `json:"containers"`
+    DesiredStatus string `json:"desiredStatus"`
+    LastStatus string `json:"lastStatus"`
+    AvailabilityZone string `json:"availabilityZone,omitempty"`
+}
+
+func (e *ECSTaskStateChange) SetOverrides(overrides Overrides) {
+    e.Overrides = overrides
+}
+
+func (e *ECSTaskStateChange) SetExecutionStoppedAt(executionStoppedAt time.Time) {
+    e.ExecutionStoppedAt = executionStoppedAt
+}
+
+func (e *ECSTaskStateChange) SetMemory(memory string) {
+    e.Memory = memory
+}
+
+func (e *ECSTaskStateChange) SetAttachments(attachments []AttachmentDetails) {
+    e.Attachments = attachments
+}
+
+func (e *ECSTaskStateChange) SetAttributes(attributes []AttributesDetails) {
+    e.Attributes = attributes
+}
+
+func (e *ECSTaskStateChange) SetPullStartedAt(pullStartedAt time.Time) {
+    e.PullStartedAt = pullStartedAt
+}
+
+func (e *ECSTaskStateChange) SetTaskArn(taskArn string) {
+    e.TaskArn = taskArn
+}
+
+func (e *ECSTaskStateChange) SetStartedAt(startedAt time.Time) {
+    e.StartedAt = startedAt
+}
+
+func (e *ECSTaskStateChange) SetCreatedAt(createdAt time.Time) {
+    e.CreatedAt = createdAt
+}
+
+func (e *ECSTaskStateChange) SetClusterArn(clusterArn string) {
+    e.ClusterArn = clusterArn
+}
+
+func (e *ECSTaskStateChange) SetConnectivity(connectivity string) {
+    e.Connectivity = connectivity
+}
+
+func (e *ECSTaskStateChange) SetPlatformVersion(platformVersion string) {
+    e.PlatformVersion = platformVersion
+}
+
+func (e *ECSTaskStateChange) SetContainerInstanceArn(containerInstanceArn string) {
+    e.ContainerInstanceArn = containerInstanceArn
+}
+
+func (e *ECSTaskStateChange) SetLaunchType(launchType string) {
+    e.LaunchType = launchType
+}
+
+func (e *ECSTaskStateChange) SetGroup(group string) {
+    e.Group = group
+}
+
+func (e *ECSTaskStateChange) SetUpdatedAt(updatedAt time.Time) {
+    e.UpdatedAt = updatedAt
+}
+
+func (e *ECSTaskStateChange) SetStopCode(stopCode string) {
+    e.StopCode = stopCode
+}
+
+func (e *ECSTaskStateChange) SetPullStoppedAt(pullStoppedAt time.Time) {
+    e.PullStoppedAt = pullStoppedAt
+}
+
+func (e *ECSTaskStateChange) SetConnectivityAt(connectivityAt time.Time) {
+    e.ConnectivityAt = connectivityAt
+}
+
+func (e *ECSTaskStateChange) SetStartedBy(startedBy string) {
+    e.StartedBy = startedBy
+}
+
+func (e *ECSTaskStateChange) SetCpu(cpu string) {
+    e.Cpu = cpu
+}
+
+func (e *ECSTaskStateChange) SetVersion(version float64) {
+    e.Version = version
+}
+
+func (e *ECSTaskStateChange) SetStoppingAt(stoppingAt time.Time) {
+    e.StoppingAt = stoppingAt
+}
+
+func (e *ECSTaskStateChange) SetStoppedAt(stoppedAt time.Time) {
+    e.StoppedAt = stoppedAt
+}
+
+func (e *ECSTaskStateChange) SetTaskDefinitionArn(taskDefinitionArn string) {
+    e.TaskDefinitionArn = taskDefinitionArn
+}
+
+func (e *ECSTaskStateChange) SetStoppedReason(stoppedReason string) {
+    e.StoppedReason = stoppedReason
+}
+
+func (e *ECSTaskStateChange) SetContainers(containers []ContainerDetails) {
+    e.Containers = containers
+}
+
+func (e *ECSTaskStateChange) SetDesiredStatus(desiredStatus string) {
+    e.DesiredStatus = desiredStatus
+}
+
+func (e *ECSTaskStateChange) SetLastStatus(lastStatus string) {
+    e.LastStatus = lastStatus
+}
+
+func (e *ECSTaskStateChange) SetAvailabilityZone(availabilityZone string) {
+    e.AvailabilityZone = availabilityZone
+}

--- a/src/pkg/clouds/aws/ecs/ecstaskstatechange/environment.go
+++ b/src/pkg/clouds/aws/ecs/ecstaskstatechange/environment.go
@@ -1,0 +1,6 @@
+package ecstaskstatechange
+
+type Environment struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}

--- a/src/pkg/clouds/aws/ecs/ecstaskstatechange/marshaller.go
+++ b/src/pkg/clouds/aws/ecs/ecstaskstatechange/marshaller.go
@@ -1,0 +1,34 @@
+package ecstaskstatechange
+
+import (
+    "encoding/json"
+)
+
+func Marshal(inputEvent interface{}) ([]byte, error) {
+    outputStream, err := json.Marshal(inputEvent)
+    if err != nil {
+        return nil, err
+    }
+
+    return outputStream, nil
+}
+
+func Unmarshal(inputStream []byte) (map[string]interface{}, error) {
+    var outputEvent map[string]interface{}
+    err := json.Unmarshal(inputStream, &outputEvent)
+    if err != nil {
+        return nil, err
+    }
+
+    return outputEvent, nil
+}
+
+func UnmarshalEvent(inputStream []byte) (AWSEvent, error) {
+    var outputEvent AWSEvent
+    err := json.Unmarshal(inputStream, &outputEvent)
+    if err != nil {
+        return AWSEvent{}, err
+    }
+
+    return outputEvent, nil
+}

--- a/src/pkg/clouds/aws/ecs/ecstaskstatechange/network_binding_details.go
+++ b/src/pkg/clouds/aws/ecs/ecstaskstatechange/network_binding_details.go
@@ -1,0 +1,24 @@
+package ecstaskstatechange
+
+type NetworkBindingDetails struct {
+    BindIP string `json:"bindIP,omitempty"`
+    Protocol string `json:"protocol,omitempty"`
+    ContainerPort float64 `json:"containerPort,omitempty"`
+    HostPort float64 `json:"hostPort,omitempty"`
+}
+
+func (n *NetworkBindingDetails) SetBindIP(bindIP string) {
+    n.BindIP = bindIP
+}
+
+func (n *NetworkBindingDetails) SetProtocol(protocol string) {
+    n.Protocol = protocol
+}
+
+func (n *NetworkBindingDetails) SetContainerPort(containerPort float64) {
+    n.ContainerPort = containerPort
+}
+
+func (n *NetworkBindingDetails) SetHostPort(hostPort float64) {
+    n.HostPort = hostPort
+}

--- a/src/pkg/clouds/aws/ecs/ecstaskstatechange/network_interface_details.go
+++ b/src/pkg/clouds/aws/ecs/ecstaskstatechange/network_interface_details.go
@@ -1,0 +1,19 @@
+package ecstaskstatechange
+
+type NetworkInterfaceDetails struct {
+    PrivateIpv4Address string `json:"privateIpv4Address,omitempty"`
+    Ipv6Address string `json:"ipv6Address,omitempty"`
+    AttachmentId string `json:"attachmentId,omitempty"`
+}
+
+func (n *NetworkInterfaceDetails) SetPrivateIpv4Address(privateIpv4Address string) {
+    n.PrivateIpv4Address = privateIpv4Address
+}
+
+func (n *NetworkInterfaceDetails) SetIpv6Address(ipv6Address string) {
+    n.Ipv6Address = ipv6Address
+}
+
+func (n *NetworkInterfaceDetails) SetAttachmentId(attachmentId string) {
+    n.AttachmentId = attachmentId
+}

--- a/src/pkg/clouds/aws/ecs/ecstaskstatechange/overrides.go
+++ b/src/pkg/clouds/aws/ecs/ecstaskstatechange/overrides.go
@@ -1,0 +1,9 @@
+package ecstaskstatechange
+
+type Overrides struct {
+    ContainerOverrides []OverridesItem `json:"containerOverrides"`
+}
+
+func (o *Overrides) SetContainerOverrides(containerOverrides []OverridesItem) {
+    o.ContainerOverrides = containerOverrides
+}

--- a/src/pkg/clouds/aws/ecs/ecstaskstatechange/overrides_item.go
+++ b/src/pkg/clouds/aws/ecs/ecstaskstatechange/overrides_item.go
@@ -1,0 +1,29 @@
+package ecstaskstatechange
+
+type OverridesItem struct {
+    Environment []Environment `json:"environment,omitempty"`
+    Memory float64 `json:"memory,omitempty"`
+    Name string `json:"name"`
+    Cpu float64 `json:"cpu,omitempty"`
+    Command []string `json:"command,omitempty"`
+}
+
+func (o *OverridesItem) SetEnvironment(environment []Environment) {
+    o.Environment = environment
+}
+
+func (o *OverridesItem) SetMemory(memory float64) {
+    o.Memory = memory
+}
+
+func (o *OverridesItem) SetName(name string) {
+    o.Name = name
+}
+
+func (o *OverridesItem) SetCpu(cpu float64) {
+    o.Cpu = cpu
+}
+
+func (o *OverridesItem) SetCommand(command []string) {
+    o.Command = command
+}

--- a/src/pkg/clouds/aws/ecs/event.go
+++ b/src/pkg/clouds/aws/ecs/event.go
@@ -1,0 +1,40 @@
+package ecs
+
+import (
+	"encoding/json"
+	"strings"
+	"time"
+
+	"github.com/DefangLabs/defang/src/pkg/clouds/aws/ecs/ecsserviceaction"
+	"github.com/DefangLabs/defang/src/pkg/clouds/aws/ecs/ecstaskstatechange"
+)
+
+type ECSServiceAction = ecsserviceaction.ECSServiceAction
+
+type ECSTaskStateChange = ecstaskstatechange.ECSTaskStateChange
+
+type ECSDeploymentStateChange struct {
+	ECSServiceAction
+	DeploymentId string `json:"deploymentId,omitempty"`
+}
+
+type Event struct {
+	Detail     json.RawMessage `json:"detail"`
+	Account    string          `json:"account"`
+	DetailType string          `json:"detail-type"`
+	Id         string          `json:"id"`
+	Region     string          `json:"region"`
+	Resources  []string        `json:"resources"`
+	Source     string          `json:"source"`
+	Time       time.Time       `json:"time"`
+	Version    string          `json:"version"`
+}
+
+func FindContainerOverrides(detail *ECSTaskStateChange, containerName string) *ecstaskstatechange.OverridesItem {
+	for _, co := range detail.Overrides.ContainerOverrides {
+		if strings.HasPrefix(co.Name, containerName) {
+			return &co
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
- Handles the ECS events that was routed to cloudwatch logs, parse the etag/service, and display relevant info from the whole event structure
- Fix bug of tail querying older events that does not handle pagination