### PR TITLE
Add --project-name cli flag. Lazily load project name from flags, env, or compose file

### DIFF
--- a/src/cmd/cli/command/commands.go
+++ b/src/cmd/cli/command/commands.go
@@ -83,7 +83,7 @@ func Execute(ctx context.Context) error {
 		}
 
 		if err.Error() == "resource_exhausted: maximum number of projects reached" {
-			printDefangHint("To deactivate a project, do:", "compose down")
+			printDefangHint("To deactivate a project, do:", "compose down --project-name <name>")
 		}
 
 		var cerr *cli.CancelError

--- a/src/cmd/cli/command/commands.go
+++ b/src/cmd/cli/command/commands.go
@@ -134,6 +134,7 @@ func SetupCommands(version string) {
 	RootCmd.PersistentFlags().BoolVar(&doDebug, "debug", pkg.GetenvBool("DEFANG_DEBUG"), "debug logging for troubleshooting the CLI")
 	RootCmd.PersistentFlags().BoolVar(&cli.DoDryRun, "dry-run", false, "dry run (don't actually change anything)")
 	RootCmd.PersistentFlags().BoolVarP(&nonInteractive, "non-interactive", "T", !hasTty, "disable interactive prompts / no TTY")
+	RootCmd.PersistentFlags().StringP("project-name", "p", "", "project name")
 	RootCmd.PersistentFlags().StringP("cwd", "C", "", "change directory before running the command")
 	_ = RootCmd.MarkPersistentFlagDirname("cwd")
 	RootCmd.PersistentFlags().StringArrayP("file", "f", []string{}, `compose file path`)
@@ -201,7 +202,6 @@ func SetupCommands(version string) {
 	// composeCmd.Flags().Int("parallel", -1, "Control max parallelism, -1 for unlimited (default -1)"); TODO: Implement compose option
 	// composeCmd.Flags().String("profile", "", "Specify a profile to enable"); TODO: Implement compose option
 	// composeCmd.Flags().String("project-directory", "", "Specify an alternate working directory"); TODO: Implement compose option
-	// composeCmd.Flags().StringP("project", "p", "", "Compose project name"); TODO: Implement compose option
 	composeUpCmd.Flags().Bool("tail", false, "tail the service logs after updating") // obsolete, but keep for backwards compatibility
 	_ = composeUpCmd.Flags().MarkHidden("tail")
 	composeUpCmd.Flags().Bool("force", false, "force a build of the image even if nothing has changed")
@@ -1286,6 +1286,10 @@ func configureLoader(cmd *cobra.Command) compose.Loader {
 		panic(err)
 	}
 
+	o.ProjectName, err = f.GetString("project-name")
+	if err != nil {
+		panic(err)
+	}
 	return compose.NewLoaderWithOptions(o)
 }
 

--- a/src/cmd/cli/command/commands.go
+++ b/src/cmd/cli/command/commands.go
@@ -587,7 +587,7 @@ var generateCmd = &cobra.Command{
 			ConfigPaths: []string{filepath.Join(prompt.Folder, "compose.yaml")},
 		}
 		loader := compose.NewLoaderWithOptions(loaderOptions)
-		project, _ := loader.LoadCompose(cmd.Context())
+		project, _ := loader.LoadProject(cmd.Context())
 
 		var envInstructions []string
 		for _, envVar := range collectUnsetEnvVars(project) {

--- a/src/pkg/cli/client/byoc/aws/byoc_test.go
+++ b/src/pkg/cli/client/byoc/aws/byoc_test.go
@@ -67,6 +67,10 @@ type FakeLoader struct {
 	ProjectName string
 }
 
-func (f FakeLoader) LoadCompose(ctx context.Context) (*compose.Project, error) {
+func (f FakeLoader) LoadProject(ctx context.Context) (*compose.Project, error) {
 	return &compose.Project{Name: f.ProjectName}, nil
+}
+
+func (f FakeLoader) LoadProjectName(ctx context.Context) (string, error) {
+	return f.ProjectName, nil
 }

--- a/src/pkg/cli/client/byoc/baseclient.go
+++ b/src/pkg/cli/client/byoc/baseclient.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"slices"
 	"strings"
-	"sync"
 
 	"github.com/DefangLabs/defang/src/pkg"
 	"github.com/DefangLabs/defang/src/pkg/cli/client"
@@ -56,7 +55,7 @@ type ByocBaseClient struct {
 	ShouldDelegateSubdomain bool
 	TenantID                string
 
-	loadProjOnce    func() (*compose.Project, error)
+	project         *compose.Project
 	bootstrapLister BootstrapLister
 }
 
@@ -82,15 +81,6 @@ func NewByocBaseClient(ctx context.Context, grpcClient client.GrpcClient, tenant
 		},
 		bootstrapLister: bl,
 	}
-	b.loadProjOnce = sync.OnceValues(func() (*compose.Project, error) {
-		proj, err := b.GrpcClient.Loader.LoadCompose(ctx)
-		if err != nil {
-			return nil, err
-		}
-		b.PrivateDomain = DnsSafeLabel(proj.Name) + ".internal"
-		b.ProjectName = proj.Name
-		return proj, nil
-	})
 	return b
 }
 
@@ -104,20 +94,42 @@ func (b *ByocBaseClient) GetVersions(context.Context) (*defangv1.Version, error)
 }
 
 func (b *ByocBaseClient) LoadProject(ctx context.Context) (*compose.Project, error) {
-	return b.loadProjOnce()
+	if b.project != nil {
+		return b.project, nil
+	}
+	project, err := b.Loader.LoadProject(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	b.project = project
+	b.setProjectName(project.Name)
+
+	return project, nil
 }
 
 func (b *ByocBaseClient) LoadProjectName(ctx context.Context) (string, error) {
-
-	proj, err := b.loadProjOnce()
-	if err == nil {
-		b.ProjectName = proj.Name
-		return proj.Name, nil
+	if b.ProjectName != "" {
+		return b.ProjectName, nil
 	}
-	if !errors.Is(err, types.ErrComposeFileNotFound) {
+	projectName, err := b.Loader.LoadProjectName(ctx) // Load the project to get the name
+	if err != nil {
+		if errors.Is(err, types.ErrComposeFileNotFound) {
+			return b.loadProjectNameFromRemote(ctx)
+		}
+
 		return "", err
 	}
 
+	b.setProjectName(projectName)
+	return projectName, nil
+}
+
+func (b *ByocBaseClient) ServiceDNS(name string) string {
+	return DnsSafeLabel(name) // TODO: consider merging this with getPrivateFqdn
+}
+
+func (b *ByocBaseClient) loadProjectNameFromRemote(ctx context.Context) (string, error) {
 	// Get the list of projects from remote
 	projectNames, err := b.bootstrapLister.BootstrapList(ctx)
 	if err != nil {
@@ -132,7 +144,7 @@ func (b *ByocBaseClient) LoadProjectName(ctx context.Context) (string, error) {
 	}
 	if len(projectNames) == 1 {
 		term.Debug("Using default project: ", projectNames[0])
-		b.ProjectName = projectNames[0]
+		b.setProjectName(projectNames[0])
 		return projectNames[0], nil
 	}
 
@@ -141,14 +153,15 @@ func (b *ByocBaseClient) LoadProjectName(ctx context.Context) (string, error) {
 		if !slices.Contains(projectNames, projectName) {
 			return "", fmt.Errorf("project %q specified by COMPOSE_PROJECT_NAME not found", projectName)
 		}
-		term.Debug("Using project from COMPOSE_PROJECT_NAME environment variable:", projectNames[0])
-		b.ProjectName = projectName
+		term.Debug("Using project from COMPOSE_PROJECT_NAME environment variable:", projectName)
+		b.setProjectName(projectName)
 		return projectName, nil
 	}
 
 	return "", errors.New("multiple projects found; please go to the correct project directory where the compose file is or set COMPOSE_PROJECT_NAME")
 }
 
-func (b *ByocBaseClient) ServiceDNS(name string) string {
-	return DnsSafeLabel(name) // TODO: consider merging this with getPrivateFqdn
+func (b *ByocBaseClient) setProjectName(projectName string) {
+	b.ProjectName = projectName
+	b.PrivateDomain = DnsSafeLabel(b.ProjectName) + ".internal"
 }

--- a/src/pkg/cli/client/byoc/do/byoc.go
+++ b/src/pkg/cli/client/byoc/do/byoc.go
@@ -235,7 +235,7 @@ func (b *ByocDo) environment() map[string]string {
 		"DEFANG_ORG":                 b.TenantID,
 		"DOMAIN":                     b.ProjectDomain,
 		"PRIVATE_DOMAIN":             b.PrivateDomain,
-		"PROJECT":                    b.PulumiProject,
+		"PROJECT":                    b.ProjectName,
 		"PULUMI_BACKEND_URL":         fmt.Sprintf(`s3://%s.digitaloceanspaces.com/%s`, region, b.driver.BucketName), // TODO: add a way to override bucket
 		"PULUMI_CONFIG_PASSPHRASE":   pkg.Getenv("PULUMI_CONFIG_PASSPHRASE", "asdf"),                                // TODO: make customizable
 		"STACK":                      b.PulumiStack,
@@ -251,7 +251,7 @@ func (b *ByocDo) update(ctx context.Context, service *defangv1.Service) (*defang
 
 	si := &defangv1.ServiceInfo{
 		Service: service,
-		Project: b.PulumiProject,
+		Project: b.ProjectName,
 		Etag:    pkg.RandomID(),
 	}
 

--- a/src/pkg/cli/client/client.go
+++ b/src/pkg/cli/client/client.go
@@ -16,7 +16,8 @@ type ServerStream[Res any] interface {
 }
 
 type ProjectLoader interface {
-	LoadCompose(context.Context) (*compose.Project, error)
+	LoadProjectName(context.Context) (string, error)
+	LoadProject(context.Context) (*compose.Project, error)
 }
 
 type FabricClient interface {

--- a/src/pkg/cli/client/playground.go
+++ b/src/pkg/cli/client/playground.go
@@ -15,10 +15,16 @@ import (
 
 type PlaygroundClient struct {
 	GrpcClient
+	project     *compose.Project
+	projectName string
 }
 
 func (g PlaygroundClient) LoadProject(ctx context.Context) (*compose.Project, error) {
-	return g.Loader.LoadCompose(ctx)
+	if g.project != nil {
+		return g.project, nil
+	}
+
+	return g.Loader.LoadProject(ctx)
 }
 
 func (g PlaygroundClient) Deploy(ctx context.Context, req *defangv1.DeployRequest) (*defangv1.DeployResponse, error) {
@@ -126,9 +132,13 @@ func (g PlaygroundClient) ServiceDNS(name string) string {
 }
 
 func (g PlaygroundClient) LoadProjectName(ctx context.Context) (string, error) {
-	proj, err := g.Loader.LoadCompose(ctx)
+	if g.projectName != "" {
+		return g.projectName, nil
+	}
+
+	name, err := g.Loader.LoadProjectName(ctx)
 	if err == nil {
-		return proj.Name, nil
+		return name, nil
 	}
 	if !errors.Is(err, types.ErrComposeFileNotFound) {
 		return "", err

--- a/src/pkg/cli/compose/compose_test.go
+++ b/src/pkg/cli/compose/compose_test.go
@@ -9,62 +9,62 @@ import (
 	"github.com/DefangLabs/defang/src/pkg/term"
 )
 
-func TestLoadCompose(t *testing.T) {
+func TestLoadProject(t *testing.T) {
 	term.SetDebug(testing.Verbose())
 
 	t.Run("no project name defaults to parent directory name", func(t *testing.T) {
 		loader := NewLoaderWithPath("../../../tests/noprojname/compose.yaml")
-		p, err := loader.LoadCompose(context.Background())
+		p, err := loader.LoadProject(context.Background())
 		if err != nil {
-			t.Fatalf("LoadCompose() failed: %v", err)
+			t.Fatalf("LoadProject() failed: %v", err)
 		}
 		if p.Name != "noprojname" { // Use the parent directory name as project name
-			t.Errorf("LoadCompose() failed: expected project name tenant-id, got %q", p.Name)
+			t.Errorf("LoadProject() failed: expected project name tenant-id, got %q", p.Name)
 		}
 	})
 
 	t.Run("no project name defaults to fancy parent directory name", func(t *testing.T) {
 		loader := NewLoaderWithPath("../../../tests/Fancy-Proj_Dir/compose.yaml")
-		p, err := loader.LoadCompose(context.Background())
+		p, err := loader.LoadProject(context.Background())
 		if err != nil {
-			t.Fatalf("LoadCompose() failed: %v", err)
+			t.Fatalf("LoadProject() failed: %v", err)
 		}
 		if p.Name != "fancy-proj_dir" { // Use the parent directory name as project name
-			t.Errorf("LoadCompose() failed: expected project name tenant-id, got %q", p.Name)
+			t.Errorf("LoadProject() failed: expected project name tenant-id, got %q", p.Name)
 		}
 	})
 
 	t.Run("use project name in compose file", func(t *testing.T) {
 		loader := NewLoaderWithPath("../../../tests/testproj/compose.yaml")
-		p, err := loader.LoadCompose(context.Background())
+		p, err := loader.LoadProject(context.Background())
 		if err != nil {
-			t.Fatalf("LoadCompose() failed: %v", err)
+			t.Fatalf("LoadProject() failed: %v", err)
 		}
 		if p.Name != "tests" {
-			t.Errorf("LoadCompose() failed: expected project name, got %q", p.Name)
+			t.Errorf("LoadProject() failed: expected project name, got %q", p.Name)
 		}
 	})
 
 	t.Run("COMPOSE_PROJECT_NAME env var should override project name", func(t *testing.T) {
 		t.Setenv("COMPOSE_PROJECT_NAME", "overridename")
 		loader := NewLoaderWithPath("../../../tests/testproj/compose.yaml")
-		p, err := loader.LoadCompose(context.Background())
+		p, err := loader.LoadProject(context.Background())
 		if err != nil {
-			t.Fatalf("LoadCompose() failed: %v", err)
+			t.Fatalf("LoadProject() failed: %v", err)
 		}
 		if p.Name != "overridename" {
-			t.Errorf("LoadCompose() failed: expected project name to be overwritten by env var, got %q", p.Name)
+			t.Errorf("LoadProject() failed: expected project name to be overwritten by env var, got %q", p.Name)
 		}
 	})
 
 	t.Run("use project name should not be overriden by tenantID", func(t *testing.T) {
 		loader := NewLoaderWithPath("../../../tests/testproj/compose.yaml")
-		p, err := loader.LoadCompose(context.Background())
+		p, err := loader.LoadProject(context.Background())
 		if err != nil {
-			t.Fatalf("LoadCompose() failed: %v", err)
+			t.Fatalf("LoadProject() failed: %v", err)
 		}
 		if p.Name != "tests" {
-			t.Errorf("LoadCompose() failed: expected project name tests, got %q", p.Name)
+			t.Errorf("LoadProject() failed: expected project name tests, got %q", p.Name)
 		}
 	})
 
@@ -88,23 +88,23 @@ func TestLoadCompose(t *testing.T) {
 
 		// execute test
 		loader := NewLoaderWithPath("")
-		p, err := loader.LoadCompose(context.Background())
+		p, err := loader.LoadProject(context.Background())
 		if err != nil {
-			t.Fatalf("LoadCompose() failed: %v", err)
+			t.Fatalf("LoadProject() failed: %v", err)
 		}
 		if p.Name != "tests" {
-			t.Errorf("LoadCompose() failed: expected project name tests, got %q", p.Name)
+			t.Errorf("LoadProject() failed: expected project name tests, got %q", p.Name)
 		}
 	})
 
 	t.Run("load alternative compose file", func(t *testing.T) {
 		loader := NewLoaderWithPath("../../../tests/alttestproj/altcomp.yaml")
-		p, err := loader.LoadCompose(context.Background())
+		p, err := loader.LoadProject(context.Background())
 		if err != nil {
-			t.Fatalf("LoadCompose() failed: %v", err)
+			t.Fatalf("LoadProject() failed: %v", err)
 		}
 		if p.Name != "altcomp" {
-			t.Errorf("LoadCompose() failed: expected project name altcomp, got %q", p.Name)
+			t.Errorf("LoadProject() failed: expected project name altcomp, got %q", p.Name)
 		}
 	})
 }
@@ -120,9 +120,9 @@ func TestComposeGoNoDoubleWarningLog(t *testing.T) {
 	term.DefaultTerm = term.NewTerm(&warnings, &warnings)
 
 	loader := NewLoaderWithPath("../../../tests/compose-go-warn/compose.yaml")
-	_, err := loader.LoadCompose(context.Background())
+	_, err := loader.LoadProject(context.Background())
 	if err != nil {
-		t.Fatalf("LoadCompose() failed: %v", err)
+		t.Fatalf("LoadProject() failed: %v", err)
 	}
 
 	if bytes.Count(warnings.Bytes(), []byte(`"yes" for boolean is not supported by YAML 1.2`)) != 1 {
@@ -138,13 +138,13 @@ func TestComposeOnlyOneFile(t *testing.T) {
 	os.Chdir("../../../tests/toomany")
 
 	loader := NewLoaderWithPath("")
-	project, err := loader.LoadCompose(context.Background())
+	project, err := loader.LoadProject(context.Background())
 	if err != nil {
-		t.Errorf("LoadCompose() failed: %v", err)
+		t.Errorf("LoadProject() failed: %v", err)
 	}
 
 	if len(project.ComposeFiles) != 1 {
-		t.Errorf("LoadCompose() failed: expected only one config file, got %d", len(project.ComposeFiles))
+		t.Errorf("LoadProject() failed: expected only one config file, got %d", len(project.ComposeFiles))
 	}
 }
 
@@ -157,16 +157,16 @@ func TestComposeMultipleFiles(t *testing.T) {
 
 	composeFiles := []string{"compose1.yaml", "compose2.yaml"}
 	loader := NewLoaderWithOptions(LoaderOptions{ConfigPaths: composeFiles})
-	project, err := loader.LoadCompose(context.Background())
+	project, err := loader.LoadProject(context.Background())
 	if err != nil {
-		t.Fatalf("LoadCompose() failed: %v", err)
+		t.Fatalf("LoadProject() failed: %v", err)
 	}
 
 	if len(project.ComposeFiles) != 2 {
-		t.Errorf("LoadCompose() failed: expected 2 compose files, got %d", len(project.ComposeFiles))
+		t.Errorf("LoadProject() failed: expected 2 compose files, got %d", len(project.ComposeFiles))
 	}
 
 	if len(project.Services) != 2 {
-		t.Errorf("LoadCompose() failed: expected 2 services, got %d", len(project.Services))
+		t.Errorf("LoadProject() failed: expected 2 services, got %d", len(project.Services))
 	}
 }

--- a/src/pkg/cli/compose/compose_test.go
+++ b/src/pkg/cli/compose/compose_test.go
@@ -31,8 +31,7 @@ func TestLoadProjectName(t *testing.T) {
 	}
 
 	t.Run("COMPOSE_PROJECT_NAME env var should override project name", func(t *testing.T) {
-		os.Setenv("COMPOSE_PROJECT_NAME", "overridename")
-		defer os.Unsetenv("COMPOSE_PROJECT_NAME")
+		t.Setenv("COMPOSE_PROJECT_NAME", "overridename")
 		loader := NewLoaderWithPath("../../../tests/testproj/compose.yaml")
 		name, err := loader.LoadProjectName(context.Background())
 		if err != nil {

--- a/src/pkg/cli/compose/compose_test.go
+++ b/src/pkg/cli/compose/compose_test.go
@@ -72,9 +72,6 @@ func TestLoadProject(t *testing.T) {
 		if len(p.Services) != 0 {
 			t.Errorf("LoadProject() failed: expected 0 services, got %d", len(p.Services))
 		}
-		if len(p.Secrets) != 1 {
-			t.Errorf("LoadProject() failed: expected 1 secrets, got %d", len(p.Secrets))
-		}
 	})
 
 	t.Run("no project name defaults to fancy parent directory name", func(t *testing.T) {
@@ -90,9 +87,6 @@ func TestLoadProject(t *testing.T) {
 		if len(p.Services) != 0 {
 			t.Errorf("LoadProject() failed: expected 0 services, got %d", len(p.Services))
 		}
-		if len(p.Secrets) != 1 {
-			t.Errorf("LoadProject() failed: expected 1 secrets, got %d", len(p.Secrets))
-		}
 	})
 
 	t.Run("use project name in compose file", func(t *testing.T) {
@@ -106,9 +100,6 @@ func TestLoadProject(t *testing.T) {
 		}
 		if len(p.Services) != 1 {
 			t.Errorf("LoadProject() failed: expected 1 services, got %d", len(p.Services))
-		}
-		if len(p.Secrets) != 1 {
-			t.Errorf("LoadProject() failed: expected 1 secrets, got %d", len(p.Secrets))
 		}
 	})
 
@@ -125,9 +116,6 @@ func TestLoadProject(t *testing.T) {
 		if len(p.Services) != 1 {
 			t.Errorf("LoadProject() failed: expected 1 services, got %d", len(p.Services))
 		}
-		if len(p.Secrets) != 1 {
-			t.Errorf("LoadProject() failed: expected 1 secrets, got %d", len(p.Secrets))
-		}
 	})
 
 	t.Run("use project name should not be overriden by tenantID", func(t *testing.T) {
@@ -141,9 +129,6 @@ func TestLoadProject(t *testing.T) {
 		}
 		if len(p.Services) != 1 {
 			t.Errorf("LoadProject() failed: expected 1 services, got %d", len(p.Services))
-		}
-		if len(p.Secrets) != 1 {
-			t.Errorf("LoadProject() failed: expected 1 secrets, got %d", len(p.Secrets))
 		}
 	})
 
@@ -176,9 +161,6 @@ func TestLoadProject(t *testing.T) {
 		}
 		if len(p.Services) != 1 {
 			t.Errorf("LoadProject() failed: expected 1 services, got %d", len(p.Services))
-		}
-		if len(p.Secrets) != 0 {
-			t.Errorf("LoadProject() failed: expected 0 secrets, got %d", len(p.Secrets))
 		}
 	})
 

--- a/src/pkg/cli/compose/compose_test.go
+++ b/src/pkg/cli/compose/compose_test.go
@@ -42,6 +42,21 @@ func TestLoadProjectName(t *testing.T) {
 			t.Errorf("LoadProjectName() failed: expected project name to be overwritten by env var, got %q", name)
 		}
 	})
+
+	t.Run("--project-name has precidence over COMPOSE_PROJECT_NAME env var", func(t *testing.T) {
+		t.Setenv("COMPOSE_PROJECT_NAME", "ignoreme")
+		options := LoaderOptions{ProjectName: "expectedname"}
+		loader := NewLoaderWithOptions(options)
+		name, err := loader.LoadProjectName(context.Background())
+		if err != nil {
+			t.Fatalf("LoadProjectName() failed: %v", err)
+		}
+
+		if name != "expectedname" {
+			t.Errorf("LoadProjectName() failed: expected project name to be overwritten by env var, got %q", name)
+		}
+	})
+
 }
 
 func TestLoadProjectNameWithoutComposeFile(t *testing.T) {

--- a/src/pkg/cli/compose/convert_test.go
+++ b/src/pkg/cli/compose/convert_test.go
@@ -150,7 +150,7 @@ func TestConvertPort(t *testing.T) {
 func TestConvert(t *testing.T) {
 	testRunCompose(t, func(t *testing.T, path string) {
 		loader := NewLoaderWithPath(path)
-		proj, err := loader.LoadCompose(context.Background())
+		proj, err := loader.LoadProject(context.Background())
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/src/pkg/cli/compose/loader.go
+++ b/src/pkg/cli/compose/loader.go
@@ -27,7 +27,8 @@ type Loader struct {
 }
 
 func NewLoaderWithOptions(options LoaderOptions) Loader {
-	// We do not want to include all the os environment variables, only COMPOSE_PROJECT_NAME
+	// if no --project-name is provided, try to get it from the environment
+	// https://docs.docker.com/compose/project-name/#set-a-project-name
 	if options.ProjectName == "" {
 		if envProjName, ok := os.LookupEnv("COMPOSE_PROJECT_NAME"); ok {
 			options.ProjectName = envProjName

--- a/src/pkg/cli/compose/loader.go
+++ b/src/pkg/cli/compose/loader.go
@@ -27,9 +27,11 @@ type Loader struct {
 }
 
 func NewLoaderWithOptions(options LoaderOptions) Loader {
-	// HACK: We do not want to include all the os environment variables, only COMPOSE_PROJECT_NAME
-	if envProjName, ok := os.LookupEnv("COMPOSE_PROJECT_NAME"); ok {
-		options.ProjectName = envProjName
+	// We do not want to include all the os environment variables, only COMPOSE_PROJECT_NAME
+	if options.ProjectName == "" {
+		if envProjName, ok := os.LookupEnv("COMPOSE_PROJECT_NAME"); ok {
+			options.ProjectName = envProjName
+		}
 	}
 
 	return Loader{options: options}

--- a/src/pkg/cli/compose/loader.go
+++ b/src/pkg/cli/compose/loader.go
@@ -43,7 +43,20 @@ func NewLoaderWithPath(path string) Loader {
 	return NewLoaderWithOptions(LoaderOptions{ConfigPaths: configPaths})
 }
 
-func (c Loader) LoadCompose(ctx context.Context) (*compose.Project, error) {
+func (c Loader) LoadProjectName(ctx context.Context) (string, error) {
+	if c.options.ProjectName != "" {
+		return c.options.ProjectName, nil
+	}
+
+	project, err := c.LoadProject(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	return project.Name, nil
+}
+
+func (c Loader) LoadProject(ctx context.Context) (*compose.Project, error) {
 	// Set logrus send logs via the term package
 	termLogger := logs.TermLogFormatter{Term: term.DefaultTerm}
 	logrus.SetFormatter(termLogger)

--- a/src/pkg/cli/compose/loader.go
+++ b/src/pkg/cli/compose/loader.go
@@ -19,6 +19,7 @@ import (
 type LoaderOptions struct {
 	ConfigPaths []string
 	WorkingDir  string
+	ProjectName string
 }
 
 type Loader struct {

--- a/src/pkg/cli/compose/loader_test.go
+++ b/src/pkg/cli/compose/loader_test.go
@@ -17,7 +17,7 @@ import (
 func TestLoader(t *testing.T) {
 	testRunCompose(t, func(t *testing.T, path string) {
 		loader := NewLoaderWithPath(path)
-		proj, err := loader.LoadCompose(context.Background())
+		proj, err := loader.LoadProject(context.Background())
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/src/pkg/cli/compose/validation_test.go
+++ b/src/pkg/cli/compose/validation_test.go
@@ -24,7 +24,7 @@ func TestValidationAndConvert(t *testing.T) {
 
 		options := LoaderOptions{ConfigPaths: []string{path}}
 		loader := Loader{options: options}
-		proj, err := loader.LoadCompose(context.Background())
+		proj, err := loader.LoadProject(context.Background())
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/src/pkg/cli/composeUp_test.go
+++ b/src/pkg/cli/composeUp_test.go
@@ -16,9 +16,9 @@ func TestComposeUp(t *testing.T) {
 	defer func() { DoDryRun = false }()
 
 	loader := compose.NewLoaderWithPath("../../tests/testproj/compose.yaml")
-	proj, err := loader.LoadCompose(context.Background())
+	proj, err := loader.LoadProject(context.Background())
 	if err != nil {
-		t.Fatalf("LoadCompose() failed: %v", err)
+		t.Fatalf("LoadProject() failed: %v", err)
 	}
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/src/pkg/cli/debug_test.go
+++ b/src/pkg/cli/debug_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestDebug(t *testing.T) {
-	project, err := compose.NewLoaderWithPath("../../tests/debugproj/compose.yaml").LoadCompose(context.Background())
+	project, err := compose.NewLoaderWithPath("../../tests/debugproj/compose.yaml").LoadProject(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/src/pkg/cli/tail_test.go
+++ b/src/pkg/cli/tail_test.go
@@ -80,9 +80,9 @@ func TestTail(t *testing.T) {
 	})
 
 	loader := compose.NewLoaderWithPath("../../tests/testproj/compose.yaml")
-	proj, err := loader.LoadCompose(context.Background())
+	proj, err := loader.LoadProject(context.Background())
 	if err != nil {
-		t.Fatalf("LoadCompose() failed: %v", err)
+		t.Fatalf("LoadProject() failed: %v", err)
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
This pull request aims to add support for running `defang compose` commands outside of the project's working directory by using the `--project-name` CLI flag. In order to accomplish this, the `compose.Loader` has been refactored to accept a `projectName` and to avoid trying to read the `compose.yaml` file from disk unless absolutely necessary.

Many commands do not require any project information aside from the name, so will not need to read the compose file if the project name is passed using this new flag.

The `compose.Loader` will keep a reference to the project name passed by `--project-name` flag, or by the `COMPOSE_PROJECT_NAME` env var. If a project name has not been passed through the cli flag or environment, the `compose.Loader` will read the `compose.yaml` file from the path passed in with `-f` or from the current working directory. Once the compose file has been read, the `compose.Loader` will keep a reference to it in memory to avoid reading it again.

In order to implement this, I have removed some stateful attributes with values derived from the project name. I have replaced references to these attributes with function calls which ask the loader for the project name. This introduces a fair amount of churn into the diff since `compose.Loader.GetProjectName` can return an error and callers of these derived values may now need to handle these errors.

**TODO**
- [x] flesh out further test coverage
- [x] make sure it is still possible to derive project name from the current working directory
- [ ] update docs to add a "Concept" for "Project"
