### PR TITLE
Jordan/tail job column

### DIFF
--- a/src/pkg/cli/tail.go
+++ b/src/pkg/cli/tail.go
@@ -287,12 +287,13 @@ func tail(ctx context.Context, client client.Client, params TailOptions) error {
 		}
 
 		for _, e := range msg.Entries {
+			job := valueOrDefault(e.Job, "")
 			service := valueOrDefault(e.Service, msg.Service)
 			host := valueOrDefault(e.Host, msg.Host)
 			etag := valueOrDefault(e.Etag, msg.Etag)
 
 			// HACK: skip noisy CI/CD logs (except errors)
-			isInternal := service == "cd" || service == "ci" || service == "kaniko" || service == "fabric" || host == "kaniko" || host == "fabric"
+			isInternal := service == "cd" || service == "ci" || service == "kaniko" || service == "fabric" || job == "kaniko" || job == "fabric"
 			onlyErrors := !DoVerbose && isInternal
 			if onlyErrors && !e.Stderr {
 				if params.EndEventDetectFunc != nil && params.EndEventDetectFunc([]string{service}, host, e.Message) {
@@ -341,6 +342,10 @@ func tail(ctx context.Context, client client.Client, params TailOptions) error {
 					prefixLen, _ = buf.Printc(tsColor, tsString, " ")
 					if params.Etag == "" {
 						l, _ := buf.Printc(termenv.ANSIYellow, etag, " ")
+						prefixLen += l
+					}
+					if DoVerbose {
+						l, _ := buf.Printc(termenv.ANSIMagenta, job, " ")
 						prefixLen += l
 					}
 					if len(params.Services) == 0 {

--- a/src/pkg/cli/tail_test.go
+++ b/src/pkg/cli/tail_test.go
@@ -92,18 +92,18 @@ func TestTail(t *testing.T) {
 		ServerStream: &client.MockServerStream{
 			Resps: []*defangv1.TailResponse{
 				{Service: "service1", Etag: "SOMEETAG", Host: "SOMEHOST", Entries: []*defangv1.LogEntry{
-					{Message: "e1msg1", Timestamp: timestamppb.New(time.Now())},
-					{Message: "e1msg2", Timestamp: timestamppb.New(time.Now()), Etag: "SOMEOTHERETAG"},                                              // Test event etag override the response etag
-					{Message: "e1msg3", Timestamp: timestamppb.New(time.Now()), Etag: "SOMEOTHERETAG2", Host: "SOMEOTHERHOST"},                      // override both etag and host
-					{Message: "e1msg4", Timestamp: timestamppb.New(time.Now()), Etag: "SOMEOTHERETAG2", Host: "SOMEOTHERHOST", Service: "service2"}, // override both etag, host and service
-					{Message: "e1err1", Timestamp: timestamppb.New(time.Now()), Stderr: true},                                                       // Error message should be in stdout too when not raw
+					{Message: "e1msg1", Timestamp: timestamppb.New(time.Now()), Job: "job1"},                                                                     // Test default values
+					{Message: "e1msg2", Timestamp: timestamppb.New(time.Now()), Job: "job1", Etag: "SOMEOTHERETAG"},                                              // Test event etag override the response etag
+					{Message: "e1msg3", Timestamp: timestamppb.New(time.Now()), Job: "job1", Etag: "SOMEOTHERETAG2", Host: "SOMEOTHERHOST"},                      // override both etag and host
+					{Message: "e1msg4", Timestamp: timestamppb.New(time.Now()), Job: "job1", Etag: "SOMEOTHERETAG2", Host: "SOMEOTHERHOST", Service: "service2"}, // override both etag, host and service
+					{Message: "e1err1", Timestamp: timestamppb.New(time.Now()), Job: "job1", Stderr: true},                                                       // Error message should be in stdout too when not raw
 				}},
 				{Service: "service1", Etag: "SOMEETAG", Host: "SOMEHOST", Entries: []*defangv1.LogEntry{ // Test entry etag does not affect the default values from response
-					{Message: "e2err1", Timestamp: timestamppb.New(time.Now()), Stderr: true, Etag: "SOMEOTHERETAG"}, // Error message should be in stdout too when not raw
-					{Message: "e2msg1", Timestamp: timestamppb.New(time.Now()), Etag: "ENTRIES2ETAG"},
-					{Message: "e2msg2", Timestamp: timestamppb.New(time.Now())},
-					{Message: "e2msg3", Timestamp: timestamppb.New(time.Now()), Etag: "SOMEOTHERETAG2", Host: "SOMEOTHERHOST", Service: "service2"}, // override both etag, host and service
-					{Message: "e2msg4", Timestamp: timestamppb.New(time.Now())},
+					{Message: "e2err1", Timestamp: timestamppb.New(time.Now()), Job: "job1", Stderr: true, Etag: "SOMEOTHERETAG"}, // Error message should be in stdout too when not raw
+					{Message: "e2msg1", Timestamp: timestamppb.New(time.Now()), Job: "job1", Etag: "ENTRIES2ETAG"},
+					{Message: "e2msg2", Timestamp: timestamppb.New(time.Now()), Job: "job1"},
+					{Message: "e2msg3", Timestamp: timestamppb.New(time.Now()), Job: "job1", Etag: "SOMEOTHERETAG2", Host: "SOMEOTHERHOST", Service: "service2"}, // override both etag, host and service
+					{Message: "e2msg4", Timestamp: timestamppb.New(time.Now()), Job: "job1"},
 				}},
 			},
 		},
@@ -112,16 +112,16 @@ func TestTail(t *testing.T) {
 	Tail(ctx, c, TailOptions{})
 
 	expectedLogs := []string{
-		"SOMEETAG service1 SOMEHOST e1msg1",
-		"SOMEOTHERETAG service1 SOMEHOST e1msg2",
-		"SOMEOTHERETAG2 service1 SOMEOTHERHOST e1msg3",
-		"SOMEOTHERETAG2 service2 SOMEOTHERHOST e1msg4",
-		"SOMEETAG service1 SOMEHOST e1err1",
-		"SOMEOTHERETAG service1 SOMEHOST e2err1",
-		"ENTRIES2ETAG service1 SOMEHOST e2msg1",
-		"SOMEETAG service1 SOMEHOST e2msg2",
-		"SOMEOTHERETAG2 service2 SOMEOTHERHOST e2msg3",
-		"SOMEETAG service1 SOMEHOST e2msg4",
+		"SOMEETAG job1 service1 SOMEHOST e1msg1",
+		"SOMEOTHERETAG job1 service1 SOMEHOST e1msg2",
+		"SOMEOTHERETAG2 job1 service1 SOMEOTHERHOST e1msg3",
+		"SOMEOTHERETAG2 job1 service2 SOMEOTHERHOST e1msg4",
+		"SOMEETAG job1 service1 SOMEHOST e1err1",
+		"SOMEOTHERETAG job1 service1 SOMEHOST e2err1",
+		"ENTRIES2ETAG job1 service1 SOMEHOST e2msg1",
+		"SOMEETAG job1 service1 SOMEHOST e2msg2",
+		"SOMEOTHERETAG2 job1 service2 SOMEOTHERHOST e2msg3",
+		"SOMEETAG job1 service1 SOMEHOST e2msg4",
 	}
 
 	got := strings.Split(strings.TrimRight(stdout.String(), "\n"), "\n")


### PR DESCRIPTION
Follow up to #683 
Depends on https://github.com/DefangLabs/defang-mvp/pull/1016

Merge those first.

Fixes #426

Print a new `job` column in the tail output when verbose mode is enabled.