### PR TITLE
Reformat whoami string

### DIFF
--- a/src/cmd/cli/command/commands.go
+++ b/src/cmd/cli/command/commands.go
@@ -400,10 +400,12 @@ var whoamiCmd = &cobra.Command{
 	Args:  cobra.NoArgs,
 	Short: "Show the current user",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		err := cli.Whoami(cmd.Context(), client) // always prints
+		str, err := cli.Whoami(cmd.Context(), client)
 		if err != nil {
 			return err
 		}
+
+		term.Infof(str)
 		return nil
 	},
 }

--- a/src/pkg/cli/whoami.go
+++ b/src/pkg/cli/whoami.go
@@ -3,15 +3,18 @@ package cli
 import (
 	"context"
 
-	"github.com/DefangLabs/defang/src/pkg/cli/client"
+	cliClient "github.com/DefangLabs/defang/src/pkg/cli/client"
 	"github.com/DefangLabs/defang/src/pkg/term"
 )
 
-func Whoami(ctx context.Context, client client.Client) error {
+func Whoami(ctx context.Context, client cliClient.Client) error {
 	resp, err := client.WhoAmI(ctx)
 	if err != nil {
 		return err
 	}
-	term.Infof("You are logged into tenant %q in %q region %q", resp.Tenant, resp.Account, resp.Region)
+
+	term.Infof("You are logged into %s region %s with tenant %q",
+		resp.Account, resp.Region, resp.Tenant)
+
 	return nil
 }

--- a/src/pkg/cli/whoami.go
+++ b/src/pkg/cli/whoami.go
@@ -2,19 +2,19 @@ package cli
 
 import (
 	"context"
+	"fmt"
 
 	cliClient "github.com/DefangLabs/defang/src/pkg/cli/client"
-	"github.com/DefangLabs/defang/src/pkg/term"
 )
 
-func Whoami(ctx context.Context, client cliClient.Client) error {
+func Whoami(ctx context.Context, client cliClient.Client) (string, error) {
 	resp, err := client.WhoAmI(ctx)
 	if err != nil {
-		return err
+		return "", err
 	}
 
-	term.Infof("You are logged into %s region %s with tenant %q",
-		resp.Account, resp.Region, resp.Tenant)
-
-	return nil
+	return fmt.Sprintf(
+		"You are logged into %s region %s with tenant %q",
+		resp.Account, resp.Region, resp.Tenant,
+	), nil
 }

--- a/src/pkg/cli/whoami_test.go
+++ b/src/pkg/cli/whoami_test.go
@@ -1,0 +1,51 @@
+package cli
+
+import (
+	"context"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	cliClient "github.com/DefangLabs/defang/src/pkg/cli/client"
+	defangv1 "github.com/DefangLabs/defang/src/protos/io/defang/v1"
+	"github.com/DefangLabs/defang/src/protos/io/defang/v1/defangv1connect"
+	"github.com/bufbuild/connect-go"
+	"google.golang.org/protobuf/types/known/emptypb"
+)
+
+type grpcWhoamiMockHandler struct {
+	defangv1connect.UnimplementedFabricControllerHandler
+}
+
+func (g *grpcWhoamiMockHandler) WhoAmI(context.Context, *connect.Request[emptypb.Empty]) (*connect.Response[defangv1.WhoAmIResponse], error) {
+	return connect.NewResponse(&defangv1.WhoAmIResponse{
+		Tenant:  "tenant-1",
+		Account: "playground",
+		Region:  "us-test-2",
+	}), nil
+
+}
+
+func TestWhoami(t *testing.T) {
+	fabricServer := &grpcWhoamiMockHandler{}
+	_, handler := defangv1connect.NewFabricControllerHandler(fabricServer)
+
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	ctx := context.Background()
+	url := strings.TrimPrefix(server.URL, "http://")
+	grpcClient := Connect(url, nil)
+	client := cliClient.PlaygroundClient{GrpcClient: grpcClient}
+
+	got, err := Whoami(ctx, &client)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := `You are logged into playground region us-test-2 with tenant "tenant-1"`
+
+	if got != want {
+		t.Errorf("Whoami() = %v, want: %v", got, want)
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/DefangLabs/defang/issues/566
Depends on https://github.com/DefangLabs/defang-mvp/pull/854

We decided to continue to print the region in the whoami string, but the re-format the values such that the account and region are listed before the tenant. Further, in https://github.com/DefangLabs/defang-mvp/pull/854, we update the playground account name from `defang` to `playground` to further clarify that the user is not using their own cloud.