### PR TITLE
Avoid adding subcommands to multiple parent commands

### DIFF
--- a/src/cmd/cli/command/commands.go
+++ b/src/cmd/cli/command/commands.go
@@ -386,7 +386,7 @@ var RootCmd = &cobra.Command{
 var loginCmd = &cobra.Command{
 	Use:   "login",
 	Args:  cobra.NoArgs,
-	Short: "Authenticate to the Defang cluster",
+	Short: "Authenticate to Defang",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if nonInteractive {
 			if err := cli.NonInteractiveLogin(cmd.Context(), client, cluster); err != nil {
@@ -641,7 +641,7 @@ var getServicesCmd = &cobra.Command{
 	Annotations: authNeededAnnotation,
 	Args:        cobra.NoArgs,
 	Aliases:     []string{"getServices", "ls", "list"},
-	Short:       "Get list of services on the cluster",
+	Short:       "Get list of services in the project",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		long, _ := cmd.Flags().GetBool("long")
 

--- a/src/cmd/cli/command/commands.go
+++ b/src/cmd/cli/command/commands.go
@@ -218,12 +218,12 @@ func SetupCommands(version string) {
 	composeCmd.AddCommand(composeStartCmd)
 	composeCmd.AddCommand(composeRestartCmd)
 	composeCmd.AddCommand(composeStopCmd)
-	composeCmd.AddCommand(getServicesCmd) // like docker compose ls
+	// composeCmd.AddCommand(getServicesCmd) // like docker compose ls
 	RootCmd.AddCommand(composeCmd)
 
 	// Add up/down commands to the root as well
-	RootCmd.AddCommand(composeDownCmd)
-	RootCmd.AddCommand(composeUpCmd)
+	// RootCmd.AddCommand(composeDownCmd)
+	// RootCmd.AddCommand(composeUpCmd)
 	// RootCmd.AddCommand(composeStartCmd)
 	// RootCmd.AddCommand(composeRestartCmd)
 	// RootCmd.AddCommand(composeStopCmd)


### PR DESCRIPTION
Fixes https://github.com/DefangLabs/defang/issues/612

@lionello intended to define aliases for these commands in https://github.com/DefangLabs/defang/commit/1701383f6f876eb20273c9b856e02bf7df47c26a

We will have to find another way.

`Command.AddCommand` sets the command's `parent`—meaning that it will in-effect _move_ the command from any previous parent to a new one.

See [spf13/cobra/command.go#L1312
](https://github.com/spf13/cobra/blob/756ba6dad61458cbbf7abecfc502d230574c57d2/command.go#L1312)


