### PR TITLE
Cache root resolver dns result for http client for 1m

### DIFF
--- a/src/pkg/cli/cert.go
+++ b/src/pkg/cli/cert.go
@@ -71,6 +71,7 @@ var (
 			return nil
 		},
 	}
+	httpRetryDelayBase = 5 * time.Second
 )
 
 func GenerateLetsEncryptCert(ctx context.Context, client cliClient.Client) error {
@@ -123,7 +124,10 @@ func generateCert(ctx context.Context, domain string, targets []string) {
 		return
 	}
 	term.Infof("Triggering cert generation for %v", domain)
-	triggerCertGeneration(ctx, domain)
+	if err := triggerCertGeneration(ctx, domain); err != nil {
+		term.Errorf("Error triggering cert generation, please try again")
+		return
+	}
 
 	term.Infof("Waiting for TLS cert to be online for %v, this could take a few minutes", domain)
 	if err := waitForTLS(ctx, domain); err != nil {
@@ -135,7 +139,7 @@ func generateCert(ctx context.Context, domain string, targets []string) {
 	term.Printf("TLS cert for %v is ready\n", domain)
 }
 
-func triggerCertGeneration(ctx context.Context, domain string) {
+func triggerCertGeneration(ctx context.Context, domain string) error {
 	doSpinner := term.StdoutCanColor() && term.IsTerminal()
 	if doSpinner {
 		spinCtx, cancel := context.WithCancel(ctx)
@@ -156,10 +160,13 @@ func triggerCertGeneration(ctx context.Context, domain string) {
 			}
 		}()
 	}
-	if err := getWithRetries(ctx, fmt.Sprintf("http://%v", domain), 3); err != nil { // Retry incase of DNS error
+	// Our own retry logic uses the root resolver to prevent cached DNS and retry on all non-200 errors
+	if err := getWithRetries(ctx, fmt.Sprintf("http://%v", domain), 5); err != nil { // Retry incase of DNS error
 		// Ignore possible tls error as cert attachment may take time
 		term.Debugf(" - Error triggering cert generation: %v", err)
+		return err
 	}
+	return nil
 }
 
 func waitForTLS(ctx context.Context, domain string) error {
@@ -335,7 +342,7 @@ func getWithRetries(ctx context.Context, url string, tries int) error {
 		term.Debugf("Error fetching %v: %v, tries left %v", url, err, tries-i-1)
 		errs = append(errs, err)
 
-		delay := (100 * time.Millisecond) << i // Simple exponential backoff
+		delay := httpRetryDelayBase << i // Simple exponential backoff
 		if err := pkg.SleepWithContext(ctx, delay); err != nil {
 			return err
 		}

--- a/src/pkg/cli/cert_test.go
+++ b/src/pkg/cli/cert_test.go
@@ -294,6 +294,10 @@ func mockBody(s string) io.ReadCloser {
 }
 
 func TestGetWithRetries(t *testing.T) {
+	originalDelayBase := httpRetryDelayBase
+	httpRetryDelayBase = 100 * time.Millisecond
+	t.Cleanup(func() { httpRetryDelayBase = originalDelayBase })
+
 	t.Run("success on first try", func(t *testing.T) {
 		tc := &testClient{tries: []tryResult{
 			{result: &http.Response{StatusCode: 200, Body: mockBody("")}, err: nil},

--- a/src/pkg/cli/cert_test.go
+++ b/src/pkg/cli/cert_test.go
@@ -303,7 +303,7 @@ func TestGetWithRetries(t *testing.T) {
 			{result: &http.Response{StatusCode: 200, Body: mockBody("")}, err: nil},
 		}}
 		originalClient := httpClient
-		defer func() { httpClient = originalClient }()
+		t.Cleanup(func() { httpClient = originalClient })
 		httpClient = tc
 		err := getWithRetries(context.Background(), "http://example.com", 3)
 		if err != nil {
@@ -320,7 +320,7 @@ func TestGetWithRetries(t *testing.T) {
 			{result: &http.Response{StatusCode: 200, Body: mockBody("")}, err: nil},
 		}}
 		originalClient := httpClient
-		defer func() { httpClient = originalClient }()
+		t.Cleanup(func() { httpClient = originalClient })
 		httpClient = tc
 		err := getWithRetries(context.Background(), "http://example.com", 3)
 		if err != nil {
@@ -337,7 +337,7 @@ func TestGetWithRetries(t *testing.T) {
 			{result: nil, err: errors.New("error")},
 		}}
 		originalClient := httpClient
-		defer func() { httpClient = originalClient }()
+		t.Cleanup(func() { httpClient = originalClient })
 		httpClient = tc
 		err := getWithRetries(context.Background(), "http://example.com", 3)
 		if err == nil {
@@ -356,7 +356,7 @@ func TestGetWithRetries(t *testing.T) {
 			{result: &http.Response{StatusCode: 503, Body: mockBody("Random Error")}, err: nil},
 		}}
 		originalClient := httpClient
-		defer func() { httpClient = originalClient }()
+		t.Cleanup(func() { httpClient = originalClient })
 		httpClient = tc
 		err := getWithRetries(context.Background(), "http://example.com", 3)
 		if err == nil {
@@ -375,7 +375,7 @@ func TestGetWithRetries(t *testing.T) {
 			{result: &http.Response{StatusCode: 503, Body: mockBody("Random Error")}, err: nil},
 		}}
 		originalClient := httpClient
-		defer func() { httpClient = originalClient }()
+		t.Cleanup(func() { httpClient = originalClient })
 		httpClient = tc
 		err := getWithRetries(context.Background(), "http://example.com", 1)
 		if err == nil {

--- a/src/pkg/cli/cert_test.go
+++ b/src/pkg/cli/cert_test.go
@@ -3,12 +3,16 @@ package cli
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"net"
 	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"slices"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/DefangLabs/defang/src/pkg/dns"
 	"github.com/DefangLabs/defang/src/pkg/term"
@@ -294,6 +298,8 @@ func TestGetWithRetries(t *testing.T) {
 		tc := &testClient{tries: []tryResult{
 			{result: &http.Response{StatusCode: 200, Body: mockBody("")}, err: nil},
 		}}
+		originalClient := httpClient
+		defer func() { httpClient = originalClient }()
 		httpClient = tc
 		err := getWithRetries(context.Background(), "http://example.com", 3)
 		if err != nil {
@@ -309,6 +315,8 @@ func TestGetWithRetries(t *testing.T) {
 			{result: nil, err: errors.New("error")},
 			{result: &http.Response{StatusCode: 200, Body: mockBody("")}, err: nil},
 		}}
+		originalClient := httpClient
+		defer func() { httpClient = originalClient }()
 		httpClient = tc
 		err := getWithRetries(context.Background(), "http://example.com", 3)
 		if err != nil {
@@ -324,6 +332,8 @@ func TestGetWithRetries(t *testing.T) {
 			{result: &http.Response{StatusCode: 503, Body: mockBody("Random Error")}, err: nil},
 			{result: nil, err: errors.New("error")},
 		}}
+		originalClient := httpClient
+		defer func() { httpClient = originalClient }()
 		httpClient = tc
 		err := getWithRetries(context.Background(), "http://example.com", 3)
 		if err == nil {
@@ -341,6 +351,8 @@ func TestGetWithRetries(t *testing.T) {
 			{result: &http.Response{StatusCode: 502, Body: mockBody("Random Error")}, err: nil},
 			{result: &http.Response{StatusCode: 503, Body: mockBody("Random Error")}, err: nil},
 		}}
+		originalClient := httpClient
+		defer func() { httpClient = originalClient }()
 		httpClient = tc
 		err := getWithRetries(context.Background(), "http://example.com", 3)
 		if err == nil {
@@ -358,6 +370,8 @@ func TestGetWithRetries(t *testing.T) {
 			{result: &http.Response{StatusCode: 502, Body: mockBody("Random Error")}, err: nil},
 			{result: &http.Response{StatusCode: 503, Body: mockBody("Random Error")}, err: nil},
 		}}
+		originalClient := httpClient
+		defer func() { httpClient = originalClient }()
 		httpClient = tc
 		err := getWithRetries(context.Background(), "http://example.com", 1)
 		if err == nil {
@@ -367,4 +381,75 @@ func TestGetWithRetries(t *testing.T) {
 			t.Errorf("Expected 3 calls, got %v", tc.calls)
 		}
 	})
+}
+
+type MockResolver struct {
+	calls int
+}
+
+func (mr *MockResolver) LookupIPAddr(ctx context.Context, domain string) ([]net.IPAddr, error) {
+	mr.calls++
+	return []net.IPAddr{net.IPAddr{IP: net.ParseIP("127.0.0.1")}}, nil
+}
+func (mr *MockResolver) LookupCNAME(ctx context.Context, domain string) (string, error) {
+	mr.calls++
+	return "", nil
+}
+func (mr *MockResolver) LookupNS(ctx context.Context, domain string) ([]*net.NS, error) {
+	mr.calls++
+	return []*net.NS{&net.NS{Host: ""}}, nil
+}
+
+func TestHttpClient(t *testing.T) {
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, "Hello, client")
+	}))
+	defer ts.Close()
+	var mr MockResolver
+	resolver = &mr
+	dnsCacheDuration = 50 * time.Millisecond
+
+	tsu, err := url.Parse(ts.URL)
+	if err != nil {
+		t.Fatalf("could not parse test server url '%v': %v", ts.URL, err)
+	}
+	_, port, err := net.SplitHostPort(tsu.Host)
+	if err != nil {
+		t.Fatalf("could not get test server port from '%v': %v", tsu.Host, err)
+	}
+	req, err := http.NewRequest("GET", fmt.Sprintf("http://example.com:%v/", port), nil)
+	if err != nil {
+		t.Fatalf("failed to create request: %v", err)
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		t.Fatalf("failed to make http call: %v", err)
+	}
+	resp.Body.Close()
+
+	if mr.calls != 1 {
+		t.Fatalf("expected 1 dns lookup, but got %v", mr.calls)
+	}
+
+	resp, err = httpClient.Do(req)
+	if err != nil {
+		t.Fatalf("failed to make http call: %v", err)
+	}
+	resp.Body.Close()
+	if mr.calls != 1 {
+		t.Fatalf("expected no increase in dns lookup, but got %v", mr.calls)
+	}
+
+	time.Sleep(80 * time.Millisecond)
+	resp, err = httpClient.Do(req)
+	if err != nil {
+		t.Fatalf("failed to make http call: %v", err)
+	}
+	resp.Body.Close()
+	if mr.calls != 2 {
+		t.Fatalf("expected 2nd dns lookup after cache expiry, but got %v", mr.calls)
+	}
+
 }


### PR DESCRIPTION
- Cache root resolver dns result for http client for 1m
- also add more delay between triggering tries.
- Fails cert gen command and prompt for retry when trigger fails

Reproduced issue and verified fixed:
```
 * defang.lol DNS is properly configured!
 * Triggering cert generation for defang.lol
 - Redirecting from http://defang.lol to http://fabric-prod1.defang.dev:80/?shard=45b05cc9&
 - Error fetching http://defang.lol: HTTP 503: failed to update acme certificate: failed to get certificates: obtaining certificate: solving challenge: defang.lol: [defang.lol] authorization failed: HTTP 400 urn:ietf:params:acme:error:dns - DNS problem: NXDOMAIN looking up A for defang.lol - check that a DNS record exists for this domain; DNS problem: NXDOMAIN looking up AAAA for defang.lol - check that a DNS record exists for this domain
, tries left 4
 - Redirecting from http://defang.lol to http://fabric-prod1.defang.dev:80/?shard=45b05cc9&
 - Error fetching http://defang.lol: HTTP 503: failed to update acme certificate: failed to get certificates: obtaining certificate: solving challenge: defang.lol: [defang.lol] authorization failed: HTTP 400 urn:ietf:params:acme:error:dns - DNS problem: NXDOMAIN looking up A for defang.lol - check that a DNS record exists for this domain; DNS problem: NXDOMAIN looking up AAAA for defang.lol - check that a DNS record exists for this domain
, tries left 3
 - Redirecting from http://defang.lol to http://fabric-prod1.defang.dev:80/?shard=45b05cc9&
 * Waiting for TLS cert to be online for defang.lol, this could take a few minutes
 - Error checking TLS cert for defang.lol: Get "https://defang.lol": tls: failed to verify certificate: x509: certificate relies on 
TLS cert for defang.lol is ready
```