### PR TITLE
fix regression when compose name is specified

### DIFF
--- a/src/pkg/cli/compose/loader.go
+++ b/src/pkg/cli/compose/loader.go
@@ -25,12 +25,11 @@ func (c Loader) LoadCompose(ctx context.Context) (*compose.Project, error) {
 		return nil, err
 	}
 	term.Debug("Loading compose file", composeFilePath)
-	workDir := filepath.Dir(composeFilePath)
 
 	// Compose-go uses the logrus logger, so we need to configure it to be more like our own logger
 	logrus.SetFormatter(&logrus.TextFormatter{DisableTimestamp: true, DisableColors: !term.StderrCanColor(), DisableLevelTruncation: true})
 
-	projOpts, err := getDefaultProjectOptions(workDir)
+	projOpts, err := getDefaultProjectOptions(composeFilePath)
 	if err != nil {
 		return nil, err
 	}
@@ -46,7 +45,7 @@ func (c Loader) LoadCompose(ctx context.Context) (*compose.Project, error) {
 	}
 
 	// Hack: Fill in the missing environment variables that were stripped by the normalization process
-	projOpts, err = getDefaultProjectOptions(workDir, cli.WithNormalization(false)) // Disable normalization to keep unset environment variables
+	projOpts, err = getDefaultProjectOptions(composeFilePath, cli.WithNormalization(false)) // Disable normalization to keep unset environment variables
 	if err != nil {
 		return nil, err
 	}
