### PR TITLE
Add preview mode

### DIFF
--- a/src/cmd/cli/command/commands.go
+++ b/src/cmd/cli/command/commands.go
@@ -149,16 +149,16 @@ func SetupCommands(version string) {
 	_ = RootCmd.MarkPersistentFlagFilename("file", "yml", "yaml")
 
 	// Bootstrap command
-	RootCmd.AddCommand(bootstrapCmd)
-	bootstrapCmd.AddCommand(cdDestroyCmd)
-	bootstrapCmd.AddCommand(cdDownCmd)
-	bootstrapCmd.AddCommand(cdRefreshCmd)
+	RootCmd.AddCommand(cdCmd)
+	cdCmd.AddCommand(cdDestroyCmd)
+	cdCmd.AddCommand(cdDownCmd)
+	cdCmd.AddCommand(cdRefreshCmd)
 	cdTearDownCmd.Flags().Bool("force", false, "force the teardown of the CD stack")
-	bootstrapCmd.AddCommand(cdTearDownCmd)
+	cdCmd.AddCommand(cdTearDownCmd)
 	cdListCmd.Flags().Bool("remote", false, "invoke the command on the remote cluster")
-	bootstrapCmd.AddCommand(cdListCmd)
-	bootstrapCmd.AddCommand(cdCancelCmd)
-	bootstrapCmd.AddCommand(cdPreviewCmd)
+	cdCmd.AddCommand(cdListCmd)
+	cdCmd.AddCommand(cdCancelCmd)
+	cdCmd.AddCommand(cdPreviewCmd)
 
 	// Eula command
 	tosCmd.Flags().Bool("agree-tos", false, "agree to the Defang terms of service")
@@ -873,7 +873,7 @@ var logoutCmd = &cobra.Command{
 	},
 }
 
