### PR TITLE
move notarization into goreleaser

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -176,8 +176,8 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/v') # only run this step on tagged commits
         with:
           endpoint: https://wus2.codesigning.azure.net/ # from Azure portal
-          trusted-signing-account-name: DefangLabs # from Azure portal
-          certificate-profile-name: signed-binary-test # from Azure portal
+          trusted-signing-account-name: DefangLabs      # from Azure portal
+          certificate-profile-name: signed-binary       # from Azure portal
           files-folder: ${{ github.workspace }}\src\dist
           files-folder-filter: exe # no dll
           files-folder-recurse: true
@@ -194,6 +194,15 @@ jobs:
           exclude-azure-powershell-credential: true
           exclude-azure-developer-cli-credential: true
           exclude-interactive-browser-credential: true
+
+      - name: Zip signed files
+        run: |
+          $refName = '${{ github.ref_name }}'
+          $cleanRefName = $refName -replace '^v', ''
+          Compress-Archive -Path defang-cli_windows_amd64_v1\* -DestinationPath dist\windows\defang_${{ github.ref_name }}_windows_amd64.zip
+          Compress-Archive -Path defang-cli_windows_arm64\* -DestinationPath dist\windows\defang_${{ github.ref_name }}_windows_arm64.zip
+        shell: pwsh
+        working-directory: src\dist\windows
 
       - name: Upload dist-win folder
         uses: actions/upload-artifact@v4
@@ -233,6 +242,9 @@ jobs:
           MACOS_P12_BASE64: ${{ secrets.MACOS_P12_BASE64 }}
           MACOS_P12_PASSWORD: ${{ secrets.MACOS_P12_PASSWORD }}
           KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+          MACOS_NOTARIZATION_APPLE_ID: ${{ secrets.MACOS_NOTARIZATION_APPLE_ID }}
+          MACOS_NOTARIZATION_TEAM_ID: ${{ secrets.MACOS_NOTARIZATION_TEAM_ID }}
+          MACOS_NOTARIZATION_APP_PW: ${{ secrets.MACOS_NOTARIZATION_APP_PW }}
 
       - name: Upload dist-mac folder
         uses: actions/upload-artifact@v4
@@ -247,7 +259,7 @@ jobs:
     needs:
       - build-and-sign-mac
       - build-and-sign
-    runs-on: macos-latest # for notarization
+    runs-on: ubuntu-latest # for notarization
     permissions:
       contents: write # to upload archives as GitHub Releases
     steps:
@@ -292,16 +304,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # GITHUB_TOKEN is limited to the current repository
           DISCORD_WEBHOOK_ID: ${{ secrets.DISCORD_WEBHOOK_ID }}
           DISCORD_WEBHOOK_TOKEN: ${{ secrets.DISCORD_WEBHOOK_TOKEN }}
-
-      - name: Notarize macOS app # TODO: move to goreleaser.yml
-        shell: bash
-        run: |
-          bin/notarize.sh dist/darwin/defang_*_macOS.zip
-        working-directory: src
-        env:
-          MACOS_NOTARIZATION_APPLE_ID: ${{ secrets.MACOS_NOTARIZATION_APPLE_ID }}
-          MACOS_NOTARIZATION_TEAM_ID: ${{ secrets.MACOS_NOTARIZATION_TEAM_ID }}
-          MACOS_NOTARIZATION_APP_PW: ${{ secrets.MACOS_NOTARIZATION_APP_PW }}
 
   post-release:
     runs-on: ubuntu-latest

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -119,7 +119,7 @@ jobs:
 
   build-and-sign:
     name: Build app and sign files (with Trusted Signing)
-    if: startsWith(github.ref, 'refs/tags/v') # only run this step on tagged commits
+    # if: startsWith(github.ref, 'refs/tags/v') # only run this step on tagged commits
     environment: release # must use environment to be able to authenticate with Azure Federated Identity for Trusted Signing
     needs: go-test
     runs-on: windows-latest
@@ -165,7 +165,6 @@ jobs:
       # From https://github.com/Azure/trusted-signing-action/pull/37
       - name: Azure login
         uses: azure/login@v2
-        if: startsWith(github.ref, 'refs/tags/v') # only run this step on tagged commits
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -173,11 +172,10 @@ jobs:
 
       - name: Trusted Signing
         uses: Azure/trusted-signing-action@v0.3.20
-        if: startsWith(github.ref, 'refs/tags/v') # only run this step on tagged commits
         with:
           endpoint: https://wus2.codesigning.azure.net/ # from Azure portal
           trusted-signing-account-name: DefangLabs      # from Azure portal
-          certificate-profile-name: signed-binary       # from Azure portal
+          certificate-profile-name: signed-binary       # from Azure portal; TODO use -test profile for testing
           files-folder: ${{ github.workspace }}\src\dist
           files-folder-filter: exe # no dll
           files-folder-recurse: true
@@ -195,12 +193,11 @@ jobs:
           exclude-azure-developer-cli-credential: true
           exclude-interactive-browser-credential: true
 
-      - name: Zip signed files
+      - name: Update archives
         run: |
