### PR TITLE
Proposal: flag to expose OS env to compose loader

### DIFF
--- a/src/cmd/cli/command/compose.go
+++ b/src/cmd/cli/command/compose.go
@@ -173,6 +173,7 @@ func makeComposeUpCmd() *cobra.Command {
 			return nil
 		},
 	}
+	composeUpCmd.Flags().StringArrayP("env", "e", nil, "expose environment variables")
 	composeUpCmd.Flags().BoolP("detach", "d", false, "run in detached mode")
 	composeUpCmd.Flags().Bool("force", false, "force a build of the image even if nothing has changed")
 	composeUpCmd.Flags().Bool("tail", false, "tail the service logs after updating") // obsolete, but keep for backwards compatibility
@@ -185,6 +186,7 @@ func makeComposeStartCmd() *cobra.Command {
 	composeStartCmd := &cobra.Command{
 		Use:         "start",
 		Aliases:     []string{"deploy"},
+		Deprecated:  "use 'up --detach' instead",
 		Annotations: authNeededAnnotation,
 		Args:        cobra.NoArgs, // TODO: takes optional list of service names
 		Short:       "Reads a Compose file and deploys services to the cluster",
@@ -231,6 +233,7 @@ func makeComposeRestartCmd() *cobra.Command {
 func makeComposeStopCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:         "stop",
+		Deprecated:  "use 'down --detach' instead",
 		Annotations: authNeededAnnotation,
 		Args:        cobra.NoArgs, // TODO: takes optional list of service names
 		Short:       "Reads a Compose file and stops its services",
@@ -301,7 +304,7 @@ func makeComposeDownCmd() *cobra.Command {
 }
 
 func makeComposeConfigCmd() *cobra.Command {
-	return &cobra.Command{
+	composeConfigCmd := &cobra.Command{
 		Use:   "config",
 		Args:  cobra.NoArgs, // TODO: takes optional list of service names
 		Short: "Reads a Compose file and shows the generated config",
@@ -314,6 +317,8 @@ func makeComposeConfigCmd() *cobra.Command {
 			return nil
 		},
 	}
+	composeConfigCmd.Flags().StringArrayP("env", "e", nil, "expose environment variables")
+	return composeConfigCmd
 }
 
 func makeComposeLsCmd() *cobra.Command {

--- a/src/pkg/cli/client/client.go
+++ b/src/pkg/cli/client/client.go
@@ -38,6 +38,7 @@ type FabricClient interface {
 
 type Client interface {
 	FabricClient
+	ProjectLoader
 
 	BootstrapCommand(context.Context, string) (types.ETag, error)
 	BootstrapList(context.Context) ([]string, error)
@@ -56,9 +57,6 @@ type Client interface {
 	Follow(context.Context, *defangv1.TailRequest) (ServerStream[defangv1.TailResponse], error)
 	TearDown(context.Context) error
 	WhoAmI(context.Context) (*defangv1.WhoAmIResponse, error)
-
-	LoadProject(context.Context) (*compose.Project, error)
-	LoadProjectName(context.Context) (string, error)
 }
 
 type Property struct {

--- a/src/pkg/cli/compose/compose_test.go
+++ b/src/pkg/cli/compose/compose_test.go
@@ -225,7 +225,7 @@ func TestComposeOnlyOneFile(t *testing.T) {
 	loader := NewLoaderWithPath("")
 	project, err := loader.LoadProject(context.Background())
 	if err != nil {
-		t.Errorf("LoadProject() failed: %v", err)
+		t.Fatalf("LoadProject() failed: %v", err)
 	}
 
 	if len(project.ComposeFiles) != 1 {

--- a/src/pkg/cli/compose/convert_test.go
+++ b/src/pkg/cli/compose/convert_test.go
@@ -149,7 +149,7 @@ func TestConvertPort(t *testing.T) {
 
 func TestConvert(t *testing.T) {
 	testRunCompose(t, func(t *testing.T, path string) {
-		loader := NewLoaderWithPath(path)
+		loader := newLoaderWithPath(t, path)
 		proj, err := loader.LoadProject(context.Background())
 		if err != nil {
 			t.Fatal(err)

--- a/src/pkg/cli/compose/loader.go
+++ b/src/pkg/cli/compose/loader.go
@@ -40,11 +40,11 @@ func NewLoaderWithOptions(options LoaderOptions) Loader {
 }
 
 func NewLoaderWithPath(path string) Loader {
-	configPaths := []string{}
+	options := LoaderOptions{}
 	if path != "" {
-		configPaths = append(configPaths, path)
+		options.ConfigPaths = []string{path}
 	}
-	return NewLoaderWithOptions(LoaderOptions{ConfigPaths: configPaths})
+	return NewLoaderWithOptions(options)
 }
 
 func (c Loader) LoadProjectName(ctx context.Context) (string, error) {

--- a/src/pkg/cli/compose/loader_test.go
+++ b/src/pkg/cli/compose/loader_test.go
@@ -14,9 +14,15 @@ import (
 	"github.com/hexops/gotextdiff/span"
 )
 
+func newLoaderWithPath(t *testing.T, path string) Loader {
+	t.Setenv("FROM_ENV", "exposed-from-env")
+	options := LoaderOptions{ConfigPaths: []string{path}, ExposedEnv: []string{"FROM_ENV"}}
+	return NewLoaderWithOptions(options)
+}
+
 func TestLoader(t *testing.T) {
 	testRunCompose(t, func(t *testing.T, path string) {
-		loader := NewLoaderWithPath(path)
+		loader := newLoaderWithPath(t, path)
 		proj, err := loader.LoadProject(context.Background())
 		if err != nil {
 			t.Fatal(err)

--- a/src/pkg/cli/compose/validation_test.go
+++ b/src/pkg/cli/compose/validation_test.go
@@ -22,8 +22,7 @@ func TestValidationAndConvert(t *testing.T) {
 		logs := new(bytes.Buffer)
 		term.DefaultTerm = term.NewTerm(logs, logs)
 
-		options := LoaderOptions{ConfigPaths: []string{path}}
-		loader := Loader{options: options}
+		loader := newLoaderWithPath(t, path)
 		proj, err := loader.LoadProject(context.Background())
 		if err != nil {
 			t.Fatal(err)

--- a/src/tests/fromenv/compose.yaml
+++ b/src/tests/fromenv/compose.yaml
@@ -1,0 +1,5 @@
+services:
+  fromenv:
+    image: alpine
+    environment:
+      - FROM_ENV

--- a/src/tests/fromenv/compose.yaml.convert
+++ b/src/tests/fromenv/compose.yaml.convert
@@ -1,0 +1,12 @@
+[
+  {
+    "name": "fromenv",
+    "image": "alpine",
+    "platform": 2,
+    "internal": true,
+    "environment": {
+      "FROM_ENV": "exposed-from-env"
+    },
+    "networks": 1
+  }
+]

--- a/src/tests/fromenv/compose.yaml.golden
+++ b/src/tests/fromenv/compose.yaml.golden
@@ -1,0 +1,11 @@
+name: fromenv
+services:
+  fromenv:
+    environment:
+      FROM_ENV: exposed-from-env
+    image: alpine
+    networks:
+      default: null
+networks:
+  default:
+    name: fromenv_default

--- a/src/tests/fromenv/compose.yaml.warnings
+++ b/src/tests/fromenv/compose.yaml.warnings
@@ -1,0 +1,2 @@
+ ! service "fromenv": missing compose directive: restart; assuming 'unless-stopped' (add 'restart' to silence)
+ ! service "fromenv": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors


### PR DESCRIPTION
Adding `--env` (short `-e`) to expose OS env to the Compose loader, eg. for interpolation.
```yaml
services:
  service1:
    image: alpine
    environment:
      - API_KEY
```

Could be overridden during "up" by doing:

```
defang compose up -e API_KEY
```

This is similar to `docker run -e …`, though `docker compose` offers no such flag.