### PR TITLE
Support for multiple compose files

### DIFF
--- a/src/cmd/cli/command/commands.go
+++ b/src/cmd/cli/command/commands.go
@@ -574,7 +574,7 @@ var generateCmd = &cobra.Command{
 			WorkingDir:  prompt.Folder,
 			ConfigPaths: []string{filepath.Join(prompt.Folder, "compose.yaml")},
 		}
-		loader := compose.NewLoaderWithOptions(projectOptions)
+		loader := compose.NewLoaderWithOptions(&projectOptions)
 		project, _ := loader.LoadCompose(cmd.Context())
 
 		var envInstructions []string
@@ -1272,7 +1272,7 @@ func configureLoader(cmd *cobra.Command) compose.Loader {
 		panic(err)
 	}
 
-	return compose.NewLoaderWithOptions(o)
+	return compose.NewLoaderWithOptions(&o)
 }
 
 func awsInEnv() bool {

--- a/src/cmd/cli/command/commands.go
+++ b/src/cmd/cli/command/commands.go
@@ -322,10 +322,7 @@ var RootCmd = &cobra.Command{
 		}
 
 		composeFilePath, _ := cmd.Flags().GetString("file")
-		loader, err := compose.NewLoader(composeFilePath)
-		if err != nil {
-			return err
-		}
+		loader := compose.NewLoader(composeFilePath)
 		client = cli.NewClient(cmd.Context(), cluster, provider, loader)
 
 		if v, err := client.GetVersions(cmd.Context()); err == nil {
@@ -586,10 +583,7 @@ var generateCmd = &cobra.Command{
 		}
 
 		// Load the project and check for empty environment variables
-		loader, err := compose.NewLoader(filepath.Join(prompt.Folder, "compose.yaml"))
-		if err != nil {
-			return err
-		}
+		loader := compose.NewLoader(filepath.Join(prompt.Folder, "compose.yaml"))
 		project, _ := loader.LoadCompose(cmd.Context())
 
 		var envInstructions []string

--- a/src/cmd/cli/command/commands.go
+++ b/src/cmd/cli/command/commands.go
@@ -25,7 +25,6 @@ import (
 	defangv1 "github.com/DefangLabs/defang/src/protos/io/defang/v1"
 	"github.com/aws/smithy-go"
 	"github.com/bufbuild/connect-go"
-	composeCli "github.com/compose-spec/compose-go/v2/cli"
 	proj "github.com/compose-spec/compose-go/v2/types"
 	"github.com/spf13/cobra"
 )
@@ -570,11 +569,11 @@ var generateCmd = &cobra.Command{
 		}
 
 		// Load the project and check for empty environment variables
-		projectOptions := composeCli.ProjectOptions{
+		loaderOptions := compose.LoaderOptions{
 			WorkingDir:  prompt.Folder,
 			ConfigPaths: []string{filepath.Join(prompt.Folder, "compose.yaml")},
 		}
-		loader := compose.NewLoaderWithOptions(&projectOptions)
+		loader := compose.NewLoaderWithOptions(loaderOptions)
 		project, _ := loader.LoadCompose(cmd.Context())
 
 		var envInstructions []string
@@ -1261,18 +1260,19 @@ var tosCmd = &cobra.Command{
 
 func configureLoader(cmd *cobra.Command) compose.Loader {
 	f := cmd.Flags()
-	o := composeCli.ProjectOptions{}
+	o := compose.LoaderOptions{}
 	var err error
 	o.ConfigPaths, err = f.GetStringArray("file") // to make sure the flag is defined
 	if err != nil {
 		panic(err)
 	}
+
 	o.WorkingDir, err = f.GetString("cwd")
 	if err != nil {
 		panic(err)
 	}
 
-	return compose.NewLoaderWithOptions(&o)
+	return compose.NewLoaderWithOptions(o)
 }
 
 func awsInEnv() bool {

--- a/src/cmd/cli/command/commands.go
+++ b/src/cmd/cli/command/commands.go
@@ -322,7 +322,10 @@ var RootCmd = &cobra.Command{
 		}
 
 		composeFilePath, _ := cmd.Flags().GetString("file")
-		loader := compose.Loader{ComposeFilePath: composeFilePath}
+		loader, err := compose.NewLoader(composeFilePath)
+		if err != nil {
+			return err
+		}
 		client = cli.NewClient(cmd.Context(), cluster, provider, loader)
 
 		if v, err := client.GetVersions(cmd.Context()); err == nil {
@@ -583,7 +586,10 @@ var generateCmd = &cobra.Command{
 		}
 
 		// Load the project and check for empty environment variables
-		loader := compose.Loader{ComposeFilePath: filepath.Join(prompt.Folder, "compose.yaml")}
+		loader, err := compose.NewLoader(filepath.Join(prompt.Folder, "compose.yaml"))
+		if err != nil {
+			return err
+		}
 		project, _ := loader.LoadCompose(cmd.Context())
 
 		var envInstructions []string

--- a/src/cmd/cli/command/commands_test.go
+++ b/src/cmd/cli/command/commands_test.go
@@ -13,7 +13,7 @@ func TestVersion(t *testing.T) {
 }
 
 func testCommand(args []string) error {
-	ctx := context.TODO()
+	ctx := context.Background()
 	SetupCommands("test")
 	RootCmd.SetArgs(args)
 	return RootCmd.ExecuteContext(ctx)

--- a/src/cmd/cli/command/commands_test.go
+++ b/src/cmd/cli/command/commands_test.go
@@ -1,0 +1,20 @@
+package command
+
+import (
+	"context"
+	"testing"
+)
+
+func TestVersion(t *testing.T) {
+	err := testCommand([]string{"version"})
+	if err != nil {
+		t.Fatalf("Version() failed: %v", err)
+	}
+}
+
+func testCommand(args []string) error {
+	ctx := context.TODO()
+	SetupCommands("test")
+	RootCmd.SetArgs(args)
+	return RootCmd.ExecuteContext(ctx)
+}

--- a/src/pkg/cli/compose/compose_test.go
+++ b/src/pkg/cli/compose/compose_test.go
@@ -157,7 +157,7 @@ func TestComposeMultipleFiles(t *testing.T) {
 	os.Chdir("../../../tests/multiple")
 
 	composeFiles := []string{"compose1.yaml", "compose2.yaml"}
-	loader := NewLoaderWithOptions(cli.ProjectOptions{ConfigPaths: composeFiles})
+	loader := NewLoaderWithOptions(&cli.ProjectOptions{ConfigPaths: composeFiles})
 	project, err := loader.LoadCompose(context.Background())
 	if err != nil {
 		t.Fatalf("LoadCompose() failed: %v", err)

--- a/src/pkg/cli/compose/compose_test.go
+++ b/src/pkg/cli/compose/compose_test.go
@@ -14,7 +14,10 @@ func TestLoadCompose(t *testing.T) {
 	term.SetDebug(testing.Verbose())
 
 	t.Run("no project name defaults to parent directory name", func(t *testing.T) {
-		loader := Loader{"../../../tests/noprojname/compose.yaml"}
+		loader, err := NewLoader("../../../tests/noprojname/compose.yaml")
+		if err != nil {
+			t.Fatalf("NewLoader() failed: %v", err)
+		}
 		p, err := loader.LoadCompose(context.Background())
 		if err != nil {
 			t.Fatalf("LoadCompose() failed: %v", err)
@@ -25,7 +28,10 @@ func TestLoadCompose(t *testing.T) {
 	})
 
 	t.Run("no project name defaults to fancy parent directory name", func(t *testing.T) {
-		loader := Loader{"../../../tests/Fancy-Proj_Dir/compose.yaml"}
+		loader, err := NewLoader("../../../tests/Fancy-Proj_Dir/compose.yaml")
+		if err != nil {
+			t.Fatalf("NewLoader() failed: %v", err)
+		}
 		p, err := loader.LoadCompose(context.Background())
 		if err != nil {
 			t.Fatalf("LoadCompose() failed: %v", err)
@@ -36,7 +42,10 @@ func TestLoadCompose(t *testing.T) {
 	})
 
 	t.Run("use project name in compose file", func(t *testing.T) {
-		loader := Loader{"../../../tests/testproj/compose.yaml"}
+		loader, err := NewLoader("../../../tests/testproj/compose.yaml")
+		if err != nil {
+			t.Fatalf("NewLoader() failed: %v", err)
+		}
 		p, err := loader.LoadCompose(context.Background())
 		if err != nil {
 			t.Fatalf("LoadCompose() failed: %v", err)
@@ -48,7 +57,10 @@ func TestLoadCompose(t *testing.T) {
 
 	t.Run("COMPOSE_PROJECT_NAME env var should override project name", func(t *testing.T) {
 		t.Setenv("COMPOSE_PROJECT_NAME", "overridename")
-		loader := Loader{"../../../tests/testproj/compose.yaml"}
+		loader, err := NewLoader("../../../tests/testproj/compose.yaml")
+		if err != nil {
+			t.Fatalf("NewLoader() failed: %v", err)
+		}
 		p, err := loader.LoadCompose(context.Background())
 		if err != nil {
 			t.Fatalf("LoadCompose() failed: %v", err)
@@ -59,7 +71,10 @@ func TestLoadCompose(t *testing.T) {
 	})
 
 	t.Run("use project name should not be overriden by tenantID", func(t *testing.T) {
-		loader := Loader{"../../../tests/testproj/compose.yaml"}
+		loader, err := NewLoader("../../../tests/testproj/compose.yaml")
+		if err != nil {
+			t.Fatalf("NewLoader() failed: %v", err)
+		}
 		p, err := loader.LoadCompose(context.Background())
 		if err != nil {
 			t.Fatalf("LoadCompose() failed: %v", err)
@@ -88,7 +103,10 @@ func TestLoadCompose(t *testing.T) {
 		t.Cleanup(teardown)
 
 		// execute test
-		loader := Loader{}
+		loader, err := NewLoader("")
+		if err != nil {
+			t.Fatalf("NewLoader() failed: %v", err)
+		}
 		p, err := loader.LoadCompose(context.Background())
 		if err != nil {
 			t.Fatalf("LoadCompose() failed: %v", err)
@@ -99,7 +117,10 @@ func TestLoadCompose(t *testing.T) {
 	})
 
 	t.Run("load alternative compose file", func(t *testing.T) {
-		loader := Loader{"../../../tests/alttestproj/altcomp.yaml"}
+		loader, err := NewLoader("../../../tests/alttestproj/altcomp.yaml")
+		if err != nil {
+			t.Fatalf("NewLoader() failed: %v", err)
+		}
 		p, err := loader.LoadCompose(context.Background())
 		if err != nil {
 			t.Fatalf("LoadCompose() failed: %v", err)
@@ -120,8 +141,11 @@ func TestComposeGoNoDoubleWarningLog(t *testing.T) {
 	var warnings bytes.Buffer
 	term.DefaultTerm = term.NewTerm(&warnings, &warnings)
 
-	loader := Loader{"../../../tests/compose-go-warn/compose.yaml"}
-	_, err := loader.LoadCompose(context.Background())
+	loader, err := NewLoader("../../../tests/compose-go-warn/compose.yaml")
+	if err != nil {
+		t.Fatalf("NewLoader() failed: %v", err)
+	}
+	_, err = loader.LoadCompose(context.Background())
 	if err != nil {
 		t.Fatalf("LoadCompose() failed: %v", err)
 	}
@@ -138,8 +162,7 @@ func TestComposeOnlyOneFile(t *testing.T) {
 	})
 	os.Chdir("../../../tests/toomany")
 
-	loader := Loader{}
-	_, err := loader.LoadCompose(context.Background())
+	_, err := NewLoader("")
 	if err == nil {
 		t.Fatalf("LoadCompose() failed: expected error, got nil")
 	}

--- a/src/pkg/cli/compose/compose_test.go
+++ b/src/pkg/cli/compose/compose_test.go
@@ -14,10 +14,7 @@ func TestLoadCompose(t *testing.T) {
 	term.SetDebug(testing.Verbose())
 
 	t.Run("no project name defaults to parent directory name", func(t *testing.T) {
-		loader, err := NewLoader("../../../tests/noprojname/compose.yaml")
-		if err != nil {
-			t.Fatalf("NewLoader() failed: %v", err)
-		}
+		loader := NewLoader("../../../tests/noprojname/compose.yaml")
 		p, err := loader.LoadCompose(context.Background())
 		if err != nil {
 			t.Fatalf("LoadCompose() failed: %v", err)
@@ -28,10 +25,7 @@ func TestLoadCompose(t *testing.T) {
 	})
 
 	t.Run("no project name defaults to fancy parent directory name", func(t *testing.T) {
-		loader, err := NewLoader("../../../tests/Fancy-Proj_Dir/compose.yaml")
-		if err != nil {
-			t.Fatalf("NewLoader() failed: %v", err)
-		}
+		loader := NewLoader("../../../tests/Fancy-Proj_Dir/compose.yaml")
 		p, err := loader.LoadCompose(context.Background())
 		if err != nil {
 			t.Fatalf("LoadCompose() failed: %v", err)
@@ -42,10 +36,7 @@ func TestLoadCompose(t *testing.T) {
 	})
 
 	t.Run("use project name in compose file", func(t *testing.T) {
-		loader, err := NewLoader("../../../tests/testproj/compose.yaml")
-		if err != nil {
-			t.Fatalf("NewLoader() failed: %v", err)
-		}
+		loader := NewLoader("../../../tests/testproj/compose.yaml")
 		p, err := loader.LoadCompose(context.Background())
 		if err != nil {
 			t.Fatalf("LoadCompose() failed: %v", err)
@@ -57,10 +48,7 @@ func TestLoadCompose(t *testing.T) {
 
 	t.Run("COMPOSE_PROJECT_NAME env var should override project name", func(t *testing.T) {
 		t.Setenv("COMPOSE_PROJECT_NAME", "overridename")
-		loader, err := NewLoader("../../../tests/testproj/compose.yaml")
-		if err != nil {
-			t.Fatalf("NewLoader() failed: %v", err)
-		}
+		loader := NewLoader("../../../tests/testproj/compose.yaml")
 		p, err := loader.LoadCompose(context.Background())
 		if err != nil {
 			t.Fatalf("LoadCompose() failed: %v", err)
@@ -71,10 +59,7 @@ func TestLoadCompose(t *testing.T) {
 	})
 
 	t.Run("use project name should not be overriden by tenantID", func(t *testing.T) {
-		loader, err := NewLoader("../../../tests/testproj/compose.yaml")
-		if err != nil {
-			t.Fatalf("NewLoader() failed: %v", err)
-		}
+		loader := NewLoader("../../../tests/testproj/compose.yaml")
 		p, err := loader.LoadCompose(context.Background())
 		if err != nil {
 			t.Fatalf("LoadCompose() failed: %v", err)
@@ -103,10 +88,7 @@ func TestLoadCompose(t *testing.T) {
 		t.Cleanup(teardown)
 
 		// execute test
-		loader, err := NewLoader("")
-		if err != nil {
-			t.Fatalf("NewLoader() failed: %v", err)
-		}
+		loader := NewLoader("")
 		p, err := loader.LoadCompose(context.Background())
 		if err != nil {
 			t.Fatalf("LoadCompose() failed: %v", err)
@@ -117,10 +99,7 @@ func TestLoadCompose(t *testing.T) {
 	})
 
 	t.Run("load alternative compose file", func(t *testing.T) {
-		loader, err := NewLoader("../../../tests/alttestproj/altcomp.yaml")
-		if err != nil {
-			t.Fatalf("NewLoader() failed: %v", err)
-		}
+		loader := NewLoader("../../../tests/alttestproj/altcomp.yaml")
 		p, err := loader.LoadCompose(context.Background())
 		if err != nil {
 			t.Fatalf("LoadCompose() failed: %v", err)
@@ -141,11 +120,8 @@ func TestComposeGoNoDoubleWarningLog(t *testing.T) {
 	var warnings bytes.Buffer
 	term.DefaultTerm = term.NewTerm(&warnings, &warnings)
 
-	loader, err := NewLoader("../../../tests/compose-go-warn/compose.yaml")
-	if err != nil {
-		t.Fatalf("NewLoader() failed: %v", err)
-	}
-	_, err = loader.LoadCompose(context.Background())
+	loader := NewLoader("../../../tests/compose-go-warn/compose.yaml")
+	_, err := loader.LoadCompose(context.Background())
 	if err != nil {
 		t.Fatalf("LoadCompose() failed: %v", err)
 	}

--- a/src/pkg/cli/compose/compose_test.go
+++ b/src/pkg/cli/compose/compose_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/DefangLabs/defang/src/pkg/term"
-	"github.com/compose-spec/compose-go/v2/cli"
 )
 
 func TestLoadCompose(t *testing.T) {
@@ -157,7 +156,7 @@ func TestComposeMultipleFiles(t *testing.T) {
 	os.Chdir("../../../tests/multiple")
 
 	composeFiles := []string{"compose1.yaml", "compose2.yaml"}
-	loader := NewLoaderWithOptions(&cli.ProjectOptions{ConfigPaths: composeFiles})
+	loader := NewLoaderWithOptions(LoaderOptions{ConfigPaths: composeFiles})
 	project, err := loader.LoadCompose(context.Background())
 	if err != nil {
 		t.Fatalf("LoadCompose() failed: %v", err)

--- a/src/pkg/cli/compose/compose_test.go
+++ b/src/pkg/cli/compose/compose_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/DefangLabs/defang/src/pkg/term"
+	"github.com/compose-spec/compose-go/v2/cli"
 )
 
 func TestLoadCompose(t *testing.T) {
@@ -145,5 +146,28 @@ func TestComposeOnlyOneFile(t *testing.T) {
 
 	if len(project.ComposeFiles) != 1 {
 		t.Errorf("LoadCompose() failed: expected only one config file, got %d", len(project.ComposeFiles))
+	}
+}
+
+func TestComposeMultipleFiles(t *testing.T) {
+	cwd, _ := os.Getwd()
+	t.Cleanup(func() {
+		os.Chdir(cwd)
+	})
+	os.Chdir("../../../tests/multiple")
+
+	composeFiles := []string{"compose1.yaml", "compose2.yaml"}
+	loader := NewLoaderWithOptions(cli.ProjectOptions{ConfigPaths: composeFiles})
+	project, err := loader.LoadCompose(context.Background())
+	if err != nil {
+		t.Fatalf("LoadCompose() failed: %v", err)
+	}
+
+	if len(project.ComposeFiles) != 2 {
+		t.Errorf("LoadCompose() failed: expected 2 compose files, got %d", len(project.ComposeFiles))
+	}
+
+	if len(project.Services) != 2 {
+		t.Errorf("LoadCompose() failed: expected 2 services, got %d", len(project.Services))
 	}
 }

--- a/src/pkg/cli/compose/compose_test.go
+++ b/src/pkg/cli/compose/compose_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"os"
-	"strings"
 	"testing"
 
 	"github.com/DefangLabs/defang/src/pkg/term"
@@ -14,7 +13,7 @@ func TestLoadCompose(t *testing.T) {
 	term.SetDebug(testing.Verbose())
 
 	t.Run("no project name defaults to parent directory name", func(t *testing.T) {
-		loader := NewLoader("../../../tests/noprojname/compose.yaml")
+		loader := NewLoaderWithPath("../../../tests/noprojname/compose.yaml")
 		p, err := loader.LoadCompose(context.Background())
 		if err != nil {
 			t.Fatalf("LoadCompose() failed: %v", err)
@@ -25,7 +24,7 @@ func TestLoadCompose(t *testing.T) {
 	})
 
 	t.Run("no project name defaults to fancy parent directory name", func(t *testing.T) {
-		loader := NewLoader("../../../tests/Fancy-Proj_Dir/compose.yaml")
+		loader := NewLoaderWithPath("../../../tests/Fancy-Proj_Dir/compose.yaml")
 		p, err := loader.LoadCompose(context.Background())
 		if err != nil {
 			t.Fatalf("LoadCompose() failed: %v", err)
@@ -36,7 +35,7 @@ func TestLoadCompose(t *testing.T) {
 	})
 
 	t.Run("use project name in compose file", func(t *testing.T) {
-		loader := NewLoader("../../../tests/testproj/compose.yaml")
+		loader := NewLoaderWithPath("../../../tests/testproj/compose.yaml")
 		p, err := loader.LoadCompose(context.Background())
 		if err != nil {
 			t.Fatalf("LoadCompose() failed: %v", err)
@@ -48,7 +47,7 @@ func TestLoadCompose(t *testing.T) {
 
 	t.Run("COMPOSE_PROJECT_NAME env var should override project name", func(t *testing.T) {
 		t.Setenv("COMPOSE_PROJECT_NAME", "overridename")
-		loader := NewLoader("../../../tests/testproj/compose.yaml")
+		loader := NewLoaderWithPath("../../../tests/testproj/compose.yaml")
 		p, err := loader.LoadCompose(context.Background())
 		if err != nil {
 			t.Fatalf("LoadCompose() failed: %v", err)
@@ -59,7 +58,7 @@ func TestLoadCompose(t *testing.T) {
 	})
 
 	t.Run("use project name should not be overriden by tenantID", func(t *testing.T) {
-		loader := NewLoader("../../../tests/testproj/compose.yaml")
+		loader := NewLoaderWithPath("../../../tests/testproj/compose.yaml")
 		p, err := loader.LoadCompose(context.Background())
 		if err != nil {
 			t.Fatalf("LoadCompose() failed: %v", err)
@@ -88,7 +87,7 @@ func TestLoadCompose(t *testing.T) {
 		t.Cleanup(teardown)
 
 		// execute test
-		loader := NewLoader("")
+		loader := NewLoaderWithPath("")
 		p, err := loader.LoadCompose(context.Background())
 		if err != nil {
 			t.Fatalf("LoadCompose() failed: %v", err)
@@ -99,7 +98,7 @@ func TestLoadCompose(t *testing.T) {
 	})
 
 	t.Run("load alternative compose file", func(t *testing.T) {
-		loader := NewLoader("../../../tests/alttestproj/altcomp.yaml")
+		loader := NewLoaderWithPath("../../../tests/alttestproj/altcomp.yaml")
 		p, err := loader.LoadCompose(context.Background())
 		if err != nil {
 			t.Fatalf("LoadCompose() failed: %v", err)
@@ -120,7 +119,7 @@ func TestComposeGoNoDoubleWarningLog(t *testing.T) {
 	var warnings bytes.Buffer
 	term.DefaultTerm = term.NewTerm(&warnings, &warnings)
 
-	loader := NewLoader("../../../tests/compose-go-warn/compose.yaml")
+	loader := NewLoaderWithPath("../../../tests/compose-go-warn/compose.yaml")
 	_, err := loader.LoadCompose(context.Background())
 	if err != nil {
 		t.Fatalf("LoadCompose() failed: %v", err)
@@ -138,14 +137,13 @@ func TestComposeOnlyOneFile(t *testing.T) {
 	})
 	os.Chdir("../../../tests/toomany")
 
-	_, err := NewLoader("")
-	if err == nil {
-		t.Fatalf("LoadCompose() failed: expected error, got nil")
+	loader := NewLoaderWithPath("")
+	project, err := loader.LoadCompose(context.Background())
+	if err != nil {
+		t.Errorf("LoadCompose() failed: %v", err)
 	}
 
-	const expected = `multiple Compose files found: ["./compose.yaml" "./docker-compose.yml"]; use -f to specify which one to use`
-	newCwd, _ := os.Getwd() // make the error message independent of the current working directory
-	if got := strings.ReplaceAll(err.Error(), newCwd, "."); got != expected {
-		t.Errorf("LoadCompose() failed: expected error %q, got: %s", expected, got)
+	if len(project.ComposeFiles) != 1 {
+		t.Errorf("LoadCompose() failed: expected only one config file, got %d", len(project.ComposeFiles))
 	}
 }

--- a/src/pkg/cli/compose/convert_test.go
+++ b/src/pkg/cli/compose/convert_test.go
@@ -149,10 +149,7 @@ func TestConvertPort(t *testing.T) {
 
 func TestConvert(t *testing.T) {
 	testRunCompose(t, func(t *testing.T, path string) {
-		loader, err := NewLoader(path)
-		if err != nil {
-			t.Fatal(err)
-		}
+		loader := NewLoader(path)
 		proj, err := loader.LoadCompose(context.Background())
 		if err != nil {
 			t.Fatal(err)

--- a/src/pkg/cli/compose/convert_test.go
+++ b/src/pkg/cli/compose/convert_test.go
@@ -149,7 +149,7 @@ func TestConvertPort(t *testing.T) {
 
 func TestConvert(t *testing.T) {
 	testRunCompose(t, func(t *testing.T, path string) {
-		loader := NewLoader(path)
+		loader := NewLoaderWithPath(path)
 		proj, err := loader.LoadCompose(context.Background())
 		if err != nil {
 			t.Fatal(err)

--- a/src/pkg/cli/compose/convert_test.go
+++ b/src/pkg/cli/compose/convert_test.go
@@ -149,7 +149,10 @@ func TestConvertPort(t *testing.T) {
 
 func TestConvert(t *testing.T) {
 	testRunCompose(t, func(t *testing.T, path string) {
-		loader := Loader{path}
+		loader, err := NewLoader(path)
+		if err != nil {
+			t.Fatal(err)
+		}
 		proj, err := loader.LoadCompose(context.Background())
 		if err != nil {
 			t.Fatal(err)

--- a/src/pkg/cli/compose/loader.go
+++ b/src/pkg/cli/compose/loader.go
@@ -27,15 +27,6 @@ func NewLoader(composeFilePath string) (*Loader, error) {
 		if err != nil {
 			return nil, types.ErrComposeFileNotFound
 		}
-
-		workingDir, err := os.Getwd()
-		if err != nil {
-			return nil, err
-		}
-		err = warnMultipleComposeFiles(workingDir)
-		if err != nil {
-			return nil, err
-		}
 	}
 
 	composeFilePath, err = filepath.Abs(composeFilePath)
@@ -71,21 +62,6 @@ func (c Loader) LoadCompose(ctx context.Context) (*compose.Project, error) {
 		fmt.Println(string(b))
 	}
 	return project, nil
-}
-
-func warnMultipleComposeFiles(workingDir string) error {
-	count := 0
-	for _, file := range cli.DefaultFileNames {
-		if _, err := os.Stat(filepath.Join(workingDir, file)); err == nil {
-			count++
-		}
-	}
-
-	if count > 1 {
-		return types.ErrMultipleComposeFilesFound
-	}
-
-	return nil
 }
 
 func getDefaultProjectOptions(composeFilePath string, extraOpts ...cli.ProjectOptionsFn) (*cli.ProjectOptions, error) {

--- a/src/pkg/cli/compose/loader.go
+++ b/src/pkg/cli/compose/loader.go
@@ -27,6 +27,15 @@ func NewLoader(composeFilePath string) (*Loader, error) {
 		if err != nil {
 			return nil, types.ErrComposeFileNotFound
 		}
+
+		workingDir, err := os.Getwd()
+		if err != nil {
+			return nil, err
+		}
+		err = warnMultipleComposeFiles(workingDir)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	composeFilePath, err = filepath.Abs(composeFilePath)
@@ -62,6 +71,21 @@ func (c Loader) LoadCompose(ctx context.Context) (*compose.Project, error) {
 		fmt.Println(string(b))
 	}
 	return project, nil
+}
+
+func warnMultipleComposeFiles(workingDir string) error {
+	count := 0
+	for _, file := range cli.DefaultFileNames {
+		if _, err := os.Stat(filepath.Join(workingDir, file)); err == nil {
+			count++
+		}
+	}
+
+	if count > 1 {
+		return types.ErrMultipleComposeFilesFound
+	}
+
+	return nil
 }
 
 func getDefaultProjectOptions(composeFilePath string, extraOpts ...cli.ProjectOptionsFn) (*cli.ProjectOptions, error) {

--- a/src/pkg/cli/compose/loader.go
+++ b/src/pkg/cli/compose/loader.go
@@ -111,6 +111,16 @@ func findDefaultComposeFilePath() (string, error) {
 		return "", err
 	}
 
+	if len(projOpts.ConfigPaths) == 0 {
+		return "", types.ErrComposeFileNotFound
+	}
+
 	// TODO: add support for default override files
+	// if more than one default ConfigPath is found here, the second one will be
+	// and override file, see: https://github.com/compose-spec/compose-go/blob/bfaf10bba3cb8dce5f74dc4a1ff6ec22ab174a0f/cli/options.go#L172
+	if len(projOpts.ConfigPaths) > 1 {
+		term.Warn("override files are not yet supported by defang. The following files will be ignored", projOpts.ConfigPaths[1:])
+	}
+
 	return projOpts.ConfigPaths[0], nil
 }

--- a/src/pkg/cli/compose/loader.go
+++ b/src/pkg/cli/compose/loader.go
@@ -124,7 +124,7 @@ func findDefaultComposeFilePath() (string, error) {
 
 	// TODO: add support for default override files
 	// if more than one default ConfigPath is found here, the second one will be
-	// and override file, see: https://github.com/compose-spec/compose-go/blob/bfaf10bba3cb8dce5f74dc4a1ff6ec22ab174a0f/cli/options.go#L172
+	// an override file, see: https://github.com/compose-spec/compose-go/blob/bfaf10bba3cb8dce5f74dc4a1ff6ec22ab174a0f/cli/options.go#L172
 	if len(projOpts.ConfigPaths) > 1 {
 		term.Warn("override files are not yet supported by defang. The following files will be ignored", projOpts.ConfigPaths[1:])
 	}

--- a/src/pkg/cli/compose/loader.go
+++ b/src/pkg/cli/compose/loader.go
@@ -19,25 +19,13 @@ type Loader struct {
 	ComposeFilePath string
 }
 
-func NewLoader(composeFilePath string) (*Loader, error) {
-	var err error
-
-	if composeFilePath == "" {
-		composeFilePath, err = findDefaultComposeFilePath()
-		if err != nil {
-			return nil, types.ErrComposeFileNotFound
-		}
-	}
-
-	composeFilePath, err = filepath.Abs(composeFilePath)
-	if err != nil {
-		return nil, err
-	}
-
-	return &Loader{ComposeFilePath: composeFilePath}, nil
+func NewLoader(composeFilePath string) *Loader {
+	return &Loader{ComposeFilePath: composeFilePath}
 }
 
 func (c Loader) LoadCompose(ctx context.Context) (*compose.Project, error) {
+	c.initializeComposeFilePath()
+
 	// Set logrus send logs via the term package
 	termLogger := logs.TermLogFormatter{Term: term.DefaultTerm}
 	logrus.SetFormatter(termLogger)
@@ -62,6 +50,25 @@ func (c Loader) LoadCompose(ctx context.Context) (*compose.Project, error) {
 		fmt.Println(string(b))
 	}
 	return project, nil
+}
+
+func (c *Loader) initializeComposeFilePath() error {
+	composeFilePath := c.ComposeFilePath
+	var err error
+	if composeFilePath == "" {
+		composeFilePath, err = findDefaultComposeFilePath()
+		if err != nil {
+			return err
+		}
+	}
+
+	composeFilePath, err = filepath.Abs(composeFilePath)
+	if err != nil {
+		return err
+	}
+
+	c.ComposeFilePath = composeFilePath
+	return nil
 }
 
 func getDefaultProjectOptions(composeFilePath string, extraOpts ...cli.ProjectOptionsFn) (*cli.ProjectOptions, error) {

--- a/src/pkg/cli/compose/loader.go
+++ b/src/pkg/cli/compose/loader.go
@@ -2,6 +2,7 @@ package compose
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 
@@ -9,6 +10,7 @@ import (
 	"github.com/DefangLabs/defang/src/pkg/term"
 	"github.com/DefangLabs/defang/src/pkg/types"
 	"github.com/compose-spec/compose-go/v2/cli"
+	"github.com/compose-spec/compose-go/v2/errdefs"
 	compose "github.com/compose-spec/compose-go/v2/types"
 	"github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v3"
@@ -52,16 +54,16 @@ func (c Loader) LoadCompose(ctx context.Context) (*compose.Project, error) {
 
 	project, err := projOpts.LoadProject(ctx)
 	if err != nil {
+		if errors.Is(err, errdefs.ErrNotFound) {
+			return nil, types.ErrComposeFileNotFound
+		}
+
 		return nil, err
 	}
 
 	if term.DoDebug() {
 		b, _ := yaml.Marshal(project)
 		fmt.Println(string(b))
-	}
-
-	if len(project.ComposeFiles) == 0 {
-		return nil, types.ErrComposeFileNotFound
 	}
 
 	return project, nil

--- a/src/pkg/cli/compose/loader.go
+++ b/src/pkg/cli/compose/loader.go
@@ -19,6 +19,10 @@ type Loader struct {
 	ComposeFilePath string
 }
 
+func NewLoader(composeFilePath string) (*Loader, error) {
+	return &Loader{ComposeFilePath: composeFilePath}, nil
+}
+
 func (c Loader) LoadCompose(ctx context.Context) (*compose.Project, error) {
 	composeFilePath, err := getComposeFilePath(c.ComposeFilePath)
 	if err != nil {

--- a/src/pkg/cli/compose/loader.go
+++ b/src/pkg/cli/compose/loader.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path/filepath"
 
 	"github.com/DefangLabs/defang/src/pkg/logs"
 	"github.com/DefangLabs/defang/src/pkg/term"
@@ -16,21 +15,27 @@ import (
 )
 
 type Loader struct {
-	ComposeFilePath string
+	options cli.ProjectOptions
 }
 
-func NewLoader(composeFilePath string) *Loader {
-	return &Loader{ComposeFilePath: composeFilePath}
+func NewLoaderWithOptions(options cli.ProjectOptions) Loader {
+	return Loader{options: options}
+}
+
+func NewLoaderWithPath(path string) Loader {
+	configPaths := []string{}
+	if path != "" {
+		configPaths = append(configPaths, path)
+	}
+	return NewLoaderWithOptions(cli.ProjectOptions{ConfigPaths: configPaths})
 }
 
 func (c Loader) LoadCompose(ctx context.Context) (*compose.Project, error) {
-	c.initializeComposeFilePath()
-
 	// Set logrus send logs via the term package
 	termLogger := logs.TermLogFormatter{Term: term.DefaultTerm}
 	logrus.SetFormatter(termLogger)
 
-	projOpts, err := getDefaultProjectOptions(c.ComposeFilePath)
+	projOpts, err := c.normalizeProjectOptions(c.options.ConfigPaths)
 	if err != nil {
 		return nil, err
 	}
@@ -49,35 +54,20 @@ func (c Loader) LoadCompose(ctx context.Context) (*compose.Project, error) {
 		b, _ := yaml.Marshal(project)
 		fmt.Println(string(b))
 	}
+
+	if len(projOpts.ConfigPaths) == 0 {
+		return nil, types.ErrComposeFileNotFound
+	}
+
 	return project, nil
 }
 
-func (c *Loader) initializeComposeFilePath() error {
-	composeFilePath := c.ComposeFilePath
-	var err error
-	if composeFilePath == "" {
-		composeFilePath, err = findDefaultComposeFilePath()
-		if err != nil {
-			return err
-		}
-	}
-
-	composeFilePath, err = filepath.Abs(composeFilePath)
-	if err != nil {
-		return err
-	}
-
-	c.ComposeFilePath = composeFilePath
-	return nil
-}
-
-func getDefaultProjectOptions(composeFilePath string, extraOpts ...cli.ProjectOptionsFn) (*cli.ProjectOptions, error) {
-	workingDir := filepath.Dir(composeFilePath)
-
+func (c Loader) normalizeProjectOptions(configs []string) (*cli.ProjectOptions, error) {
+	options := c.options
 	// Based on how docker compose setup its own project options
 	// https://github.com/docker/compose/blob/1a14fcb1e6645dd92f5a4f2da00071bd59c2e887/cmd/compose/compose.go#L326-L346
-	opts := []cli.ProjectOptionsFn{
-		cli.WithWorkingDirectory(workingDir),
+	optFns := []cli.ProjectOptionsFn{
+		cli.WithWorkingDirectory(options.WorkingDir),
 		// First apply os.Environment, always win
 		// -- DISABLED -- cli.WithOsEnv,
 		// Load PWD/.env if present and no explicit --env-file has been set
@@ -87,7 +77,7 @@ func getDefaultProjectOptions(composeFilePath string, extraOpts ...cli.ProjectOp
 		// get compose file path set by COMPOSE_FILE
 		cli.WithConfigFileEnv,
 		// if none was selected, get default compose.yaml file from current dir or parent folder
-		// cli.WithDefaultConfigPath, // NO: we find the config path eagerly when setting up the Loader
+		cli.WithDefaultConfigPath,
 		// cli.WithName(o.ProjectName)
 
 		// Calling the 2 functions below the 2nd time as the loaded env in first call modifies the behavior of the 2nd call
@@ -100,34 +90,11 @@ func getDefaultProjectOptions(composeFilePath string, extraOpts ...cli.ProjectOp
 		cli.WithDiscardEnvFile,
 		cli.WithConsistency(false), // TODO: check fails if secrets are used but top-level 'secrets:' is missing
 	}
-	opts = append(opts, extraOpts...)
-	projOpts, err := cli.NewProjectOptions([]string{composeFilePath}, opts...)
+
+	projOpts, err := cli.NewProjectOptions(options.ConfigPaths, optFns...)
 	if err != nil {
 		return nil, err
 	}
 
 	return projOpts, nil
-}
-
-func findDefaultComposeFilePath() (string, error) {
-	opts := []cli.ProjectOptionsFn{
-		cli.WithDefaultConfigPath,
-	}
-	projOpts, err := cli.NewProjectOptions([]string{}, opts...)
-	if err != nil {
-		return "", err
-	}
-
-	if len(projOpts.ConfigPaths) == 0 {
-		return "", types.ErrComposeFileNotFound
-	}
-
-	// TODO: add support for default override files
-	// if more than one default ConfigPath is found here, the second one will be
-	// an override file, see: https://github.com/compose-spec/compose-go/blob/bfaf10bba3cb8dce5f74dc4a1ff6ec22ab174a0f/cli/options.go#L172
-	if len(projOpts.ConfigPaths) > 1 {
-		term.Warn("override files are not yet supported by defang. The following files will be ignored", projOpts.ConfigPaths[1:])
-	}
-
-	return projOpts.ConfigPaths[0], nil
 }

--- a/src/pkg/cli/compose/loader_test.go
+++ b/src/pkg/cli/compose/loader_test.go
@@ -16,11 +16,15 @@ import (
 
 func TestLoader(t *testing.T) {
 	testRunCompose(t, func(t *testing.T, path string) {
-		loader := Loader{path}
+		loader, err := NewLoader(path)
+		if err != nil {
+			t.Fatal(err)
+		}
 		proj, err := loader.LoadCompose(context.Background())
 		if err != nil {
 			t.Fatal(err)
 		}
+
 		yaml, err := proj.MarshalYAML()
 		if err != nil {
 			t.Fatal(err)

--- a/src/pkg/cli/compose/loader_test.go
+++ b/src/pkg/cli/compose/loader_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestLoader(t *testing.T) {
 	testRunCompose(t, func(t *testing.T, path string) {
-		loader := NewLoader(path)
+		loader := NewLoaderWithPath(path)
 		proj, err := loader.LoadCompose(context.Background())
 		if err != nil {
 			t.Fatal(err)

--- a/src/pkg/cli/compose/loader_test.go
+++ b/src/pkg/cli/compose/loader_test.go
@@ -16,10 +16,7 @@ import (
 
 func TestLoader(t *testing.T) {
 	testRunCompose(t, func(t *testing.T, path string) {
-		loader, err := NewLoader(path)
-		if err != nil {
-			t.Fatal(err)
-		}
+		loader := NewLoader(path)
 		proj, err := loader.LoadCompose(context.Background())
 		if err != nil {
 			t.Fatal(err)

--- a/src/pkg/cli/compose/validation_test.go
+++ b/src/pkg/cli/compose/validation_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/DefangLabs/defang/src/pkg/cli/client"
 	"github.com/DefangLabs/defang/src/pkg/term"
 	defangv1 "github.com/DefangLabs/defang/src/protos/io/defang/v1"
+	"github.com/compose-spec/compose-go/v2/cli"
 )
 
 func TestValidationAndConvert(t *testing.T) {
@@ -22,7 +23,8 @@ func TestValidationAndConvert(t *testing.T) {
 		logs := new(bytes.Buffer)
 		term.DefaultTerm = term.NewTerm(logs, logs)
 
-		loader := NewLoader(path)
+		options := cli.ProjectOptions{ConfigPaths: []string{path}}
+		loader := Loader{options: options}
 		proj, err := loader.LoadCompose(context.Background())
 		if err != nil {
 			t.Fatal(err)

--- a/src/pkg/cli/compose/validation_test.go
+++ b/src/pkg/cli/compose/validation_test.go
@@ -22,10 +22,7 @@ func TestValidationAndConvert(t *testing.T) {
 		logs := new(bytes.Buffer)
 		term.DefaultTerm = term.NewTerm(logs, logs)
 
-		loader, err := NewLoader(path)
-		if err != nil {
-			t.Fatal(err)
-		}
+		loader := NewLoader(path)
 		proj, err := loader.LoadCompose(context.Background())
 		if err != nil {
 			t.Fatal(err)

--- a/src/pkg/cli/compose/validation_test.go
+++ b/src/pkg/cli/compose/validation_test.go
@@ -23,7 +23,7 @@ func TestValidationAndConvert(t *testing.T) {
 		logs := new(bytes.Buffer)
 		term.DefaultTerm = term.NewTerm(logs, logs)
 
-		options := cli.ProjectOptions{ConfigPaths: []string{path}}
+		options := &cli.ProjectOptions{ConfigPaths: []string{path}}
 		loader := Loader{options: options}
 		proj, err := loader.LoadCompose(context.Background())
 		if err != nil {

--- a/src/pkg/cli/compose/validation_test.go
+++ b/src/pkg/cli/compose/validation_test.go
@@ -22,7 +22,10 @@ func TestValidationAndConvert(t *testing.T) {
 		logs := new(bytes.Buffer)
 		term.DefaultTerm = term.NewTerm(logs, logs)
 
-		loader := Loader{path}
+		loader, err := NewLoader(path)
+		if err != nil {
+			t.Fatal(err)
+		}
 		proj, err := loader.LoadCompose(context.Background())
 		if err != nil {
 			t.Fatal(err)

--- a/src/pkg/cli/compose/validation_test.go
+++ b/src/pkg/cli/compose/validation_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/DefangLabs/defang/src/pkg/cli/client"
 	"github.com/DefangLabs/defang/src/pkg/term"
 	defangv1 "github.com/DefangLabs/defang/src/protos/io/defang/v1"
-	"github.com/compose-spec/compose-go/v2/cli"
 )
 
 func TestValidationAndConvert(t *testing.T) {
@@ -23,7 +22,7 @@ func TestValidationAndConvert(t *testing.T) {
 		logs := new(bytes.Buffer)
 		term.DefaultTerm = term.NewTerm(logs, logs)
 
-		options := &cli.ProjectOptions{ConfigPaths: []string{path}}
+		options := LoaderOptions{ConfigPaths: []string{path}}
 		loader := Loader{options: options}
 		proj, err := loader.LoadCompose(context.Background())
 		if err != nil {

--- a/src/pkg/cli/composeUp_test.go
+++ b/src/pkg/cli/composeUp_test.go
@@ -15,10 +15,7 @@ func TestComposeUp(t *testing.T) {
 	DoDryRun = true
 	defer func() { DoDryRun = false }()
 
-	loader, err := compose.NewLoader("../../tests/testproj/compose.yaml")
-	if err != nil {
-		t.Fatalf("NewLoader() failed: %v", err)
-	}
+	loader := compose.NewLoader("../../tests/testproj/compose.yaml")
 	proj, err := loader.LoadCompose(context.Background())
 	if err != nil {
 		t.Fatalf("LoadCompose() failed: %v", err)

--- a/src/pkg/cli/composeUp_test.go
+++ b/src/pkg/cli/composeUp_test.go
@@ -15,7 +15,7 @@ func TestComposeUp(t *testing.T) {
 	DoDryRun = true
 	defer func() { DoDryRun = false }()
 
-	loader := compose.NewLoader("../../tests/testproj/compose.yaml")
+	loader := compose.NewLoaderWithPath("../../tests/testproj/compose.yaml")
 	proj, err := loader.LoadCompose(context.Background())
 	if err != nil {
 		t.Fatalf("LoadCompose() failed: %v", err)

--- a/src/pkg/cli/composeUp_test.go
+++ b/src/pkg/cli/composeUp_test.go
@@ -15,7 +15,10 @@ func TestComposeUp(t *testing.T) {
 	DoDryRun = true
 	defer func() { DoDryRun = false }()
 
-	loader := compose.Loader{"../../tests/testproj/compose.yaml"}
+	loader, err := compose.NewLoader("../../tests/testproj/compose.yaml")
+	if err != nil {
+		t.Fatalf("NewLoader() failed: %v", err)
+	}
 	proj, err := loader.LoadCompose(context.Background())
 	if err != nil {
 		t.Fatalf("LoadCompose() failed: %v", err)

--- a/src/pkg/cli/debug_test.go
+++ b/src/pkg/cli/debug_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestDebug(t *testing.T) {
-	project, err := compose.Loader{"../../tests/debugproj/compose.yaml"}.LoadCompose(context.Background())
+	project, err := compose.NewLoaderWithPath("../../tests/debugproj/compose.yaml").LoadCompose(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/src/pkg/cli/tail_test.go
+++ b/src/pkg/cli/tail_test.go
@@ -79,7 +79,11 @@ func TestTail(t *testing.T) {
 		term.DefaultTerm = defaultTerm
 	})
 
-	proj, err := compose.Loader{"../../tests/testproj/compose.yaml"}.LoadCompose(context.Background())
+	loader, err := compose.NewLoader("../../tests/testproj/compose.yaml")
+	if err != nil {
+		t.Fatalf("NewLoader() failed: %v", err)
+	}
+	proj, err := loader.LoadCompose(context.Background())
 	if err != nil {
 		t.Fatalf("LoadCompose() failed: %v", err)
 	}

--- a/src/pkg/cli/tail_test.go
+++ b/src/pkg/cli/tail_test.go
@@ -79,10 +79,7 @@ func TestTail(t *testing.T) {
 		term.DefaultTerm = defaultTerm
 	})
 
-	loader, err := compose.NewLoader("../../tests/testproj/compose.yaml")
-	if err != nil {
-		t.Fatalf("NewLoader() failed: %v", err)
-	}
+	loader := compose.NewLoader("../../tests/testproj/compose.yaml")
 	proj, err := loader.LoadCompose(context.Background())
 	if err != nil {
 		t.Fatalf("LoadCompose() failed: %v", err)

--- a/src/pkg/cli/tail_test.go
+++ b/src/pkg/cli/tail_test.go
@@ -79,7 +79,7 @@ func TestTail(t *testing.T) {
 		term.DefaultTerm = defaultTerm
 	})
 
-	loader := compose.NewLoader("../../tests/testproj/compose.yaml")
+	loader := compose.NewLoaderWithPath("../../tests/testproj/compose.yaml")
 	proj, err := loader.LoadCompose(context.Background())
 	if err != nil {
 		t.Fatalf("LoadCompose() failed: %v", err)

--- a/src/pkg/types/error.go
+++ b/src/pkg/types/error.go
@@ -3,4 +3,3 @@ package types
 import "errors"
 
 var ErrComposeFileNotFound = errors.New("no compose file found")
-var ErrMultipleComposeFilesFound = errors.New(`multiple Compose files found: ["./compose.yaml" "./docker-compose.yml"]; use -f to specify which one to use`)

--- a/src/pkg/types/error.go
+++ b/src/pkg/types/error.go
@@ -3,3 +3,4 @@ package types
 import "errors"
 
 var ErrComposeFileNotFound = errors.New("no compose file found")
+var ErrMultipleComposeFilesFound = errors.New(`multiple Compose files found: ["./compose.yaml" "./docker-compose.yml"]; use -f to specify which one to use`)

--- a/src/tests/multiple/compose1.yaml
+++ b/src/tests/multiple/compose1.yaml
@@ -1,0 +1,3 @@
+services:
+  service1:
+    image: example

--- a/src/tests/multiple/compose2.yaml
+++ b/src/tests/multiple/compose2.yaml
@@ -1,0 +1,3 @@
+services:
+  service2:
+    image: example


### PR DESCRIPTION
Fixes #509 

In #500, we were concerned that the presence of both a `compose.yaml` and ` docker-compose.yaml` file could be confusing, so we decided to return an error and exit early. However, `compose-go` _does_ log out a warning in this scenario, as does `docker compose`. We've changed our mind and decided to aim for closer parity with docker here by reverting to logging the warning and continuing with `compose.yaml`.

While implementing this, in an effort to bring us to closer parity with docker compose, we decided to go ahead and add support for passing `-f` multiple times—adding support for multiple compose files.

- [x] Add support for multiple compose files with `-f`.
- [x] Modify `compose.LoadCompose` to leverage the `compose-go` library to find default compose file paths if one isn't passed explicitly.
- [x] Avoid returning an error if multiple default compose files are found. `compose-go` will always pick `compose.yaml` over `docker-compose.yaml`. It will also log a warning message explaining this to stderr.
- [x] Remove `toomany` test case since there is nothing meaningful to test anymore.
- [x] Add a simple test at the command level for something like `defang version` to make sure it doesn't try to load a compose file during intialization. In time, we should add command-level tests for everything with a mock server.
- [x] lazily verify compose path, to avoid requiring it for commands like `defang version` which do not use it.