### PR TITLE
Add more warning for service name replacement

### DIFF
--- a/src/pkg/cli/compose/convert.go
+++ b/src/pkg/cli/compose/convert.go
@@ -137,9 +137,10 @@ func ConvertServices(ctx context.Context, c client.Client, serviceConfigs compos
 
 			// Check if the environment variable is an existing config; if so, mark it as such
 			if _, ok := slices.BinarySearch(config.Names, key); ok {
-				term.Warnf("service %q: environment variable %q overridden by config", svccfg.Name, key)
 				if serviceNameRegex != nil && serviceNameRegex.MatchString(*value) {
-					term.Warnf("service %q: environment variable %q with value %q contains a service name needs to be normalized, but it will be repalced by an existing config. service names in a config will not be normalized.", svccfg.Name, key, *value)
+					term.Warnf("service %q: The environment variable %q, with the value %q, contains a service name that needs to be normalized. however, it will be replaced by an existing configuration. service names within a configuration will not be normalized.", svccfg.Name, key, *value)
+				} else {
+					term.Warnf("service %q: environment variable %q overridden by config", svccfg.Name, key)
 				}
 				envFromConfig = append(envFromConfig, key)
 				continue
@@ -154,7 +155,7 @@ func ConvertServices(ctx context.Context, c client.Client, serviceConfigs compos
 				if val != *value {
 					term.Warnf("service %q: service names were replaced in environment variable %q: %q", svccfg.Name, key, val)
 				} else if nonReplaceServiceNameRegex != nil && nonReplaceServiceNameRegex.MatchString(*value) {
-					term.Warnf("service %q: service names were NOT replaced in environment variable %q: %q, only service with port mode host will be replaced", svccfg.Name, key, val)
+					term.Warnf("service %q: service names in the environment variable %q (%q) were not replaced. only services with port mode set to host will be replaced.", svccfg.Name, key, val)
 				}
 			}
 			envs[key] = val

--- a/src/pkg/cli/compose/convert.go
+++ b/src/pkg/cli/compose/convert.go
@@ -138,7 +138,7 @@ func ConvertServices(ctx context.Context, c client.Client, serviceConfigs compos
 			// Check if the environment variable is an existing config; if so, mark it as such
 			if _, ok := slices.BinarySearch(config.Names, key); ok {
 				if serviceNameRegex != nil && serviceNameRegex.MatchString(*value) {
-					term.Warnf("service %q: The environment variable %q, with the value %q, contains a service name that needs to be normalized. however, it will be replaced by an existing configuration. service names within a configuration will not be normalized.", svccfg.Name, key, *value)
+					term.Warnf("service %q: environment variable %q needs service name fix-up, but is overridden by config, which will not be fixed up.", svccfg.Name, key)
 				} else {
 					term.Warnf("service %q: environment variable %q overridden by config", svccfg.Name, key)
 				}
@@ -153,9 +153,9 @@ func ConvertServices(ctx context.Context, c client.Client, serviceConfigs compos
 					return c.ServiceDNS(NormalizeServiceName(serviceName))
 				})
 				if val != *value {
-					term.Warnf("service %q: service names were replaced in environment variable %q: %q", svccfg.Name, key, val)
+					term.Warnf("service %q: service names were fixed up in environment variable %q: %q", svccfg.Name, key, val)
 				} else if nonReplaceServiceNameRegex != nil && nonReplaceServiceNameRegex.MatchString(*value) {
-					term.Warnf("service %q: service names in the environment variable %q (%q) were not replaced. only services with port mode set to host will be replaced.", svccfg.Name, key, val)
+					term.Warnf("service %q: service names in the environment variable %q were not fixed up, only services with port mode set to host will be fixed up.", svccfg.Name, key)
 				}
 			}
 			envs[key] = val

--- a/src/pkg/cli/compose/loader_test.go
+++ b/src/pkg/cli/compose/loader_test.go
@@ -45,8 +45,11 @@ func compare(actual []byte, goldenFile string) error {
 		}
 		return os.WriteFile(goldenFile, actual, 0644)
 	} else {
-		return diff(string(actual), string(golden))
+		if err := diff(string(actual), string(golden)); err != nil {
+			return fmt.Errorf("%s %w", goldenFile, err)
+		}
 	}
+	return nil
 }
 
 func diff(actualRaw, goldenRaw string) error {

--- a/src/tests/alttestproj/compose.yaml.warnings
+++ b/src/tests/alttestproj/compose.yaml.warnings
@@ -1,0 +1,1 @@
+ * Compressing build context for dfnx at .

--- a/src/tests/emptyenv/compose.yaml.warnings
+++ b/src/tests/emptyenv/compose.yaml.warnings
@@ -1,2 +1,3 @@
  ! service "emptyenv": missing compose directive: restart; assuming 'unless-stopped' (add 'restart' to silence)
  ! service "emptyenv": missing memory reservation; specify deploy.resources.reservations.memory to avoid out-of-memory errors
+ * Compressing build context for emptyenv at .

--- a/src/tests/fixupenv/compose.yaml
+++ b/src/tests/fixupenv/compose.yaml
@@ -9,3 +9,16 @@ services:
     environment:
       - "API_URL=http://Mistral:8000"
       - "SENSITIVE_DATA"
+  bad-service:
+    image: "somedb:latest"
+    ports:
+      - mode: ingress
+        target: 5432
+  use-bad-service:
+    image: "service:latest"
+    environment:
+      - "DB_URL=bad-service:5432"
+  env-in-config:
+    image: "service:latest"
+    environment:
+      - "CONFIG1=http://Mistral:8000"

--- a/src/tests/fixupenv/compose.yaml.convert
+++ b/src/tests/fixupenv/compose.yaml.convert
@@ -1,5 +1,28 @@
 [
   {
+    "name": "bad-service",
+    "image": "somedb:latest",
+    "platform": 2,
+    "internal": true,
+    "ports": [
+      {
+        "target": 5432,
+        "mode": 1
+      }
+    ],
+    "networks": 1
+  },
+  {
+    "name": "env-in-config",
+    "image": "service:latest",
+    "platform": 2,
+    "internal": true,
+    "environment": {
+      "CONFIG1": "http://mistral:8000"
+    },
+    "networks": 1
+  },
+  {
     "name": "mistral",
     "image": "mistral:latest",
     "platform": 2,
@@ -24,6 +47,16 @@
         "source": "SENSITIVE_DATA"
       }
     ],
+    "networks": 1
+  },
+  {
+    "name": "use-bad-service",
+    "image": "service:latest",
+    "platform": 2,
+    "internal": true,
+    "environment": {
+      "DB_URL": "bad-service:5432"
+    },
     "networks": 1
   }
 ]