-          $refName = '${{ github.ref_name }}'
-          $cleanRefName = $refName -replace '^v', ''
-          Compress-Archive -Path defang-cli_windows_amd64_v1\* -DestinationPath dist\windows\defang_${{ github.ref_name }}_windows_amd64.zip
-          Compress-Archive -Path defang-cli_windows_arm64\* -DestinationPath dist\windows\defang_${{ github.ref_name }}_windows_arm64.zip
+          $version = '${{ github.ref_name }}' -replace '^v', ''
+          Compress-Archive -Path defang-cli_windows_amd64_v1\* -DestinationPath "dist\windows\defang_${version}_windows_amd64.zip" -Update
+          Compress-Archive -Path defang-cli_windows_arm64\* -DestinationPath "dist\windows\defang_${version}_windows_arm64.zip" -Update
         shell: pwsh
         working-directory: src\dist\windows
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -27,9 +27,9 @@ jobs:
         run: go test -test.short -v ./...
         working-directory: src
 
-      # - name: Build MacOS binary
-      #   run: GOOS=darwin go build ./cmd/cli
-      #   working-directory: src
+      - name: Build MacOS binary
+        run: GOOS=darwin go build ./cmd/cli
+        working-directory: src
 
       - name: Build Windows binary
         run: GOOS=windows go build ./cmd/cli
@@ -145,7 +145,7 @@ jobs:
         with:
           distribution: goreleaser-pro # either 'goreleaser' (default) or 'goreleaser-pro'
           # version: latest
-          args: release --split ${{ !startsWith(github.ref, 'refs/tags/v') && '--snapshot' || '' }}
+          args: release --split ${{ startsWith(github.ref, 'refs/tags/v') && '' || '--snapshot' }}
           workdir: src
         env:
           GGOOS: linux
@@ -156,7 +156,7 @@ jobs:
         with:
           distribution: goreleaser-pro # either 'goreleaser' (default) or 'goreleaser-pro'
           # version: latest
-          args: release --split ${{ !startsWith(github.ref, 'refs/tags/v') && '--snapshot' || '' }}
+          args: release --split ${{ startsWith(github.ref, 'refs/tags/v') && '' || '--snapshot' }}
           workdir: src
         env:
           GGOOS: windows
@@ -173,9 +173,9 @@ jobs:
       - name: Trusted Signing
         uses: Azure/trusted-signing-action@v0.3.20
         with:
-          endpoint: https://wus2.codesigning.azure.net/ # from Azure portal
-          trusted-signing-account-name: DefangLabs      # from Azure portal
-          certificate-profile-name: signed-binary       # from Azure portal; TODO use -test profile for testing
+          endpoint: https://wus2.codesigning.azure.net/                                                        # from Azure portal
+          trusted-signing-account-name: DefangLabs                                                             # from Azure portal
+          certificate-profile-name: signed-binary${{ startsWith(github.ref, 'refs/tags/v') && '' || '-test' }} # from Azure portal
           files-folder: ${{ github.workspace }}\src\dist
           files-folder-filter: exe # no dll
           files-folder-recurse: true
@@ -194,12 +194,15 @@ jobs:
           exclude-interactive-browser-credential: true
 
       - name: Update archives
+        if: startsWith(github.ref, 'refs/tags/v') # skip this step for snapshots because we don't know the name of the archive
         run: |
-          $version = '${{ github.ref_name }}' -replace '^v', ''
-          Compress-Archive -Path defang-cli_windows_amd64_v1\* -DestinationPath "dist\windows\defang_${version}_windows_amd64.zip" -Update
-          Compress-Archive -Path defang-cli_windows_arm64\* -DestinationPath "dist\windows\defang_${version}_windows_arm64.zip" -Update
+          $version = '${GITHUB_REF_NAME}' -replace '^v', ''
+          Compress-Archive -Path defang-cli_windows_amd64_v1\* -DestinationPath "defang_${version}_windows_amd64.zip" -Update
+          Compress-Archive -Path defang-cli_windows_arm64\* -DestinationPath "defang_${version}_windows_arm64.zip" -Update
         shell: pwsh
         working-directory: src\dist\windows
+        env:
+          GITHUB_REF_NAME: ${{ github.ref_name }}
 
       - name: Upload dist-win folder
         uses: actions/upload-artifact@v4
@@ -230,7 +233,7 @@ jobs:
         with:
           distribution: goreleaser-pro # either 'goreleaser' (default) or 'goreleaser-pro'
           # version: latest
-          args: release --split ${{ !startsWith(github.ref, 'refs/tags/v') && '--snapshot' || '' }}
+          args: release --split ${{ startsWith(github.ref, 'refs/tags/v') && '' || '--snapshot' }}
           workdir: src
         env:
           GGOOS: darwin
@@ -256,7 +259,7 @@ jobs:
     needs:
       - build-and-sign-mac
       - build-and-sign
-    runs-on: ubuntu-latest # for notarization
+    runs-on: ubuntu-latest
     permissions:
       contents: write # to upload archives as GitHub Releases
     steps:

