### PR TITLE
Fix for non-interactive mode

### DIFF
--- a/src/pkg/cli/tail_test.go
+++ b/src/pkg/cli/tail_test.go
@@ -74,9 +74,9 @@ func TestTail(t *testing.T) {
 	DoVerbose = true // Output host
 	defaultTerm := term.DefaultTerm
 	term.DefaultTerm = testTerm
-	defer func() {
+	t.Cleanup(func() {
 		term.DefaultTerm = defaultTerm
-	}()
+	})
 
 	proj, err := ComposeLoader{"../../tests/testproj/compose.yaml"}.LoadCompose(context.Background())
 	if err != nil {

--- a/src/pkg/term/colorizer.go
+++ b/src/pkg/term/colorizer.go
@@ -44,10 +44,8 @@ func NewTerm(stdout, stderr io.Writer) *Term {
 	}
 	t.hasDarkBg = t.stdout.HasDarkBackground()
 	if hasTermInEnv() {
-		fout, outIsFile := stdout.(interface{ Fd() uintptr })
-		ferr, errIsFile := stderr.(interface{ Fd() uintptr })
-		if outIsFile && errIsFile {
-			t.isTerminal = term.IsTerminal(int(fout.Fd())) && term.IsTerminal(int(ferr.Fd()))
+		if fout, ok := stdout.(interface{ Fd() uintptr }); ok {
+			t.isTerminal = term.IsTerminal(int(fout.Fd())) && term.IsTerminal(int(os.Stdin.Fd()))
 		}
 	}
 	t.outCanColor = doColor(t.stdout)

--- a/src/pkg/term/colorizer_test.go
+++ b/src/pkg/term/colorizer_test.go
@@ -69,10 +69,10 @@ func TestStripAnsi(t *testing.T) {
 }
 
 func TestAddingPrefix(t *testing.T) {
-	currentTerm := DefaultTerm
-	defer func() {
-		DefaultTerm = currentTerm
-	}()
+	defaultTerm := DefaultTerm
+	t.Cleanup(func() {
+		DefaultTerm = defaultTerm
+	})
 	var stdout, stderr bytes.Buffer
 	DefaultTerm = NewTerm(&stdout, &stderr)
 	DefaultTerm.SetDebug(true)
@@ -119,10 +119,10 @@ func TestAddingPrefix(t *testing.T) {
 }
 
 func TestInfoAddSpaceBetweenStrings(t *testing.T) {
-	currentTerm := DefaultTerm
-	defer func() {
-		DefaultTerm = currentTerm
-	}()
+	defaultTerm := DefaultTerm
+	t.Cleanup(func() {
+		DefaultTerm = defaultTerm
+	})
 	var stdout, stderr bytes.Buffer
 	DefaultTerm = NewTerm(&stdout, &stderr)
 	DefaultTerm.SetDebug(true)
@@ -148,5 +148,11 @@ func TestInfoAddSpaceBetweenStrings(t *testing.T) {
 
 	if stderr.String() != "" {
 		t.Errorf("Expected stderr to be empty, got %q", stderr.String())
+	}
+}
+
+func TestIsTerminal(t *testing.T) {
+	if IsTerminal() {
+		t.Error("Expected IsTerminal() to return false")
 	}
 }


### PR DESCRIPTION
Regression from #457 https://github.com/DefangLabs/defang/pull/457/files#r1651826691

This broke `echo a | defang config set KEY`