### PR TITLE
Fix Compose port warnings

### DIFF
--- a/src/pkg/cli/compose/convert.go
+++ b/src/pkg/cli/compose/convert.go
@@ -310,13 +310,13 @@ func convertPort(port compose.ServicePortConfig) *defangv1.Port {
 	switch port.Mode {
 	case "":
 		// TODO: This never happens now as compose-go set default to "ingress"
-		term.Warnf("No port 'mode' was specified; defaulting to 'ingress' (add 'mode: ingress' to silence)")
+		term.Warnf("port %d: no 'mode' was specified; defaulting to 'ingress' (add 'mode: ingress' to silence)", port.Target)
 		fallthrough
 	case "ingress":
 		// This code is unnecessarily complex because compose-go silently converts short port: syntax to ingress+tcp
 		if port.Protocol != "udp" {
 			if port.Published != "" {
-				term.Warnf("Published ports are ignored in ingress mode")
+				term.Debugf("port %d: ignoring 'published: %s' in 'ingress' mode", port.Target, port.Published)
 			}
 			pbPort.Mode = defangv1.Mode_INGRESS
 			if pbPort.Protocol == defangv1.Protocol_TCP {
@@ -324,7 +324,7 @@ func convertPort(port compose.ServicePortConfig) *defangv1.Port {
 			}
 			break
 		}
-		term.Warnf("UDP ports default to 'host' mode (add 'mode: host' to silence)")
+		term.Warnf("port %d: UDP ports default to 'host' mode (add 'mode: host' to silence)", port.Target)
 		fallthrough
 	case "host":
 		pbPort.Mode = defangv1.Mode_HOST

--- a/src/pkg/cli/compose/convert_test.go
+++ b/src/pkg/cli/compose/convert_test.go
@@ -22,7 +22,7 @@ func TestConvertPort(t *testing.T) {
 		{
 			name:    "No target port xfail",
 			input:   types.ServicePortConfig{},
-			wantErr: "port 'target' must be an integer between 1 and 32767",
+			wantErr: "port 0: 'target' must be an integer between 1 and 32767",
 		},
 		{
 			name:     "Undefined mode and protocol, target only",
@@ -72,12 +72,12 @@ func TestConvertPort(t *testing.T) {
 		{
 			name:    "Host mode and protocol, published range xfail",
 			input:   types.ServicePortConfig{Mode: "host", Target: 1234, Published: "1511-2222"},
-			wantErr: "port 'published' range must include 'target': 1511-2222",
+			wantErr: "port 1234: 'published' range must include 'target': 1511-2222",
 		},
 		{
 			name:    "Host mode and protocol, published range xfail",
 			input:   types.ServicePortConfig{Mode: "host", Target: 1234, Published: "22222"},
-			wantErr: "port 'published' must be empty or equal to 'target': 22222",
+			wantErr: "port 1234: 'published' must be empty or equal to 'target': 22222",
 		},
 		{
 			name:     "Host mode and protocol, target in published range",
@@ -107,7 +107,7 @@ func TestConvertPort(t *testing.T) {
 		{
 			name:    "Localhost IP, unsupported mode and protocol xfail",
 			input:   types.ServicePortConfig{Mode: "ingress", HostIP: "127.0.0.1", Protocol: "tcp", Published: "1234", Target: 1234},
-			wantErr: "port 'host_ip' is not supported",
+			wantErr: "port 1234: 'host_ip' is not supported",
 		},
 		{
 			name:     "Ingress mode without host IP, single target, published range xfail", // - 1511-2223:1234

--- a/src/pkg/cli/tail.go
+++ b/src/pkg/cli/tail.go
@@ -352,7 +352,7 @@ func tail(ctx context.Context, client client.Client, params TailOptions) error {
 						prefixLen += l
 					}
 				} else {
-					io.WriteString(buf, strings.Repeat(" ", prefixLen))
+					buf.WriteString(strings.Repeat(" ", prefixLen))
 				}
 				if term.StdoutCanColor() {
 					if !strings.Contains(line, "\033[") {
@@ -361,7 +361,8 @@ func tail(ctx context.Context, client client.Client, params TailOptions) error {
 				} else {
 					line = term.StripAnsi(line)
 				}
-				io.WriteString(buf, line)
+				buf.WriteString(line)
+				buf.WriteRune('\n')
 
 				// Detect end logging event
 				if params.EndEventDetectFunc != nil && params.EndEventDetectFunc([]string{service}, host, line) {
@@ -369,7 +370,7 @@ func tail(ctx context.Context, client client.Client, params TailOptions) error {
 					return nil
 				}
 			}
-			term.Println(buf.String())
+			term.Print(buf.String())
 		}
 	}
 }

--- a/src/tests/ports/compose.yaml
+++ b/src/tests/ports/compose.yaml
@@ -1,0 +1,26 @@
+services:
+  short:
+    image: bogus
+    ports:
+      - 80
+  short-published:
+    image: bogus
+    ports:
+      - "8081:81"
+  long:
+    image: bogus
+    ports:
+      - target: 82
+  long-published:
+    image: bogus
+    ports:
+      - target: 83
+        published: 8083
+  short-udp:
+    image: bogus
+    ports:
+      - "84/udp"
+  short-udp-published:
+    image: bogus
+    ports:
+      - "8085:85/udp"

--- a/src/tests/ports/compose.yaml.convert
+++ b/src/tests/ports/compose.yaml.convert
@@ -1,0 +1,84 @@
+[
+  {
+    "name": "long",
+    "image": "bogus",
+    "platform": 2,
+    "internal": true,
+    "ports": [
+      {
+        "target": 82,
+        "protocol": 3,
+        "mode": 1
+      }
+    ],
+    "networks": 1
+  },
+  {
+    "name": "long-published",
+    "image": "bogus",
+    "platform": 2,
+    "internal": true,
+    "ports": [
+      {
+        "target": 83,
+        "protocol": 3,
+        "mode": 1
+      }
+    ],
+    "networks": 1
+  },
+  {
+    "name": "short",
+    "image": "bogus",
+    "platform": 2,
+    "internal": true,
+    "ports": [
+      {
+        "target": 80,
+        "protocol": 3,
+        "mode": 1
+      }
+    ],
+    "networks": 1
+  },
+  {
+    "name": "short-published",
+    "image": "bogus",
+    "platform": 2,
+    "internal": true,
+    "ports": [
+      {
+        "target": 81,
+        "protocol": 3,
+        "mode": 1
+      }
+    ],
+    "networks": 1
+  },
+  {
+    "name": "short-udp",
+    "image": "bogus",
+    "platform": 2,
+    "internal": true,
+    "ports": [
+      {
+        "target": 84,
+        "protocol": 1
+      }
+    ],
+    "networks": 1
+  },
+  {
+    "name": "short-udp-published",
+    "image": "bogus",
+    "platform": 2,
+    "internal": true,
+    "ports": [
+      {
+        "target": 85,
+        "protocol": 1
+      }
+    ],
+    "networks": 1
+  }
+]

--- a/src/tests/ports/compose.yaml.golden
+++ b/src/tests/ports/compose.yaml.golden
@@ -1,0 +1,56 @@
+name: ports
+services:
+  long:
+    image: bogus
+    networks:
+      default: null
+    ports:
+      - mode: ingress
+        target: 82
+        protocol: tcp
+  long-published:
+    image: bogus
+    networks:
+      default: null
+    ports:
+      - mode: ingress
+        target: 83
+        published: "8083"
+        protocol: tcp
+  short:
+    image: bogus
+    networks:
+      default: null
+    ports:
+      - mode: ingress
+        target: 80
+        protocol: tcp
+  short-published:
+    image: bogus
+    networks:
+      default: null
+    ports:
+      - mode: ingress
+        target: 81
+        published: "8081"
+        protocol: tcp
+  short-udp:
+    image: bogus
+    networks:
+      default: null
+    ports:
+      - mode: ingress
+        target: 84
+        protocol: udp
+  short-udp-published:
+    image: bogus
+    networks:
+      default: null
+    ports:
+      - mode: ingress
+        target: 85
+        published: "8085"
+        protocol: udp
+networks:
+  default:
+    name: ports_default

--- a/src/tests/ports/compose.yaml.warnings
+++ b/src/tests/ports/compose.yaml.warnings
@@ -1,0 +1,19 @@
+ ! port 84: UDP ports default to 'host' mode (add 'mode: host' to silence)
+ ! port 85: UDP ports default to 'host' mode (add 'mode: host' to silence)
+ ! service "long": ingress port without healthcheck defaults to GET / HTTP/1.1
+ ! service "long": missing compose directive: restart; assuming 'unless-stopped' (add 'restart' to silence)
+ ! service "long": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors
+ ! service "long-published": ingress port without healthcheck defaults to GET / HTTP/1.1
+ ! service "long-published": missing compose directive: restart; assuming 'unless-stopped' (add 'restart' to silence)
+ ! service "long-published": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors
+ ! service "short": ingress port without healthcheck defaults to GET / HTTP/1.1
+ ! service "short": missing compose directive: restart; assuming 'unless-stopped' (add 'restart' to silence)
+ ! service "short": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors
+ ! service "short-published": ingress port without healthcheck defaults to GET / HTTP/1.1
+ ! service "short-published": missing compose directive: restart; assuming 'unless-stopped' (add 'restart' to silence)
+ ! service "short-published": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors
+ ! service "short-udp": ingress port without healthcheck defaults to GET / HTTP/1.1
+ ! service "short-udp": missing compose directive: restart; assuming 'unless-stopped' (add 'restart' to silence)
+ ! service "short-udp": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors
+ ! service "short-udp-published": missing compose directive: restart; assuming 'unless-stopped' (add 'restart' to silence)
+port 85: 'published' must be empty or equal to 'target': 8085

--- a/src/tests/testproj/compose.yaml.warnings
+++ b/src/tests/testproj/compose.yaml.warnings
@@ -1,4 +1,4 @@
- ! UDP ports default to 'host' mode (add 'mode: host' to silence)
+ ! port 4567: UDP ports default to 'host' mode (add 'mode: host' to silence)
  ! service "dfnx": secrets will be exposed as environment variables, not files (use 'environment' instead)
  ! unsupported compose extension: "x-unsupported"
  * Compressing build context for dfnx at .


### PR DESCRIPTION
- Fix regression in `tail` https://github.com/DefangLabs/defang/pull/613/files#diff-eaaea9856777a2f5870fca35a2c52aef840f045c6558b3b56def7132d9125e95L364
- In https://github.com/DefangLabs/defang-mvp/pull/939 we added "published" ports to all generated files (because of #546) but this shows a warning; made the warning into debug-only message
- Added port numbers to warnings to help identify the offending port

```
 ! Published ports are ignored in ingress mode
```