--- a/src/.goreleaser.yml
+++ b/src/.goreleaser.yml
@@ -46,7 +46,7 @@ archives:
     name_template: '{{ .ProjectName }}_{{ .Version }}_{{ if eq .Os "darwin" }}macOS{{ else }}{{ .Os }}{{ end }}{{ if ne .Arch "all" }}_{{ .Arch }}{{ end }}{{ with .Arm }}v{{ . }}{{ end }}{{ with .Mips }}_{{ . }}{{ end }}{{ if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}'
     hooks:
       after:
-        - '{{ if eq .Os "darwin" }}./bin/notarize.sh "{{ .Path }}"{{ else }}true{{ end }}'
+        - '{{ if eq .Os "darwin" }}./bin/notarize.sh "{{ (index .Artifacts 0).Path }}"{{ else }}true{{ end }}'
 
 # notarize:
 #   macos:

--- a/src/.goreleaser.yml
+++ b/src/.goreleaser.yml
@@ -46,7 +46,7 @@ archives:
     name_template: '{{ .ProjectName }}_{{ .Version }}_{{ if eq .Os "darwin" }}macOS{{ else }}{{ .Os }}{{ end }}{{ if ne .Arch "all" }}_{{ .Arch }}{{ end }}{{ with .Arm }}v{{ . }}{{ end }}{{ with .Mips }}_{{ . }}{{ end }}{{ if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}'
     hooks:
       after:
-        - '{{ if eq .Os "darwin" }}./bin/notarize.sh "{{ .Artifacts[0].Path }}"{{ else }}true{{ end }}'
+        - '{{ if eq .Os "darwin" }}./bin/notarize.sh "{{ .Path }}"{{ else }}true{{ end }}'
 
 # notarize:
 #   macos:

--- a/src/.goreleaser.yml
+++ b/src/.goreleaser.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+# yaml-language-server: $schema=https://goreleaser.com/static/schema-pro.json
 project_name: defang
 builds:
   - id: defang-mac
@@ -44,6 +44,20 @@ archives:
         format: zip
     # replace "darwin" with "macOS" in the filename; replace "all" with ""; NOTE: if you change this, also change go.yml GitHub Actions workflow
     name_template: '{{ .ProjectName }}_{{ .Version }}_{{ if eq .Os "darwin" }}macOS{{ else }}{{ .Os }}{{ end }}{{ if ne .Arch "all" }}_{{ .Arch }}{{ end }}{{ with .Arm }}v{{ . }}{{ end }}{{ with .Mips }}_{{ . }}{{ end }}{{ if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}'
+    hooks:
+      after:
+        - '{{ if eq .Os "darwin" }}./bin/notarize.sh "{{ .Artifacts[0].Path }}"{{ else }}true{{ end }}'
+
+# notarize:
+#   macos:
+#     - enabled: true
+#       sign:
+#         certificate: "{{ .Env.MACOS_P12_BASE64 }}"
+#         password: "{{ .Env.MACOS_P12_PASSWORD }}"
+#       notarize:
+#         issuer_id: "{{ .Env.MACOS_NOTARIZATION_APPLE_ID }}"
+#         key: "{{ .Env.MACOS_NOTARIZATION_APP_PW }}" TODO: this should be a base64 .p8 key file
+#         key_id: "{{ .Env.MACOS_NOTARIZATION_TEAM_ID }}"
 
 release:
   github:
@@ -67,8 +81,8 @@ release:
   # prerelease: "true"
 
 nix:
-  # commit_author: defang-io
   - homepage: https://defang.io/
+    # commit_author: defang-io
     description: Defang is the easiest way for developers to create and deploy their containerized applications
     license: "mit"
     repository:
@@ -81,7 +95,7 @@ nix:
         --fish <($out/bin/defang completion fish)
 
 changelog:
-  use: github
+  use: github-native
   filters:
     exclude:
       # Ignore messages like "defang: v0.5.3 -> v0.5.4" (which are actually for the previous version)

--- a/src/.goreleaser.yml
+++ b/src/.goreleaser.yml
@@ -46,7 +46,8 @@ archives:
     name_template: '{{ .ProjectName }}_{{ .Version }}_{{ if eq .Os "darwin" }}macOS{{ else }}{{ .Os }}{{ end }}{{ if ne .Arch "all" }}_{{ .Arch }}{{ end }}{{ with .Arm }}v{{ . }}{{ end }}{{ with .Mips }}_{{ . }}{{ end }}{{ if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}'
     hooks:
       after:
-        - '{{ if eq .Os "darwin" }}./bin/notarize.sh "{{ (index .Artifacts 0).Path }}"{{ else }}true{{ end }}'
+        - echo '{{ printf "%#v" (index .Artifacts 1) }}'
+        - '{{ if eq .Os "darwin" }}./bin/notarize.sh "dist/darwin/defang_{{ .Version }}_macOS.zip"{{ else }}true{{ end }}'
 
 # notarize:
 #   macos:


### PR DESCRIPTION
- fix for Windows: released zip has unsigned exe because we signed after archiving
- fix for MacOS: move notarization into GoReleaser so we don't announce a new version until after notarization succeeded