@@ -57,7 +56,7 @@ func (c Loader) LoadCompose(ctx context.Context) (*compose.Project, error) {
 	rawProj, err := projOpts.LoadProject(ctx)
 	logrus.SetOutput(currentOutput)
 	if err != nil {
-		return nil, err // there's no good reason this should fail, since we've already loaded the project
+		panic(err) // there's no good reason this should fail, since we've already loaded the project before
 	}
 
 	// TODO: Remove this hack once the PR is merged
@@ -82,7 +81,9 @@ func (c Loader) LoadCompose(ctx context.Context) (*compose.Project, error) {
 	return project, nil
 }
 
-func getDefaultProjectOptions(workingDir string, extraOpts ...cli.ProjectOptionsFn) (*cli.ProjectOptions, error) {
+func getDefaultProjectOptions(composeFilePath string, extraOpts ...cli.ProjectOptionsFn) (*cli.ProjectOptions, error) {
+	workingDir := filepath.Dir(composeFilePath)
+
 	// Based on how docker compose setup its own project options
 	// https://github.com/docker/compose/blob/1a14fcb1e6645dd92f5a4f2da00071bd59c2e887/cmd/compose/compose.go#L326-L346
 	opts := []cli.ProjectOptionsFn{
@@ -96,7 +97,7 @@ func getDefaultProjectOptions(workingDir string, extraOpts ...cli.ProjectOptions
 		// get compose file path set by COMPOSE_FILE
 		cli.WithConfigFileEnv,
 		// if none was selected, get default compose.yaml file from current dir or parent folder
-		cli.WithDefaultConfigPath,
+		// cli.WithDefaultConfigPath, NO: this ends up picking the "first" when more than one file is found
 		// cli.WithName(o.ProjectName)
 
 		// Calling the 2 functions below the 2nd time as the loaded env in first call modifies the behavior of the 2nd call
@@ -110,7 +111,7 @@ func getDefaultProjectOptions(workingDir string, extraOpts ...cli.ProjectOptions
 		cli.WithConsistency(false), // TODO: check fails if secrets are used but top-level 'secrets:' is missing
 	}
 	opts = append(opts, extraOpts...)
-	projOpts, err := cli.NewProjectOptions(nil, opts...)
+	projOpts, err := cli.NewProjectOptions([]string{composeFilePath}, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -141,29 +142,23 @@ func getComposeFilePath(userSpecifiedComposeFile string) (string, error) {
 	term.Debug("Looking for compose file - searching for", searchPattern)
 	for {
 		if files, _ := filepath.Glob(filepath.Join(path, searchPattern)); len(files) > 1 {
-			err = fmt.Errorf("multiple Compose files found: %q; use -f to specify which one to use", files)
-			break
+			return "", fmt.Errorf("multiple Compose files found: %q; use -f to specify which one to use", files)
 		} else if len(files) == 1 {
 			// found compose file, we're done
-			path = files[0]
-			break
+			return files[0], nil
 		}
 
 		if len(userSpecifiedComposeFile) > 0 {
-			err = fmt.Errorf("no Compose file found at %q: %w", userSpecifiedComposeFile, os.ErrNotExist)
-			break
+			return "", fmt.Errorf("no Compose file found at %q: %w", userSpecifiedComposeFile, os.ErrNotExist)
 		}
 
 		// compose file not found, try parent directory
 		nextPath := filepath.Dir(path)
 		if nextPath == path {
 			// previous search was of root, we're done
-			err = types.ErrComposeFileNotFound
-			break
+			return "", types.ErrComposeFileNotFound
 		}
 
 		path = nextPath
 	}
-
-	return path, err
 }

--- a/src/pkg/cli/tail_test.go
+++ b/src/pkg/cli/tail_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/DefangLabs/defang/src/pkg/cli/client"
+	"github.com/DefangLabs/defang/src/pkg/cli/compose"
 	"github.com/DefangLabs/defang/src/pkg/term"
 	defangv1 "github.com/DefangLabs/defang/src/protos/io/defang/v1"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -78,7 +79,7 @@ func TestTail(t *testing.T) {
 		term.DefaultTerm = defaultTerm
 	})
 
-	proj, err := ComposeLoader{"../../tests/testproj/compose.yaml"}.LoadCompose(context.Background())
+	proj, err := compose.Loader{"../../tests/testproj/compose.yaml"}.LoadCompose(context.Background())
 	if err != nil {
 		t.Fatalf("LoadCompose() failed: %v", err)
 	}

--- a/src/tests/alttestproj/altcomp.yaml
+++ b/src/tests/alttestproj/altcomp.yaml
@@ -1,4 +1,4 @@
-name: tests
+name: altcomp
 services:
   dfnx:
     restart: unless-stopped

--- a/src/tests/alttestproj/compose.yaml
+++ b/src/tests/alttestproj/compose.yaml
@@ -2,44 +2,8 @@ name: tests
 services:
   dfnx:
     restart: unless-stopped
-    build:
-      context: .
-      dockerfile: Dockerfile
-      target: alttestproj
-      args:
-        DNS: dfnx
+    build: .
     deploy:
       resources:
-        limits:
-          cpus: '0.50'
-          memory: 512M
         reservations:
-          cpus: '0.25'
           memory: 256M
-    ports:
-      - target: 80
-        mode: ingress
-      - target: 1234
-        # mode: host
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost/"]
-      # disable: true
-
-  # dfnx:
-  #   build:
-  #     context: .
-      # dockerfile: Dockerfile.dfn
-    # ports:
-      # - 80
-
-  echo:
-    image: ealen/echo-server
-    ports:
-      - target: 80
-        mode: ingress
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost/"]
-    # domainname: echotest.gnafed.click
-    profiles:
-      - donotstart
-    x-defang-dns-role: arn:aws:iam::123456789012:role/ecs-service-role

--- a/src/tests/alttestproj/compose.yaml.convert
+++ b/src/tests/alttestproj/compose.yaml.convert
@@ -7,36 +7,13 @@
       "replicas": 1,
       "resources": {
         "reservations": {
-          "memory": 256,
-          "cpus": 0.25
+          "memory": 256
         }
       }
     },
-    "ports": [
-      {
-        "target": 80,
-        "mode": 1
-      },
-      {
-        "target": 1234,
-        "mode": 1
-      }
-    ],
     "build": {
       "context": ".",
-      "dockerfile": "Dockerfile",
-      "args": {
-        "DNS": "dfnx"
-      },
-      "target": "alttestproj"
-    },
-    "healthcheck": {
-      "test": [
-        "CMD",
-        "curl",
-        "-f",
-        "http://localhost/"
-      ]
+      "dockerfile": "Dockerfile"
     },
     "networks": 1
   }

--- a/src/tests/alttestproj/compose.yaml.golden
+++ b/src/tests/alttestproj/compose.yaml.golden
@@ -4,29 +4,12 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-      args:
-        DNS: dfnx
-      target: alttestproj
     deploy:
       resources:
-        limits:
-          cpus: 0.5
-          memory: "536870912"
         reservations:
-          cpus: 0.25
           memory: "268435456"
-    healthcheck:
-      test:
-        - CMD
-        - curl
-        - -f
-        - http://localhost/
     networks:
       default: null
-    ports:
-      - mode: ingress
-        target: 80
-      - target: 1234
     restart: unless-stopped
 networks:
   default:

--- a/src/tests/networks/compose.yaml
+++ b/src/tests/networks/compose.yaml
@@ -1,14 +1,18 @@
 services:
   service1:
+    image: example
     networks:
       invalid-network-name: {}
   service2:
+    image: example
     networks:
       public: {}
   service3:
+    image: example
     networks:
       - public
   service4:
+    image: example
     networks:
       - private
 networks:

--- a/src/tests/networks/compose.yaml.convert
+++ b/src/tests/networks/compose.yaml.convert
@@ -1,22 +1,26 @@
 [
   {
     "name": "service1",
+    "image": "example",
     "platform": 2,
     "internal": true,
     "networks": 1
   },
   {
     "name": "service2",
+    "image": "example",
     "platform": 2,
     "networks": 2
   },
   {
     "name": "service3",
+    "image": "example",
     "platform": 2,
     "networks": 2
   },
   {
     "name": "service4",
+    "image": "example",
     "platform": 2,
     "internal": true,
     "networks": 1

--- a/src/tests/networks/compose.yaml.golden
+++ b/src/tests/networks/compose.yaml.golden
@@ -1,15 +1,19 @@
 name: networks
 services:
   service1:
+    image: example
     networks:
       invalid-network-name: {}
   service2:
+    image: example
     networks:
       public: {}
   service3:
+    image: example
     networks:
       public: null
   service4:
+    image: example
     networks:
       private: null
 networks:

--- a/src/tests/redis/compose.yaml
+++ b/src/tests/redis/compose.yaml
@@ -4,7 +4,7 @@ services:
     x-defang-redis:
 
   y:
-    image: nginx
+    image: example
     x-defang-redis:
 
   z:

--- a/src/tests/redis/compose.yaml.convert
+++ b/src/tests/redis/compose.yaml.convert
@@ -9,7 +9,7 @@
   },
   {
     "name": "y",
-    "image": "nginx",
+    "image": "example",
     "platform": 2,
     "internal": true,
     "networks": 1,

--- a/src/tests/redis/compose.yaml.golden
+++ b/src/tests/redis/compose.yaml.golden
@@ -6,7 +6,7 @@ services:
       default: null
     x-defang-redis: null
   "y":
-    image: nginx
+    image: example
     networks:
       default: null
     x-defang-redis: null

--- a/src/tests/toomany/compose.yaml
+++ b/src/tests/toomany/compose.yaml
@@ -1,0 +1,3 @@
+services:
+  service1:
+    image: example

--- a/src/tests/toomany/compose.yaml.convert
+++ b/src/tests/toomany/compose.yaml.convert
@@ -1,0 +1,9 @@
+[
+  {
+    "name": "service1",
+    "image": "example",
+    "platform": 2,
+    "internal": true,
+    "networks": 1
+  }
+]

--- a/src/tests/toomany/compose.yaml.golden
+++ b/src/tests/toomany/compose.yaml.golden
@@ -1,0 +1,9 @@
+name: toomany
+services:
+  service1:
+    image: example
+    networks:
+      default: null
+networks:
+  default:
+    name: toomany_default

--- a/src/tests/toomany/compose.yaml.warnings
+++ b/src/tests/toomany/compose.yaml.warnings
@@ -1,0 +1,2 @@
+level=warning msg="service \"service1\": missing compose directive: restart; assuming 'unless-stopped' (add 'restart' to silence)"
+level=warning msg="service \"service1\": missing memory reservation; specify deploy.resources.reservations.memory to avoid out-of-memory errors"

--- a/src/tests/toomany/docker-compose.yml
+++ b/src/tests/toomany/docker-compose.yml
@@ -1,0 +1,3 @@
+services:
+  service1:
+    image: example

--- a/src/tests/toomany/docker-compose.yml.convert
+++ b/src/tests/toomany/docker-compose.yml.convert
@@ -1,0 +1,9 @@
+[
+  {
+    "name": "service1",
+    "image": "example",
+    "platform": 2,
+    "internal": true,
+    "networks": 1
+  }
+]

--- a/src/tests/toomany/docker-compose.yml.golden
+++ b/src/tests/toomany/docker-compose.yml.golden
@@ -1,0 +1,9 @@
+name: toomany
+services:
+  service1:
+    image: example
+    networks:
+      default: null
+networks:
+  default:
+    name: toomany_default

--- a/src/tests/toomany/docker-compose.yml.warnings
+++ b/src/tests/toomany/docker-compose.yml.warnings
@@ -1,0 +1,2 @@
+level=warning msg="service \"service1\": missing compose directive: restart; assuming 'unless-stopped' (add 'restart' to silence)"
+level=warning msg="service \"service1\": missing memory reservation; specify deploy.resources.reservations.memory to avoid out-of-memory errors"


### PR DESCRIPTION
also adds a new `toomany` test case to test the case when there are more than 1 compose files in a folder