--- a/src/tests/fixupenv/compose.yaml.golden
+++ b/src/tests/fixupenv/compose.yaml.golden
@@ -7,11 +7,30 @@ services:
     ports:
       - mode: host
         target: 8000
+  bad-service:
+    image: somedb:latest
+    networks:
+      default: null
+    ports:
+      - mode: ingress
+        target: 5432
+  env-in-config:
+    environment:
+      CONFIG1: http://Mistral:8000
+    image: service:latest
+    networks:
+      default: null
   ui:
     environment:
       API_URL: http://Mistral:8000
       SENSITIVE_DATA: null
     image: ui:latest
+    networks:
+      default: null
+  use-bad-service:
+    environment:
+      DB_URL: bad-service:5432
+    image: service:latest
     networks:
       default: null
 networks:

--- a/src/tests/fixupenv/compose.yaml.warnings
+++ b/src/tests/fixupenv/compose.yaml.warnings
@@ -3,13 +3,13 @@
  ! service "bad-service": ingress port without healthcheck defaults to GET / HTTP/1.1
  ! service "bad-service": missing compose directive: restart; assuming 'unless-stopped' (add 'restart' to silence)
  ! service "bad-service": missing memory reservation; specify deploy.resources.reservations.memory to avoid out-of-memory errors
- ! service "env-in-config": The environment variable "CONFIG1", with the value "http://Mistral:8000", contains a service name that needs to be normalized. however, it will be replaced by an existing configuration. service names within a configuration will not be normalized.
+ ! service "env-in-config": environment variable "CONFIG1" needs service name fix-up, but is overridden by config, which will not be fixed up.
  ! service "env-in-config": missing compose directive: restart; assuming 'unless-stopped' (add 'restart' to silence)
  ! service "env-in-config": missing memory reservation; specify deploy.resources.reservations.memory to avoid out-of-memory errors
  ! service "ui": missing compose directive: restart; assuming 'unless-stopped' (add 'restart' to silence)
  ! service "ui": missing memory reservation; specify deploy.resources.reservations.memory to avoid out-of-memory errors
- ! service "ui": service names were replaced in environment variable "API_URL": "http://mock-mistral:8000"
+ ! service "ui": service names were fixed up in environment variable "API_URL": "http://mock-mistral:8000"
  ! service "use-bad-service": missing compose directive: restart; assuming 'unless-stopped' (add 'restart' to silence)
  ! service "use-bad-service": missing memory reservation; specify deploy.resources.reservations.memory to avoid out-of-memory errors
- ! service "use-bad-service": service names in the environment variable "DB_URL" ("bad-service:5432") were not replaced. only services with port mode set to host will be replaced.
+ ! service "use-bad-service": service names in the environment variable "DB_URL" were not fixed up, only services with port mode set to host will be fixed up.
  ! service name "Mistral" was normalized to "mistral"

--- a/src/tests/fixupenv/compose.yaml.warnings
+++ b/src/tests/fixupenv/compose.yaml.warnings
@@ -1,5 +1,16 @@
  ! service "Mistral": missing compose directive: restart; assuming 'unless-stopped' (add 'restart' to silence)
  ! service "Mistral": missing memory reservation; specify deploy.resources.reservations.memory to avoid out-of-memory errors
