### PR TITLE
Pick right service folder for debugging

### DIFF
--- a/src/cmd/cli/command/commands.go
+++ b/src/cmd/cli/command/commands.go
@@ -55,7 +55,6 @@ func prettyError(err error) error {
 		err = errors.Unwrap(cerr)
 	}
 	return err
-
 }
 
 func Execute(ctx context.Context) error {

--- a/src/cmd/cli/command/commands.go
+++ b/src/cmd/cli/command/commands.go
@@ -915,7 +915,7 @@ var composeUpCmd = &cobra.Command{
 					} else if aiDebug {
 						// Call the AI debug endpoint using the original command context (not the tailCtx which is canceled); HACK: cmd might be canceled too
 						// TODO: use the WorkingDir of the failed service, might not be the project's root
-						if err := cli.Debug(context.TODO(), client, deploy.Etag, project.WorkingDir, failedServices); err != nil {
+						if err := cli.Debug(context.TODO(), client, deploy.Etag, project, failedServices); err != nil {
 							term.Warnf("failed to debug deployment: %v", err)
 						}
 					}
@@ -965,7 +965,7 @@ var composeStartCmd = &cobra.Command{
 }
 
 var debugCmd = &cobra.Command{
-	Use:         "debug",
+	Use:         "debug [SERVICE...]",
 	Annotations: authNeededAnnotation,
 	Args:        cobra.NoArgs,
 	Hidden:      true,
@@ -973,8 +973,12 @@ var debugCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		etag, _ := cmd.Flags().GetString("etag")
 
-		// TODO: use the WorkingDir of the current project instead of current folder
-		return cli.Debug(cmd.Context(), client, etag, ".", nil)
+		project, err := client.LoadProject(cmd.Context())
+		if err != nil {
+			return err
+		}
+
+		return cli.Debug(cmd.Context(), client, etag, project, args)
 	},
 }
 

--- a/src/cmd/cli/command/commands.go
+++ b/src/cmd/cli/command/commands.go
@@ -899,7 +899,7 @@ var composeUpCmd = &cobra.Command{
 				var errDeploymentFailed cli.ErrDeploymentFailed
 				if errors.As(context.Cause(tailCtx), &errDeploymentFailed) {
 					term.Warn(errDeploymentFailed)
-					failedServices = []string{errDeploymentFailed.Service, errDeploymentFailed.Service + "-image"} // HACK: also grab Kaniko logs
+					failedServices = []string{errDeploymentFailed.Service}
 				} else {
 					term.Warn("Deployment is not finished. Service(s) might not be running.")
 					// TODO: some services might be OK and we should only debug the ones that are not
@@ -967,7 +967,6 @@ var composeStartCmd = &cobra.Command{
 var debugCmd = &cobra.Command{
 	Use:         "debug [SERVICE...]",
 	Annotations: authNeededAnnotation,
-	Args:        cobra.NoArgs,
 	Hidden:      true,
 	Short:       "Debug a build, deployment, or service failure",
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/src/pkg/cli/debug.go
+++ b/src/pkg/cli/debug.go
@@ -91,7 +91,7 @@ func getServices(project *types.Project, names []string) types.Services {
 	services := types.Services{}
 	for _, s := range names {
 		if svc, err := project.GetService(s); err != nil {
-			term.Debugf("can't get service %q", s)
+			term.Debug("skipped for debugging:", err)
 		} else {
 			services[s] = svc
 		}

--- a/src/pkg/cli/debug.go
+++ b/src/pkg/cli/debug.go
@@ -16,10 +16,12 @@ import (
 
 // Arbitrary limit on the maximum number of files to process to avoid walking the entire drive and we have limited
 // context window for the LLM also.
-// FIXME: Find a better way to handle files.
 const maxFiles = 20
 
-var errFileLimitReached = errors.New("file limit reached")
+var (
+	errFileLimitReached = errors.New("file limit reached")
+	patterns            = []string{"*.js", "*.ts", "*.py", "*.go", "requirements.txt", "package.json", "go.mod"} // TODO: add patterns for other languages
+)
 
 func Debug(ctx context.Context, c client.Client, etag string, project *types.Project, services []string) error {
 	term.Debug("Invoking AI debugger for deployment", etag)
@@ -120,7 +122,6 @@ func findMatchingProjectFiles(project *types.Project, services []string) []*defa
 
 func findMatchingFiles(folder, dockerfile string) []*defangv1.File {
 	var files []*defangv1.File
-	patterns := []string{"*.js", "*.ts", "*.py", "*.go", "requirements.txt", "package.json", "go.mod"}
 
 	if file := readFile(filepath.Join(folder, dockerfile)); file != nil {
 		files = append(files, file)

--- a/src/pkg/cli/debug.go
+++ b/src/pkg/cli/debug.go
@@ -19,11 +19,24 @@ const maxFiles = 20
 
 var ErrFileLimitReached = errors.New("file limit reached")
 
-func Debug(ctx context.Context, c client.Client, etag, folder string, services []string) error {
+func Debug(ctx context.Context, c client.Client, etag, service string, services []string) error {
 	term.Debug("Invoking AI debugger for deployment", etag)
 
+	project, err := c.LoadProject(ctx)
+	if err != nil {
+		return err
+	}
+
+	dockerfile := "Dockerfile"
+	folder := project.WorkingDir
+	s, _ := project.GetService(service)
+	if s.Build != nil {
+		folder = s.Build.Context
+		dockerfile = s.Build.Dockerfile
+	}
+
 	// FIXME: use the project information to determine which files to send
-	patterns := []string{"Dockerfile", "*compose.yaml", "*compose.yml", "*.js", "*.ts", "*.py", "*.go", "requirements.txt", "package.json", "go.mod"}
+	patterns := []string{dockerfile, "*compose.yaml", "*compose.yml", "*.js", "*.ts", "*.py", "*.go", "requirements.txt", "package.json", "go.mod"}
 
 	files := findMatchingFiles(folder, patterns)
 

--- a/src/pkg/cli/debug_test.go
+++ b/src/pkg/cli/debug_test.go
@@ -1,0 +1,34 @@
+package cli
+
+import (
+	"context"
+	"testing"
+
+	"github.com/DefangLabs/defang/src/pkg/cli/compose"
+	defangv1 "github.com/DefangLabs/defang/src/protos/io/defang/v1"
+)
+
+func TestDebug(t *testing.T) {
+	project, err := compose.Loader{"../../tests/debugproj/compose.yaml"}.LoadCompose(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Test that the correct files are found for debugging: compose.yaml + only files from the failing service
+	files := findMatchingProjectFiles(project, []string{"failing", "failing-image"})
+	expected := []*defangv1.File{
+		{Name: "compose.yaml", Content: "services:\n  failing:\n    build: ./app\n  ok:\n    build: .\n"},
+		{Name: "main.js", Content: "// This file should be sent to the debugger"},
+	}
+	if len(files) != len(expected) {
+		t.Fatalf("expected %d files, got %d", len(expected), len(files))
+	}
+	for i, file := range files {
+		if file.Name != expected[i].Name {
+			t.Errorf("expected file name %q, got: %q", expected[i].Name, file.Name)
+		}
+		if file.Content != expected[i].Content {
+			t.Errorf("expected file content %q, got: %q", expected[i].Content, file.Content)
+		}
+	}
+}

--- a/src/pkg/cli/debug_test.go
+++ b/src/pkg/cli/debug_test.go
@@ -18,6 +18,7 @@ func TestDebug(t *testing.T) {
 	files := findMatchingProjectFiles(project, []string{"failing", "failing-image"})
 	expected := []*defangv1.File{
 		{Name: "compose.yaml", Content: "services:\n  failing:\n    build: ./app\n  ok:\n    build: .\n"},
+		{Name: "Dockerfile", Content: "FROM scratch"},
 		{Name: "main.js", Content: "// This file should be sent to the debugger"},
 	}
 	if len(files) != len(expected) {

--- a/src/tests/debugproj/app/Dockerfile
+++ b/src/tests/debugproj/app/Dockerfile
@@ -1,0 +1,1 @@
+FROM scratch

--- a/src/tests/debugproj/app/main.js
+++ b/src/tests/debugproj/app/main.js
@@ -1,0 +1,1 @@
+// This file should be sent to the debugger

--- a/src/tests/debugproj/compose.yaml
+++ b/src/tests/debugproj/compose.yaml
@@ -1,0 +1,5 @@
+services:
+  failing:
+    build: ./app
+  ok:
+    build: .

--- a/src/tests/debugproj/compose.yaml.convert
+++ b/src/tests/debugproj/compose.yaml.convert
@@ -1,0 +1,22 @@
+[
+  {
+    "name": "failing",
+    "platform": 2,
+    "internal": true,
+    "build": {
+      "context": "./app",
+      "dockerfile": "Dockerfile"
+    },
+    "networks": 1
+  },
+  {
+    "name": "ok",
+    "platform": 2,
+    "internal": true,
+    "build": {
+      "context": ".",
+      "dockerfile": "Dockerfile"
+    },
+    "networks": 1
+  }
+]

--- a/src/tests/debugproj/compose.yaml.golden
+++ b/src/tests/debugproj/compose.yaml.golden
@@ -1,0 +1,17 @@
+name: debugproj
+services:
+  failing:
+    build:
+      context: ./app
+      dockerfile: Dockerfile
+    networks:
+      default: null
+  ok:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    networks:
+      default: null
+networks:
+  default:
+    name: debugproj_default

--- a/src/tests/debugproj/compose.yaml.warnings
+++ b/src/tests/debugproj/compose.yaml.warnings
@@ -1,0 +1,6 @@
+ ! service "failing": missing compose directive: restart; assuming 'unless-stopped' (add 'restart' to silence)
+ ! service "failing": missing memory reservation; specify deploy.resources.reservations.memory to avoid out-of-memory errors
+ ! service "ok": missing compose directive: restart; assuming 'unless-stopped' (add 'restart' to silence)
+ ! service "ok": missing memory reservation; specify deploy.resources.reservations.memory to avoid out-of-memory errors
+ * Compressing build context for failing at ./app
+ * Compressing build context for ok at .

--- a/src/tests/debugproj/main.py
+++ b/src/tests/debugproj/main.py
@@ -1,0 +1,1 @@
+# This file should not be sent to the debugger


### PR DESCRIPTION
Improvements to #575 

This PR uses the project information to narrow down which files are sent to the debugger. It uses the same "walk dir" that's used by the tarball logic, so it takes `.dockerignore` into account.