### PR TITLE
fix ls hint when no services are found

### DIFF
--- a/src/cmd/cli/command/commands.go
+++ b/src/cmd/cli/command/commands.go
@@ -625,13 +625,19 @@ var getServicesCmd = &cobra.Command{
 
 		err := cli.GetServices(cmd.Context(), client, long)
 		if err != nil {
-			return err
+			if !errors.Is(err, cli.ErrNoServices) {
+				return err
+			}
+
+			term.Warn("No services found")
+
+			printDefangHint("To start a new project, do:", "new")
+			return nil
 		}
 
 		if !long {
 			printDefangHint("To see more information about your services, do:", cmd.CalledAs()+" -l")
 		}
-
 		return nil
 	},
 }

--- a/src/cmd/cli/command/hint.go
+++ b/src/cmd/cli/command/hint.go
@@ -40,7 +40,7 @@ func printDefangHint(hint string, cmds ...string) {
 
 	executable := prettyExecutable("defang")
 
-	fmt.Printf("\n%s\n", hint)
+	fmt.Printf("\n%s\n\n", hint)
 	providerFlag := RootCmd.Flag("provider")
 	clusterFlag := RootCmd.Flag("cluster")
 	var prefix string
@@ -52,7 +52,7 @@ func printDefangHint(hint string, cmds ...string) {
 		prefix = executable
 	}
 	for _, arg := range cmds {
-		fmt.Printf("\n  %s %s\n", prefix, arg)
+		fmt.Printf("  %s %s\n\n", prefix, arg)
 	}
 	if rand.Intn(10) == 0 {
 		fmt.Println("To silence these hints, do: export DEFANG_HIDE_HINTS=1")

--- a/src/pkg/cli/getServices.go
+++ b/src/pkg/cli/getServices.go
@@ -2,11 +2,14 @@ package cli
 
 import (
 	"context"
+	"errors"
 
 	"github.com/DefangLabs/defang/src/pkg/cli/client"
 	"github.com/DefangLabs/defang/src/pkg/term"
 	defangv1 "github.com/DefangLabs/defang/src/protos/io/defang/v1"
 )
+
+var ErrNoServices = errors.New("No services found")
 
 func GetServices(ctx context.Context, client client.Client, long bool) error {
 	projectName, err := client.LoadProjectName(ctx)
@@ -18,6 +21,10 @@ func GetServices(ctx context.Context, client client.Client, long bool) error {
 	serviceList, err := client.GetServices(ctx)
 	if err != nil {
 		return err
+	}
+
+	if len(serviceList.Services) == 0 {
+		return ErrNoServices
 	}
 
 	if !long {


### PR DESCRIPTION
Avoid printing the `-l` hint when there are no services. Instead, show a `defang new` hint.