### PR TITLE
Make AWS provider explicit

### DIFF
--- a/src/pkg/cli/client/provider.go
+++ b/src/pkg/cli/client/provider.go
@@ -11,7 +11,7 @@ const (
 	ProviderAuto   Provider = "auto"
 	ProviderDefang Provider = "defang"
 	ProviderAWS    Provider = "aws"
-	ProviderDO     Provider = "do"
+	ProviderDO     Provider = "digitalocean"
 	// ProviderAzure  Provider = "azure"
 	// ProviderGCP    Provider = "gcp"
 )

--- a/src/pkg/cli/connect.go
+++ b/src/pkg/cli/connect.go
@@ -83,11 +83,11 @@ func NewClient(ctx context.Context, cluster string, provider client.Provider, lo
 
 	switch provider {
 	case client.ProviderAWS:
-		term.Info("Using AWS provider") // '#' hack no logner needed as root command skips new client for competion command now
+		term.Info("Using AWS provider")
 		byocClient := aws.NewByoc(ctx, grpcClient, tenantId)
 		return byocClient
 	case client.ProviderDO:
-		term.Info("Using DO provider")
+		term.Info("Using DigitalOcean provider")
 		byocClient := do.NewByoc(ctx, grpcClient, tenantId)
 		return byocClient
 	default:


### PR DESCRIPTION
Fixes #667 by no longer using AWS provider when AWS env vars were found. You now need to explicitly mention `--provider=aws`

Technically this is a breaking change, so perhaps it's time to bump the next release to 0.6.0