### PR TITLE
Track CLI panics

### DIFF
--- a/src/cmd/cli/main.go
+++ b/src/cmd/cli/main.go
@@ -4,12 +4,21 @@ import (
 	"context"
 	"os"
 	"os/signal"
+	"runtime/debug"
 
 	"github.com/DefangLabs/defang/src/cmd/cli/command"
 	"github.com/DefangLabs/defang/src/pkg/term"
 )
 
 func main() {
+	defer func() {
+		if r := recover(); r != nil {
+			command.Track("Panic", command.P{"error", r}, command.P{"stack", string(debug.Stack())})
+			command.FlushAllTracking()
+			panic(r)
+		}
+	}()
+
 	// Handle Ctrl+C so we can exit gracefully
 	ctx, cancel := context.WithCancel(context.Background())
 	sigs := make(chan os.Signal, 1)


### PR DESCRIPTION
Results in a segment.com event like this:
```
{
  "context": {
    "library": {
      "name": "analytics-go",
      "version": "3.0.0"
    },
    "os": {
      "name": "darwin",
      "version": "arm64"
    }
  },
  "event": "Panic",
  "integrations": {},
  "originalTimestamp": "2024-08-08T22:36:33.233736594Z",
  "properties": {
    "error": "runtime error: index out of range [1] with length 0",
    "stack": "goroutine 1 [running]:\nruntime/debug.Stack()\n\t/nix/store/v8llgr5prc0rawmgynacggg0q4pbvk5w-go-1.21.10/share/go/src/runtime/debug/stack.go:24 +0x64\nmain.main.func1()\n\t/Users/…/dev/defang/src/cmd/cli/main.go:16 +0x40\npanic({0x10464afe0?, 0x14000154870?})\n\t/nix/store/v8llgr5prc0rawmgynacggg0q4pbvk5w-go-1.21.10/share/go/src/runtime/panic.go:914 +0x218\ngithub.com/DefangLabs/defang/src/pkg/cli/client/byoc/aws.(*ByocAws).BootstrapList(0x140003e5b60, {0x104af93c0, 0x1400039a910})\n\t/Users/…/dev/defang/src/pkg/cli/client/byoc/aws/byoc.go:754 +0x80c\ngithub.com/DefangLabs/defang/src/pkg/cli.BootstrapLocalList({0x104af93c0, 0x1400039a910}, {0x104b0a228, 0x140003e5b60})\n\t/Users/…/dev/defang/src/pkg/cli/bootstrap.go:39 +0x84\ngithub.com/DefangLabs/defang/src/cmd/cli/command.glob..func29(0x105732520, {0x105775ac0?, 0x0?, 0x0?})\n\t/Users/…/dev/defang/src/cmd/cli/command/commands.go:1286 +0x80\ngithub.com/spf13/cobra.(*Command).execute(0x105732520, {0x105775ac0, 0x0, 0x0})\n\t/Users/…/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:983 +0x840\ngithub.com/spf13/cobra.(*Command).ExecuteC(0x105732800)\n\t/Users/…/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:1115 +0x344\ngithub.com/spf13/cobra.(*Command).Execute(...)\n\t/Users/…/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:1039\ngithub.com/spf13/cobra.(*Command).ExecuteContext(...)\n\t/Users/…/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:1032\ngithub.com/DefangLabs/defang/src/cmd/cli/command.Execute({0x104af93c0?, 0x1400039a910})\n\t/Users/…/dev/defang/src/cmd/cli/command/commands.go:66 +0x9c\nmain.main()\n\t/Users/…/dev/defang/src/cmd/cli/main.go:36 +0x104\n"
  },
  "receivedAt": "2024-08-08T22:36:33.729Z",
  "sentAt": "2024-08-08T22:36:33.720Z",
  "timestamp": "2024-08-08T22:36:33.242Z",
  "type": "track",
  "writeKey": "REDACTED"
}
```