+ ! service "bad-service": ingress port without healthcheck defaults to GET / HTTP/1.1
+ ! service "bad-service": missing compose directive: restart; assuming 'unless-stopped' (add 'restart' to silence)
+ ! service "bad-service": missing memory reservation; specify deploy.resources.reservations.memory to avoid out-of-memory errors
+ ! service "env-in-config": environment variable "CONFIG1" overridden by config
+ ! service "env-in-config": environment variable "CONFIG1" with value "http://Mistral:8000" contains a service name needs to be normalized, but it will be repalced by an existing config. service names in a config will not be normalized.
+ ! service "env-in-config": missing compose directive: restart; assuming 'unless-stopped' (add 'restart' to silence)
+ ! service "env-in-config": missing memory reservation; specify deploy.resources.reservations.memory to avoid out-of-memory errors
  ! service "ui": missing compose directive: restart; assuming 'unless-stopped' (add 'restart' to silence)
  ! service "ui": missing memory reservation; specify deploy.resources.reservations.memory to avoid out-of-memory errors
+ ! service "ui": service names were replaced in environment variable "API_URL": "http://mock-mistral:8000"
+ ! service "use-bad-service": missing compose directive: restart; assuming 'unless-stopped' (add 'restart' to silence)
+ ! service "use-bad-service": missing memory reservation; specify deploy.resources.reservations.memory to avoid out-of-memory errors
+ ! service "use-bad-service": service names were NOT replaced in environment variable "DB_URL": "bad-service:5432", only service with port mode host will be replaced
  ! service name "Mistral" was normalized to "mistral"

--- a/src/tests/fixupenv/compose.yaml.warnings
+++ b/src/tests/fixupenv/compose.yaml.warnings
@@ -3,8 +3,7 @@
  ! service "bad-service": ingress port without healthcheck defaults to GET / HTTP/1.1
  ! service "bad-service": missing compose directive: restart; assuming 'unless-stopped' (add 'restart' to silence)
  ! service "bad-service": missing memory reservation; specify deploy.resources.reservations.memory to avoid out-of-memory errors
- ! service "env-in-config": environment variable "CONFIG1" overridden by config
- ! service "env-in-config": environment variable "CONFIG1" with value "http://Mistral:8000" contains a service name needs to be normalized, but it will be repalced by an existing config. service names in a config will not be normalized.
+ ! service "env-in-config": The environment variable "CONFIG1", with the value "http://Mistral:8000", contains a service name that needs to be normalized. however, it will be replaced by an existing configuration. service names within a configuration will not be normalized.
  ! service "env-in-config": missing compose directive: restart; assuming 'unless-stopped' (add 'restart' to silence)
  ! service "env-in-config": missing memory reservation; specify deploy.resources.reservations.memory to avoid out-of-memory errors
  ! service "ui": missing compose directive: restart; assuming 'unless-stopped' (add 'restart' to silence)
@@ -12,5 +11,5 @@
  ! service "ui": service names were replaced in environment variable "API_URL": "http://mock-mistral:8000"
  ! service "use-bad-service": missing compose directive: restart; assuming 'unless-stopped' (add 'restart' to silence)
  ! service "use-bad-service": missing memory reservation; specify deploy.resources.reservations.memory to avoid out-of-memory errors
- ! service "use-bad-service": service names were NOT replaced in environment variable "DB_URL": "bad-service:5432", only service with port mode host will be replaced
+ ! service "use-bad-service": service names in the environment variable "DB_URL" ("bad-service:5432") were not replaced. only services with port mode set to host will be replaced.
  ! service name "Mistral" was normalized to "mistral"

--- a/src/tests/redis/compose.yaml.warnings
+++ b/src/tests/redis/compose.yaml.warnings
@@ -5,3 +5,4 @@
  ! service "y": missing memory reservation; specify deploy.resources.reservations.memory to avoid out-of-memory errors
  ! service "z": missing compose directive: restart; assuming 'unless-stopped' (add 'restart' to silence)
  ! service "z": missing memory reservation; specify deploy.resources.reservations.memory to avoid out-of-memory errors
+ ! service "z": stateful service will lose data on restart; use a managed service instead

--- a/src/tests/secretname/compose.yaml.warnings
+++ b/src/tests/secretname/compose.yaml.warnings
@@ -1,1 +1,3 @@
  ! service "app": missing memory reservation; specify deploy.resources.reservations.memory to avoid out-of-memory errors
+ ! service "app": secrets will be exposed as environment variables, not files (use 'environment' instead)
+ * Compressing build context for app at .

--- a/src/tests/testproj/compose.yaml.warnings
+++ b/src/tests/testproj/compose.yaml.warnings
@@ -1,1 +1,4 @@
+ ! No port 'mode' was specified; defaulting to 'ingress' (add 'mode: ingress' to silence)
+ ! service "dfnx": secrets will be exposed as environment variables, not files (use 'environment' instead)
  ! unsupported compose extension: "x-unsupported"
+ * Compressing build context for dfnx at .


### PR DESCRIPTION
The following questions has been repeatedly pop up when a service name replacement is needed, which prevents a successful deployment:
1. The service name need to be replaced has a port not in "host" mode, meaning it has either port->mode:ingress, or missing port config, we do not warn them if this service name is used in other service that depends on it in any of its environment variables.
2. An environment variable could be replaced by a config, though we do have an warning, but it is not clear that we do not do service name replacement in the configured values