-var bootstrapCmd = &cobra.Command{
+var cdCmd = &cobra.Command{
 	Use:     "cd",
 	Aliases: []string{"bootstrap"},
 	Short:   "Manually run a command with the CD task (for BYOC only)",

--- a/src/cmd/cli/command/commands.go
+++ b/src/cmd/cli/command/commands.go
@@ -947,8 +947,11 @@ var cdPreviewCmd = &cobra.Command{
 	Args:  cobra.NoArgs,
 	Short: "Preview the changes that will be made by the CD task",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		_, _, err := cli.ComposeUp(cmd.Context(), client, compose.BuildContextPreview, defangv1.DeploymentMode_UNSPECIFIED_MODE)
-		return err
+		resp, _, err := cli.ComposeUp(cmd.Context(), client, compose.BuildContextPreview, defangv1.DeploymentMode_UNSPECIFIED_MODE)
+		if err != nil {
+			return err
+		}
+		return cli.Tail(cmd.Context(), client, cli.TailOptions{Etag: resp.Etag})
 	},
 }
 

--- a/src/cmd/cli/command/commands.go
+++ b/src/cmd/cli/command/commands.go
@@ -148,7 +148,7 @@ func SetupCommands(version string) {
 	RootCmd.PersistentFlags().StringArrayP("file", "f", []string{}, `compose file path`)
 	_ = RootCmd.MarkPersistentFlagFilename("file", "yml", "yaml")
 
-	// Bootstrap command
+	// CD command
 	RootCmd.AddCommand(cdCmd)
 	cdCmd.AddCommand(cdDestroyCmd)
 	cdCmd.AddCommand(cdDownCmd)
@@ -947,7 +947,7 @@ var cdPreviewCmd = &cobra.Command{
 	Args:  cobra.NoArgs,
 	Short: "Preview the changes that will be made by the CD task",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		resp, _, err := cli.ComposeUp(cmd.Context(), client, compose.BuildContextPreview, defangv1.DeploymentMode_UNSPECIFIED_MODE)
+		resp, _, err := cli.ComposeUp(cmd.Context(), client, compose.UploadModePreview, defangv1.DeploymentMode_UNSPECIFIED_MODE)
 		if err != nil {
 			return err
 		}

--- a/src/cmd/cli/command/commands.go
+++ b/src/cmd/cli/command/commands.go
@@ -22,6 +22,7 @@ import (
 	"github.com/DefangLabs/defang/src/pkg/scope"
 	"github.com/DefangLabs/defang/src/pkg/term"
 	"github.com/DefangLabs/defang/src/pkg/types"
+	defangv1 "github.com/DefangLabs/defang/src/protos/io/defang/v1"
 	"github.com/aws/smithy-go"
 	"github.com/bufbuild/connect-go"
 	proj "github.com/compose-spec/compose-go/v2/types"
@@ -149,14 +150,15 @@ func SetupCommands(version string) {
 
 	// Bootstrap command
 	RootCmd.AddCommand(bootstrapCmd)
-	bootstrapCmd.AddCommand(bootstrapDestroyCmd)
-	bootstrapCmd.AddCommand(bootstrapDownCmd)
-	bootstrapCmd.AddCommand(bootstrapRefreshCmd)
-	bootstrapTearDownCmd.Flags().Bool("force", false, "force the teardown of the CD stack")
-	bootstrapCmd.AddCommand(bootstrapTearDownCmd)
-	bootstrapListCmd.Flags().Bool("remote", false, "invoke the command on the remote cluster")
-	bootstrapCmd.AddCommand(bootstrapListCmd)
-	bootstrapCmd.AddCommand(bootstrapCancelCmd)
+	bootstrapCmd.AddCommand(cdDestroyCmd)
+	bootstrapCmd.AddCommand(cdDownCmd)
+	bootstrapCmd.AddCommand(cdRefreshCmd)
+	cdTearDownCmd.Flags().Bool("force", false, "force the teardown of the CD stack")
+	bootstrapCmd.AddCommand(cdTearDownCmd)
+	cdListCmd.Flags().Bool("remote", false, "invoke the command on the remote cluster")
+	bootstrapCmd.AddCommand(cdListCmd)
+	bootstrapCmd.AddCommand(cdCancelCmd)
+	bootstrapCmd.AddCommand(cdPreviewCmd)
 
 	// Eula command
 	tosCmd.Flags().Bool("agree-tos", false, "agree to the Defang terms of service")
@@ -878,7 +880,7 @@ var bootstrapCmd = &cobra.Command{
 	Hidden:  true,
 }
 
-var bootstrapDestroyCmd = &cobra.Command{
+var cdDestroyCmd = &cobra.Command{
 	Use:   "destroy",
 	Args:  cobra.NoArgs, // TODO: set MaximumNArgs(1),
 	Short: "Destroy the service stack",
@@ -887,7 +889,7 @@ var bootstrapDestroyCmd = &cobra.Command{
 	},
 }
 
-var bootstrapDownCmd = &cobra.Command{
+var cdDownCmd = &cobra.Command{
 	Use:   "down",
 	Args:  cobra.NoArgs, // TODO: set MaximumNArgs(1),
 	Short: "Refresh and then destroy the service stack",
@@ -896,7 +898,7 @@ var bootstrapDownCmd = &cobra.Command{
 	},
 }
 
-var bootstrapRefreshCmd = &cobra.Command{
+var cdRefreshCmd = &cobra.Command{
 	Use:   "refresh",
 	Args:  cobra.NoArgs, // TODO: set MaximumNArgs(1),
 	Short: "Refresh the service stack",
@@ -905,7 +907,7 @@ var bootstrapRefreshCmd = &cobra.Command{
 	},
 }
 
-var bootstrapCancelCmd = &cobra.Command{
+var cdCancelCmd = &cobra.Command{
 	Use:   "cancel",
 	Args:  cobra.NoArgs, // TODO: set MaximumNArgs(1),
 	Short: "Cancel the current CD operation",
@@ -914,7 +916,7 @@ var bootstrapCancelCmd = &cobra.Command{
 	},
 }
 
-var bootstrapTearDownCmd = &cobra.Command{
+var cdTearDownCmd = &cobra.Command{
 	Use:   "teardown",
 	Args:  cobra.NoArgs,
 	Short: "Destroy the CD cluster without destroying the services",
@@ -925,7 +927,7 @@ var bootstrapTearDownCmd = &cobra.Command{
 	},
 }
 
-var bootstrapListCmd = &cobra.Command{
+var cdListCmd = &cobra.Command{
 	Use:     "ls",
 	Args:    cobra.NoArgs,
 	Aliases: []string{"list"},
@@ -937,6 +939,16 @@ var bootstrapListCmd = &cobra.Command{
 			return cli.BootstrapCommand(cmd.Context(), client, "list")
 		}
 		return cli.BootstrapLocalList(cmd.Context(), client)
+	},
+}
+
+var cdPreviewCmd = &cobra.Command{
+	Use:   "preview",
+	Args:  cobra.NoArgs,
+	Short: "Preview the changes that will be made by the CD task",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		_, _, err := cli.ComposeUp(cmd.Context(), client, compose.BuildContextPreview, defangv1.DeploymentMode_UNSPECIFIED_MODE)
+		return err
 	},
 }
 

--- a/src/cmd/cli/command/compose.go
+++ b/src/cmd/cli/command/compose.go
@@ -49,13 +49,13 @@ func makeComposeUpCmd() *cobra.Command {
 			var force, _ = cmd.Flags().GetBool("force")
 			var detach, _ = cmd.Flags().GetBool("detach")
 
-			buildContext := compose.BuildContextDigest
+			upload := compose.UploadModeDigest
 			if force {
-				buildContext = compose.BuildContextForce
+				upload = compose.UploadModeForce
 			}
 
 			since := time.Now()
-			deploy, project, err := cli.ComposeUp(cmd.Context(), client, buildContext, mode.Value())
+			deploy, project, err := cli.ComposeUp(cmd.Context(), client, upload, mode.Value())
 
 			if err != nil {
 				if !nonInteractive && strings.Contains(err.Error(), "maximum number of projects") {
@@ -303,7 +303,7 @@ func makeComposeConfigCmd() *cobra.Command {
 		Short: "Reads a Compose file and shows the generated config",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cli.DoDryRun = true // config is like start in a dry run
-			if _, _, err := cli.ComposeUp(cmd.Context(), client, compose.BuildContextIgnore, defangv1.DeploymentMode_UNSPECIFIED_MODE); !errors.Is(err, cli.ErrDryRun) {
+			if _, _, err := cli.ComposeUp(cmd.Context(), client, compose.UploadModeIgnore, defangv1.DeploymentMode_UNSPECIFIED_MODE); !errors.Is(err, cli.ErrDryRun) {
 				return err
 			}
 			return nil

--- a/src/cmd/cli/command/compose.go
+++ b/src/cmd/cli/command/compose.go
@@ -11,6 +11,7 @@ import (
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/DefangLabs/defang/src/pkg/cli"
 	cliClient "github.com/DefangLabs/defang/src/pkg/cli/client"
+	"github.com/DefangLabs/defang/src/pkg/cli/compose"
 	"github.com/DefangLabs/defang/src/pkg/term"
 	"github.com/DefangLabs/defang/src/pkg/types"
 	defangv1 "github.com/DefangLabs/defang/src/protos/io/defang/v1"
@@ -48,8 +49,13 @@ func makeComposeUpCmd() *cobra.Command {
 			var force, _ = cmd.Flags().GetBool("force")
 			var detach, _ = cmd.Flags().GetBool("detach")
 
+			buildContext := compose.BuildContextDigest
+			if force {
+				buildContext = compose.BuildContextForce
+			}
+
 			since := time.Now()
-			deploy, project, err := cli.ComposeUp(cmd.Context(), client, force, mode.Value())
+			deploy, project, err := cli.ComposeUp(cmd.Context(), client, buildContext, mode.Value())
 
 			if err != nil {
 				if !nonInteractive && strings.Contains(err.Error(), "maximum number of projects") {
@@ -297,8 +303,7 @@ func makeComposeConfigCmd() *cobra.Command {
 		Short: "Reads a Compose file and shows the generated config",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cli.DoDryRun = true // config is like start in a dry run
-			// force=false to calculate the digest
-			if _, _, err := cli.ComposeUp(cmd.Context(), client, false, defangv1.DeploymentMode_UNSPECIFIED_MODE); !errors.Is(err, cli.ErrDryRun) {
+			if _, _, err := cli.ComposeUp(cmd.Context(), client, compose.BuildContextIgnore, defangv1.DeploymentMode_UNSPECIFIED_MODE); !errors.Is(err, cli.ErrDryRun) {
 				return err
 			}
 			return nil

--- a/src/pkg/cli/cert_test.go
+++ b/src/pkg/cli/cert_test.go
@@ -143,7 +143,7 @@ type MockResolver struct {
 
 func (mr *MockResolver) LookupIPAddr(ctx context.Context, domain string) ([]net.IPAddr, error) {
 	mr.calls++
-	return []net.IPAddr{net.IPAddr{IP: net.ParseIP("127.0.0.1")}}, nil
+	return []net.IPAddr{{IP: net.ParseIP("127.0.0.1")}}, nil
 }
 func (mr *MockResolver) LookupCNAME(ctx context.Context, domain string) (string, error) {
 	mr.calls++
@@ -151,7 +151,7 @@ func (mr *MockResolver) LookupCNAME(ctx context.Context, domain string) (string,
 }
 func (mr *MockResolver) LookupNS(ctx context.Context, domain string) ([]*net.NS, error) {
 	mr.calls++
-	return []*net.NS{&net.NS{Host: ""}}, nil
+	return []*net.NS{{Host: ""}}, nil
 }
 
 func TestHttpClient(t *testing.T) {

--- a/src/pkg/cli/client/byoc/aws/byoc.go
+++ b/src/pkg/cli/client/byoc/aws/byoc.go
@@ -64,6 +64,7 @@ func NewByocClient(ctx context.Context, grpcClient client.GrpcClient, tenantId t
 }
 
 func (b *ByocAws) setUp(ctx context.Context) error {
+	// note: the CD image is tagged with the major release number, use that for setup
 	projectCdImageTag, err := b.getCdImageTag(ctx)
 	if err != nil {
 		return err
@@ -158,7 +159,14 @@ func (b *ByocAws) getCdImageTag(ctx context.Context) (string, error) {
 }
 
 func (b *ByocAws) Deploy(ctx context.Context, req *defangv1.DeployRequest) (*defangv1.DeployResponse, error) {
-	// note: the CD image is tagged with the major release number, use that for setup
+	return b.deploy(ctx, req, "up")
+}
+
+func (b *ByocAws) Preview(ctx context.Context, req *defangv1.DeployRequest) (*defangv1.DeployResponse, error) {
+	return b.deploy(ctx, req, "preview")
+}
+
+func (b *ByocAws) deploy(ctx context.Context, req *defangv1.DeployRequest, cmd string) (*defangv1.DeployResponse, error) {
 	if err := b.setUp(ctx); err != nil {
 		return nil, err
 	}
@@ -224,7 +232,7 @@ func (b *ByocAws) Deploy(ctx context.Context, req *defangv1.DeployRequest) (*def
 			return nil, err
 		}
 	}
-	taskArn, err := b.runCdCommand(ctx, req.Mode, "up", payloadString)
+	taskArn, err := b.runCdCommand(ctx, req.Mode, cmd, payloadString)
 	if err != nil {
 		return nil, err
 	}

--- a/src/pkg/cli/client/byoc/do/byoc.go
+++ b/src/pkg/cli/client/byoc/do/byoc.go
@@ -150,10 +150,14 @@ func (b *ByocDo) getProjectUpdate(ctx context.Context) (*defangv1.ProjectUpdate,
 }
 
 func (b *ByocDo) Preview(ctx context.Context, req *defangv1.DeployRequest) (*defangv1.DeployResponse, error) {
-	return nil, errors.ErrUnsupported
+	return b.deploy(ctx, req, "preview")
 }
 
 func (b *ByocDo) Deploy(ctx context.Context, req *defangv1.DeployRequest) (*defangv1.DeployResponse, error) {
+	return b.deploy(ctx, req, "up")
+}
+
+func (b *ByocDo) deploy(ctx context.Context, req *defangv1.DeployRequest, cmd string) (*defangv1.DeployResponse, error) {
 	if err := b.setUp(ctx); err != nil {
 		return nil, err
 	}
@@ -217,7 +221,7 @@ func (b *ByocDo) Deploy(ctx context.Context, req *defangv1.DeployRequest) (*defa
 		return nil, err
 	}
 
-	_, err = b.runCdCommand(ctx, "up", payloadString)
+	_, err = b.runCdCommand(ctx, cmd, payloadString)
 	if err != nil {
 		return nil, err
 	}
@@ -407,7 +411,7 @@ func (b *ByocDo) Follow(ctx context.Context, req *defangv1.TailRequest) (client.
 	}
 
 	var appLiveURL string
-	term.Info("Waiting for command to finish to gather logs")
+	term.Info("Waiting for command to finish gathering logs")
 
 	deploymentID := ""
 
@@ -420,7 +424,7 @@ func (b *ByocDo) Follow(ctx context.Context, req *defangv1.TailRequest) (client.
 	}
 
 	if deploymentID == "" {
-		return nil, errors.New("No deployments found")
+		return nil, errors.New("no deployments found")
 	}
 
 	for {
@@ -697,7 +701,7 @@ func (b *ByocDo) getAppByName(ctx context.Context, name string) (*godo.App, erro
 		}
 	}
 
-	return nil, errors.New(fmt.Sprintf("app not found: %s", appName))
+	return nil, fmt.Errorf("app not found: %s", appName)
 }
 
 func (b *ByocDo) processServiceInfo(service *godo.AppServiceSpec) *defangv1.ServiceInfo {

--- a/src/pkg/cli/client/byoc/do/byoc.go
+++ b/src/pkg/cli/client/byoc/do/byoc.go
@@ -149,6 +149,10 @@ func (b *ByocDo) getProjectUpdate(ctx context.Context) (*defangv1.ProjectUpdate,
 	return &projUpdate, nil
 }
 
+func (b *ByocDo) Preview(ctx context.Context, req *defangv1.DeployRequest) (*defangv1.DeployResponse, error) {
+	return nil, errors.ErrUnsupported
+}
+
 func (b *ByocDo) Deploy(ctx context.Context, req *defangv1.DeployRequest) (*defangv1.DeployResponse, error) {
 	if err := b.setUp(ctx); err != nil {
 		return nil, err

--- a/src/pkg/cli/client/byoc/do/byoc.go
+++ b/src/pkg/cli/client/byoc/do/byoc.go
@@ -410,10 +410,7 @@ func (b *ByocDo) Follow(ctx context.Context, req *defangv1.TailRequest) (client.
 		return nil, err
 	}
 
-	var appLiveURL string
-	term.Info("Waiting for command to finish gathering logs")
-
-	deploymentID := ""
+	var appLiveURL, deploymentID string
 
 	if cdApp.PendingDeployment != nil {
 		deploymentID = cdApp.PendingDeployment.GetID()
@@ -427,34 +424,32 @@ func (b *ByocDo) Follow(ctx context.Context, req *defangv1.TailRequest) (client.
 		return nil, errors.New("no deployments found")
 	}
 
+	term.Info("Waiting for CD command to finish gathering logs")
 	for {
-
 		deploymentInfo, _, err := b.client.Apps.GetDeployment(ctx, cdApp.ID, deploymentID)
-
 		if err != nil {
 			return nil, err
 		}
 
 		if deploymentInfo.GetPhase() == godo.DeploymentPhase_Active {
-
 			logs, _, err := b.client.Apps.GetLogs(ctx, cdApp.ID, deploymentID, "", godo.AppLogTypeDeploy, true, 50)
 			if err != nil {
 				return nil, err
 			}
 
 			appLiveURL, err = b.processServiceLogs(ctx)
-
 			if err != nil {
 				return nil, err
 			}
 
 			readHistoricalLogs(ctx, logs.HistoricURLs)
-
 			break
 		}
-		//Sleep for 15 seconds so we dont spam the DO API
-		pkg.SleepWithContext(ctx, (time.Second)*15)
 
+		//Sleep for 15 seconds so we dont spam the DO API
+		if err := pkg.SleepWithContext(ctx, (time.Second)*15); err != nil {
+			return nil, err
+		}
 	}
 
 	return newByocServerStream(ctx, appLiveURL, req.Etag)
@@ -733,7 +728,6 @@ func (b *ByocDo) processServiceLogs(ctx context.Context) (string, error) {
 
 	// If we can get projects working, we can add the project to the list options
 	currentApps, _, err := b.client.Apps.List(ctx, &godo.ListOptions{})
-
 	if err != nil {
 		return "", err
 	}
@@ -770,6 +764,7 @@ func (b *ByocDo) processServiceLogs(ctx context.Context) (string, error) {
 			if err != nil {
 				return "", err
 			}
+
 			readHistoricalLogs(ctx, mainDeployLogs.HistoricURLs)
 
 			mainRunLogs, resp, err := b.client.Apps.GetLogs(ctx, app.ID, "", "", godo.AppLogTypeRun, true, 50)

--- a/src/pkg/cli/client/client.go
+++ b/src/pkg/cli/client/client.go
@@ -50,6 +50,7 @@ type Client interface {
 	GetService(context.Context, *defangv1.ServiceID) (*defangv1.ServiceInfo, error)
 	GetServices(context.Context) (*defangv1.ListServicesResponse, error)
 	ListConfig(context.Context) (*defangv1.Secrets, error)
+	Preview(context.Context, *defangv1.DeployRequest) (*defangv1.DeployResponse, error)
 	PutConfig(context.Context, *defangv1.PutConfigRequest) error
 	ServiceDNS(name string) string
 	Subscribe(context.Context, *defangv1.SubscribeRequest) (ServerStream[defangv1.SubscribeResponse], error)

--- a/src/pkg/cli/client/playground.go
+++ b/src/pkg/cli/client/playground.go
@@ -30,6 +30,10 @@ func (g PlaygroundClient) Deploy(ctx context.Context, req *defangv1.DeployReques
 	return getMsg(g.client.Deploy(ctx, connect.NewRequest(req)))
 }
 
+func (g PlaygroundClient) Preview(ctx context.Context, req *defangv1.DeployRequest) (*defangv1.DeployResponse, error) {
+	return nil, errors.New("the preview command is not valid for the Defang playground; did you forget --provider?")
+}
+
 func (g PlaygroundClient) GetService(ctx context.Context, req *defangv1.ServiceID) (*defangv1.ServiceInfo, error) {
 	return getMsg(g.client.Get(ctx, connect.NewRequest(req)))
 }
@@ -69,7 +73,7 @@ func (g *PlaygroundClient) Follow(ctx context.Context, req *defangv1.TailRequest
 }
 
 func (g *PlaygroundClient) BootstrapCommand(ctx context.Context, command string) (types.ETag, error) {
-	return "", errors.New("the bootstrap command is not valid for the Defang playground; did you forget --provider?")
+	return "", errors.New("the CD command is not valid for the Defang playground; did you forget --provider?")
 }
 func (g *PlaygroundClient) Destroy(ctx context.Context) (types.ETag, error) {
 	projectName, err := g.LoadProjectName(ctx)

--- a/src/pkg/cli/compose/context.go
+++ b/src/pkg/cli/compose/context.go
@@ -29,7 +29,7 @@ const (
 	BuildContextDigest  BuildContext = iota // the default: calculate the digest of the tarball so we can skip building the same image twice
 	BuildContextForce                       // force: always upload the tarball, even if it's the same as a previous one
 	BuildContextIgnore                      // dry-run: don't upload the tarball, just return the path
-	BuildContextPreview                     // preview:, like dry-run but also don't deploy
+	BuildContextPreview                     // preview: like dry-run but also don't deploy
 )
 
 const (

--- a/src/pkg/cli/compose/context.go
+++ b/src/pkg/cli/compose/context.go
@@ -26,9 +26,10 @@ import (
 type BuildContext int
 
 const (
-	BuildContextDigest BuildContext = iota // the default: calculate the digest of the tarball so we can skip building the same image twice
-	BuildContextForce                      // force: always upload the tarball, even if it's the same as a previous one
-	BuildContextIgnore                     // dry-run: don't upload the tarball, just return the path
+	BuildContextDigest  BuildContext = iota // the default: calculate the digest of the tarball so we can skip building the same image twice
+	BuildContextForce                       // force: always upload the tarball, even if it's the same as a previous one
+	BuildContextIgnore                      // dry-run: don't upload the tarball, just return the path
+	BuildContextPreview                     // preview:, like dry-run but also don't deploy
 )
 
 const (
@@ -80,7 +81,7 @@ func getRemoteBuildContext(ctx context.Context, client client.Client, name strin
 		term.Debug("Digest:", digest)
 	}
 
-	if force == BuildContextIgnore {
+	if force == BuildContextIgnore || force == BuildContextPreview {
 		return root, nil
 	}
 

--- a/src/pkg/cli/compose/convert.go
+++ b/src/pkg/cli/compose/convert.go
@@ -13,7 +13,7 @@ import (
 	compose "github.com/compose-spec/compose-go/v2/types"
 )
 
-func ConvertServices(ctx context.Context, c client.Client, serviceConfigs compose.Services, force BuildContext) ([]*defangv1.Service, error) {
+func ConvertServices(ctx context.Context, c client.Client, serviceConfigs compose.Services, upload UploadMode) ([]*defangv1.Service, error) {
 	// Create a regexp to detect private service names in environment variable values
 	var serviceNames []string
 	var nonReplaceServiceNames []string
@@ -96,7 +96,7 @@ func ConvertServices(ctx context.Context, c client.Client, serviceConfigs compos
 		var build *defangv1.Build
 		if svccfg.Build != nil {
 			// Pack the build context into a tarball and upload
-			url, err := getRemoteBuildContext(ctx, c, svccfg.Name, svccfg.Build, force)
+			url, err := getRemoteBuildContext(ctx, c, svccfg.Name, svccfg.Build, upload)
 			if err != nil {
 				return nil, err
 			}

--- a/src/pkg/cli/compose/convert_test.go
+++ b/src/pkg/cli/compose/convert_test.go
@@ -154,7 +154,7 @@ func TestConvert(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		services, err := ConvertServices(context.Background(), client.MockClient{}, proj.Services, BuildContextIgnore)
+		services, err := ConvertServices(context.Background(), client.MockClient{}, proj.Services, UploadModeIgnore)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/src/pkg/cli/compose/validation_test.go
+++ b/src/pkg/cli/compose/validation_test.go
@@ -36,7 +36,7 @@ func TestValidationAndConvert(t *testing.T) {
 		mockClient := MockClient{
 			configs: []string{"CONFIG1", "CONFIG2"},
 		}
-		if _, err = ConvertServices(context.Background(), mockClient, proj.Services, BuildContextIgnore); err != nil {
+		if _, err = ConvertServices(context.Background(), mockClient, proj.Services, UploadModeIgnore); err != nil {
 			t.Logf("Service conversion failed: %v", err)
 			logs.WriteString(err.Error() + "\n")
 		}

--- a/src/pkg/cli/composeUp_test.go
+++ b/src/pkg/cli/composeUp_test.go
@@ -24,7 +24,7 @@ func TestComposeUp(t *testing.T) {
 	}))
 	defer server.Close()
 
-	_, project, err := ComposeUp(context.Background(), client.MockClient{UploadUrl: server.URL + "/", Project: proj}, compose.BuildContextIgnore, defangv1.DeploymentMode_DEVELOPMENT)
+	_, project, err := ComposeUp(context.Background(), client.MockClient{UploadUrl: server.URL + "/", Project: proj}, compose.UploadModeIgnore, defangv1.DeploymentMode_DEVELOPMENT)
 	if !errors.Is(err, ErrDryRun) {
 		t.Fatalf("ComposeUp() failed: %v", err)
 	}

--- a/src/pkg/cli/composeUp_test.go
+++ b/src/pkg/cli/composeUp_test.go
@@ -13,9 +13,6 @@ import (
 )
 
 func TestComposeUp(t *testing.T) {
-	DoDryRun = true
-	defer func() { DoDryRun = false }()
-
 	loader := compose.NewLoaderWithPath("../../tests/testproj/compose.yaml")
 	proj, err := loader.LoadProject(context.Background())
 	if err != nil {
@@ -23,11 +20,11 @@ func TestComposeUp(t *testing.T) {
 	}
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusNoContent)
+		w.WriteHeader(http.StatusOK) // same as S3
 	}))
 	defer server.Close()
 
-	_, project, err := ComposeUp(context.Background(), client.MockClient{UploadUrl: server.URL + "/", Project: proj}, false, defangv1.DeploymentMode_DEVELOPMENT)
+	_, project, err := ComposeUp(context.Background(), client.MockClient{UploadUrl: server.URL + "/", Project: proj}, compose.BuildContextIgnore, defangv1.DeploymentMode_DEVELOPMENT)
 	if !errors.Is(err, ErrDryRun) {
 		t.Fatalf("ComposeUp() failed: %v", err)
 	}

--- a/src/pkg/cli/getServices.go
+++ b/src/pkg/cli/getServices.go
@@ -9,7 +9,7 @@ import (
 	defangv1 "github.com/DefangLabs/defang/src/protos/io/defang/v1"
 )
 
-var ErrNoServices = errors.New("No services found")
+var ErrNoServices = errors.New("no services found")
 
 func GetServices(ctx context.Context, client client.Client, long bool) error {
 	projectName, err := client.LoadProjectName(ctx)


### PR DESCRIPTION
Fixes #123 by adding a new `defang cd preview` command. Technically, this command should live under `defang compose` because it needs the Compose file, but it's BYOC only and shows raw Pulumi output, so for pros only.

If we're happy with this, we can "mirror" `preview` to top-level, like `defang preview` cf. `defang up` etc.