### PR TITLE
hide cd subcommands from the docs

### DIFF
--- a/src/cmd/cli/command/commands.go
+++ b/src/cmd/cli/command/commands.go
@@ -876,6 +876,7 @@ var bootstrapCmd = &cobra.Command{
 	Use:     "cd",
 	Aliases: []string{"bootstrap"},
 	Short:   "Manually run a command with the CD task (for BYOC only)",
+	Hidden:  true,
 }
 
 var bootstrapDestroyCmd = &cobra.Command{


### PR DESCRIPTION
The `cd` subcommands are not very useful to end-users right now, but they are unfortunately listed first in the documentation nav bar when naturally sorted alphabetically. This PR "hides" the `cd` subcommands from the docs and from the cli helptext, but the commands are still usable to us. We can revisit documenting them publically when we have a clearer user-story for them.