### PR TITLE
Bugfix: Pass local project name to Destroy

### DIFF
--- a/src/pkg/cli/client/playground.go
+++ b/src/pkg/cli/client/playground.go
@@ -79,15 +79,15 @@ func (g *PlaygroundClient) Destroy(ctx context.Context) (types.ETag, error) {
 	}
 
 	// Get all the services in the project and delete them all at once
-	project, err := g.GetServices(ctx)
+	servicesList, err := g.GetServices(ctx)
 	if err != nil {
 		return "", err
 	}
-	if len(project.Services) == 0 {
+	if len(servicesList.Services) == 0 {
 		return "", errors.New("no services found")
 	}
 	var names []string
-	for _, service := range project.Services {
+	for _, service := range servicesList.Services {
 		names = append(names, service.Service.Name)
 	}
 	resp, err := g.Delete(ctx, &defangv1.DeleteRequest{Project: projectName, Names: names})

--- a/src/pkg/cli/client/playground.go
+++ b/src/pkg/cli/client/playground.go
@@ -73,6 +73,11 @@ func (g *PlaygroundClient) BootstrapCommand(ctx context.Context, command string)
 	return "", errors.New("the bootstrap command is not valid for the Defang playground; did you forget --provider?")
 }
 func (g *PlaygroundClient) Destroy(ctx context.Context) (types.ETag, error) {
+	projectName, err := g.LoadProjectName(ctx)
+	if err != nil {
+		return "", err
+	}
+
 	// Get all the services in the project and delete them all at once
 	project, err := g.GetServices(ctx)
 	if err != nil {
@@ -85,7 +90,7 @@ func (g *PlaygroundClient) Destroy(ctx context.Context) (types.ETag, error) {
 	for _, service := range project.Services {
 		names = append(names, service.Service.Name)
 	}
-	resp, err := g.Delete(ctx, &defangv1.DeleteRequest{Project: project.Project, Names: names})
+	resp, err := g.Delete(ctx, &defangv1.DeleteRequest{Project: projectName, Names: names})
 	if err != nil {
 		return "", err
 	}

--- a/src/pkg/cli/destroy_test.go
+++ b/src/pkg/cli/destroy_test.go
@@ -1,0 +1,73 @@
+package cli
+
+import (
+	"context"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	cliClient "github.com/DefangLabs/defang/src/pkg/cli/client"
+	defangv1 "github.com/DefangLabs/defang/src/protos/io/defang/v1"
+	"github.com/DefangLabs/defang/src/protos/io/defang/v1/defangv1connect"
+	"github.com/bufbuild/connect-go"
+	compose "github.com/compose-spec/compose-go/v2/types"
+	"google.golang.org/protobuf/types/known/emptypb"
+)
+
+type grpcDestroyMockHandler struct {
+	defangv1connect.UnimplementedFabricControllerHandler
+}
+
+func (g *grpcDestroyMockHandler) Delete(context.Context, *connect.Request[defangv1.DeleteRequest]) (*connect.Response[defangv1.DeleteResponse], error) {
+	return connect.NewResponse(&defangv1.DeleteResponse{
+		Etag: "test-etag",
+	}), nil
+}
+
+func (g *grpcDestroyMockHandler) GetServices(context.Context, *connect.Request[emptypb.Empty]) (*connect.Response[defangv1.ListServicesResponse], error) {
+	return connect.NewResponse(&defangv1.ListServicesResponse{
+		Project: "tenantx",
+		Services: []*defangv1.ServiceInfo{
+			{
+				Service: &defangv1.Service{
+					Name: "test-service",
+				},
+			},
+		},
+	}), nil
+}
+
+func TestDestroy(t *testing.T) {
+	fabricServer := &grpcDestroyMockHandler{}
+	_, handler := defangv1connect.NewFabricControllerHandler(fabricServer)
+
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	ctx := context.Background()
+	url := strings.TrimPrefix(server.URL, "http://")
+	loader := FakeLoader{ProjectName: "test-project"}
+	grpcClient := Connect(url, loader)
+	client := cliClient.PlaygroundClient{GrpcClient: grpcClient}
+
+	etag, err := client.Destroy(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if etag != "test-etag" {
+		t.Fatalf("expected etag %q, got %q", "test-etag", etag)
+	}
+}
+
+type FakeLoader struct {
+	ProjectName string
+}
+
+func (f FakeLoader) LoadProject(ctx context.Context) (*compose.Project, error) {
+	return &compose.Project{Name: f.ProjectName}, nil
+}
+
+func (f FakeLoader) LoadProjectName(ctx context.Context) (string, error) {
+	return f.ProjectName, nil
+}


### PR DESCRIPTION
Bugfix: Use the local project name with `defang compose down`.

Background:
It looks like we added the `Project` field to the `DeleteRequest` in #560 but instead of sourcing the project name from the local compose file, we used the value returned by `GetServices`, which is unfortunately still populated with the tenant name. Instead, we should source the project name from the local compose file or from the `--project-name` CLI flag.