### PR TITLE
Auto-retry on Unavailable rpc

### DIFF
--- a/src/pkg/cli/client/grpc.go
+++ b/src/pkg/cli/client/grpc.go
@@ -31,7 +31,7 @@ func NewGrpcClient(host, accessToken string, tenantID types.TenantID, loader Pro
 	}
 	baseUrl += host
 	// Debug(" - Connecting to", baseUrl)
-	fabricClient := defangv1connect.NewFabricControllerClient(http.DefaultClient, baseUrl, connect.WithGRPC(), connect.WithInterceptors(auth.NewAuthInterceptor(accessToken)))
+	fabricClient := defangv1connect.NewFabricControllerClient(http.DefaultClient, baseUrl, connect.WithGRPC(), connect.WithInterceptors(auth.NewAuthInterceptor(accessToken), Retrier{}))
 
 	return GrpcClient{client: fabricClient, anonID: GetAnonID(), tenantID: tenantID, Loader: loader}
 }

--- a/src/pkg/cli/client/retrier.go
+++ b/src/pkg/cli/client/retrier.go
@@ -1,0 +1,30 @@
+package client
+
+import (
+	"context"
+	"time"
+
+	"github.com/DefangLabs/defang/src/pkg"
+	"github.com/bufbuild/connect-go"
+)
+
+type Retrier struct{}
+
+func (Retrier) WrapUnary(next connect.UnaryFunc) connect.UnaryFunc {
+	return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+		res, err := next(ctx, req)
+		if connect.CodeOf(err) == connect.CodeUnavailable {
+			// Retry once after a 1 second sleep
+			pkg.SleepWithContext(ctx, 1*time.Second)
+			res, err = next(ctx, req)
+		}
+		return res, err
+	}
+}
+func (Retrier) WrapStreamingClient(next connect.StreamingClientFunc) connect.StreamingClientFunc {
+	return next // TODO: wrap this to handle streaming rpcs like Tail
+}
+
+func (Retrier) WrapStreamingHandler(next connect.StreamingHandlerFunc) connect.StreamingHandlerFunc {
+	return next
+}

--- a/src/pkg/cli/client/retrier_test.go
+++ b/src/pkg/cli/client/retrier_test.go
@@ -1,0 +1,45 @@
+package client
+
+import (
+	"context"
+	"errors"
+	"net/http/httptest"
+	"testing"
+
+	defangv1 "github.com/DefangLabs/defang/src/protos/io/defang/v1"
+	"github.com/DefangLabs/defang/src/protos/io/defang/v1/defangv1connect"
+	"github.com/bufbuild/connect-go"
+)
+
+type grpcMockHandler struct {
+	defangv1connect.UnimplementedFabricControllerHandler
+	tries int
+}
+
+func (g *grpcMockHandler) Deploy(context.Context, *connect.Request[defangv1.DeployRequest]) (*connect.Response[defangv1.DeployResponse], error) {
+	g.tries++
+	return nil, connect.NewError(connect.CodeUnavailable, errors.New("unavailable"))
+}
+
+// func (g *grpcMockHandler) Tail(ctx context.Context, r *connect.Request[defangv1.TailRequest], s *connect.ServerStream[defangv1.TailResponse]) error {
+// 	g.tries++
+// 	return connect.NewError(connect.CodeUnavailable, errors.New("unavailable"))
+// }
+
+func TestRetrier(t *testing.T) {
+	fabricServer := &grpcMockHandler{}
+	_, handler := defangv1connect.NewFabricControllerHandler(fabricServer)
+
+	server := httptest.NewTLSServer(handler)
+	defer server.Close()
+
+	fabricClient := defangv1connect.NewFabricControllerClient(server.Client(), server.URL, connect.WithGRPC(), connect.WithInterceptors(Retrier{}))
+
+	_, err := fabricClient.Deploy(context.Background(), connect.NewRequest(&defangv1.DeployRequest{}))
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if fabricServer.tries != 2 {
+		t.Fatalf("expected 2 tries, got %d", fabricServer.tries)
+	}
+}


### PR DESCRIPTION
Automatically retry RPC calls that return `Unavailable` (so we can remove server-side retries)