### PR TITLE
Persist offline terms agreement

### DIFF
--- a/src/pkg/cli/agree_tos.go
+++ b/src/pkg/cli/agree_tos.go
@@ -12,7 +12,15 @@ import (
 
 var ErrTermsNotAgreed = errors.New("You must agree to the Defang terms of service to use this tool")
 
-func InteractiveAgreeToS(ctx context.Context, client client.Client) error {
+func InteractiveAgreeToS(ctx context.Context, c client.Client) error {
+	if client.TermsAccepted() {
+		// The user has already agreed to the terms of service recently
+		if err := nonInteractiveAgreeToS(ctx, c); err != nil {
+			term.Debug("unable to agree to terms:", err) // not fatal
+		}
+		return nil
+	}
+
 	fmt.Println("Our latest terms of service can be found at https://defang.io/terms-service.html")
 
 	var agreeToS bool
@@ -28,15 +36,24 @@ func InteractiveAgreeToS(ctx context.Context, client client.Client) error {
 		return ErrTermsNotAgreed
 	}
 
-	return NonInteractiveAgreeToS(ctx, client)
+	return NonInteractiveAgreeToS(ctx, c)
 }
 
-func NonInteractiveAgreeToS(ctx context.Context, client client.Client) error {
+func NonInteractiveAgreeToS(ctx context.Context, c client.Client) error {
 	if DoDryRun {
 		return ErrDryRun
 	}
 
-	if err := client.AgreeToS(ctx); err != nil {
+	// Persist the terms agreement in the state file so that we don't ask again
+	if err := client.AcceptTerms(); err != nil {
+		term.Debug("unable to persist terms agreement:", err) // not fatal
+	}
+
+	return nonInteractiveAgreeToS(ctx, c)
+}
+
+func nonInteractiveAgreeToS(ctx context.Context, c client.Client) error {
+	if err := c.AgreeToS(ctx); err != nil {
 		return err
 	}
 	term.Info("You have agreed to the Defang terms of service")

--- a/src/pkg/cli/client/state.go
+++ b/src/pkg/cli/client/state.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"time"
 
 	"github.com/DefangLabs/defang/src/pkg"
 	"github.com/google/uuid"
@@ -22,25 +23,46 @@ func userStateDir() (string, error) {
 var (
 	stateDir, _ = userStateDir()
 	// StateDir is the directory where the state file is stored
-	StateDir = filepath.Join(stateDir, "defang")
-
-	GetAnonID = func() string {
-		state := State{AnonID: uuid.NewString()}
-
-		// Restore anonID from config file
-		statePath := filepath.Join(StateDir, "state.json")
-		if bytes, err := os.ReadFile(statePath); err == nil {
-			json.Unmarshal(bytes, &state)
-		} else { // could be not found or path error
-			if bytes, err := json.MarshalIndent(state, "", "  "); err == nil {
-				os.MkdirAll(StateDir, 0700)
-				os.WriteFile(statePath, bytes, 0644)
-			}
-		}
-		return state.AnonID
-	}
+	StateDir  = filepath.Join(stateDir, "defang")
+	statePath = filepath.Join(StateDir, "state.json")
+	state     State
 )
 
 type State struct {
-	AnonID string
+	AnonID        string
+	TermsAccepted time.Time
+}
+
+func initState(path string) State {
+	state := State{AnonID: uuid.NewString()}
+	if bytes, err := os.ReadFile(path); err == nil {
+		json.Unmarshal(bytes, &state)
+	} else { // could be not found or path error
+		state.write(path)
+	}
+	return state
+}
+
+func (state State) write(path string) error {
+	if bytes, err := json.MarshalIndent(state, "", "  "); err != nil {
+		return err
+	} else {
+		os.MkdirAll(StateDir, 0700)
+		return os.WriteFile(path, bytes, 0644)
+	}
+}
+
+func GetAnonID() string {
+	state = initState(statePath)
+	return state.AnonID
+}
+
+func AcceptTerms() error {
+	state.TermsAccepted = time.Now()
+	return state.write(statePath)
+}
+
+func TermsAccepted() bool {
+	// Consider the terms accepted if the timestamp is within the last 24 hours
+	return time.Since(state.TermsAccepted) < 24*time.Hour
 }

--- a/src/pkg/cli/client/state.go
+++ b/src/pkg/cli/client/state.go
@@ -29,8 +29,8 @@ var (
 )
 
 type State struct {
-	AnonID        string
-	TermsAccepted time.Time
+	AnonID          string
+	TermsAcceptedAt time.Time
 }
 
 func initState(path string) State {
@@ -52,17 +52,25 @@ func (state State) write(path string) error {
 	}
 }
 
+func (state *State) acceptTerms() error {
+	state.TermsAcceptedAt = time.Now()
+	return state.write(statePath)
+}
+
+func (state State) termsAccepted() bool {
+	// Consider the terms accepted if the timestamp is within the last 24 hours
+	return time.Since(state.TermsAcceptedAt) < 24*time.Hour
+}
+
 func GetAnonID() string {
 	state = initState(statePath)
 	return state.AnonID
 }
 
 func AcceptTerms() error {
-	state.TermsAccepted = time.Now()
-	return state.write(statePath)
+	return state.acceptTerms()
 }
 
 func TermsAccepted() bool {
-	// Consider the terms accepted if the timestamp is within the last 24 hours
-	return time.Since(state.TermsAccepted) < 24*time.Hour
+	return state.termsAccepted()
 }

--- a/src/pkg/cli/client/state_test.go
+++ b/src/pkg/cli/client/state_test.go
@@ -2,8 +2,10 @@ package client
 
 import (
 	"os"
+	"path/filepath"
 	"runtime"
 	"testing"
+	"time"
 )
 
 func TestStateDir(t *testing.T) {
@@ -17,5 +19,40 @@ func TestStateDir(t *testing.T) {
 	}
 	if stateDir != "/home/user/.local/state" {
 		t.Errorf("userStateDir() returned unexpected directory: %v", stateDir)
+	}
+}
+
+func TestInitState(t *testing.T) {
+	tmp := filepath.Join(t.TempDir(), "state.json")
+	state := initState(tmp)
+	if state.AnonID == "" {
+		t.Errorf("initState() returned empty AnonID")
+	}
+	// 2nd call should read from same file
+	state2 := initState(tmp)
+	if state2.AnonID != state.AnonID {
+		t.Errorf("initState() returned different AnonID on 2nd call")
+	}
+}
+
+func TestTerms(t *testing.T) {
+	statePath = filepath.Join(t.TempDir(), "state.json")
+	_ = GetAnonID()
+	if !state.TermsAccepted.IsZero() {
+		t.Errorf("initState() returned non-zero TermsAccepted")
+	}
+	if TermsAccepted() {
+		t.Errorf("TermsAccepted() returned true, expected false")
+	}
+	if err := AcceptTerms(); err != nil {
+		t.Errorf("AcceptTerms() returned error: %v", err)
+	}
+	if !TermsAccepted() {
+		t.Errorf("TermsAccepted() returned false, expected true")
+	}
+	// Old acceptance should not count
+	state.TermsAccepted = state.TermsAccepted.Add(-25 * time.Hour)
+	if TermsAccepted() {
+		t.Errorf("TermsAccepted() returned true, expected false")
 	}
 }

--- a/src/pkg/cli/client/state_test.go
+++ b/src/pkg/cli/client/state_test.go
@@ -36,23 +36,23 @@ func TestInitState(t *testing.T) {
 }
 
 func TestTerms(t *testing.T) {
-	statePath = filepath.Join(t.TempDir(), "state.json")
-	_ = GetAnonID()
-	if !state.TermsAccepted.IsZero() {
+	tmp := filepath.Join(t.TempDir(), "state.json")
+	state := initState(tmp)
+	if !state.TermsAcceptedAt.IsZero() {
 		t.Errorf("initState() returned non-zero TermsAccepted")
 	}
-	if TermsAccepted() {
+	if state.termsAccepted() {
 		t.Errorf("TermsAccepted() returned true, expected false")
 	}
-	if err := AcceptTerms(); err != nil {
+	if err := state.acceptTerms(); err != nil {
 		t.Errorf("AcceptTerms() returned error: %v", err)
 	}
-	if !TermsAccepted() {
+	if !state.termsAccepted() {
 		t.Errorf("TermsAccepted() returned false, expected true")
 	}
 	// Old acceptance should not count
-	state.TermsAccepted = state.TermsAccepted.Add(-25 * time.Hour)
-	if TermsAccepted() {
+	state.TermsAcceptedAt = state.TermsAcceptedAt.Add(-25 * time.Hour)
+	if state.termsAccepted() {
 		t.Errorf("TermsAccepted() returned true, expected false")
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/DefangLabs/defang-mvp/issues/711

We avoid login during the first `defang generate` to lower the barrier of entry, but we still need to ask for terms agreement. Later, when the user logs in they'll get asked again, because the agreement was never persisted on the server.

This PR will track the agreement in the user's state file. To avoid changes in terms between the first (offline) agreement and a future log in, we track the time and ask again if more than 1 day has passed.