### PR TITLE
Increase build context warning limit to 100

### DIFF
--- a/src/pkg/cli/compose/context.go
+++ b/src/pkg/cli/compose/context.go
@@ -33,7 +33,7 @@ const (
 
 const (
 	MiB                 = 1024 * 1024
-	ContextFileLimit    = 10
+	ContextFileLimit    = 100
 	ContextSizeLimit    = 10 * MiB
 	sourceDateEpoch     = 315532800 // 1980-01-01, same as nix-shell
 	defaultDockerIgnore = `# Default .dockerignore file for Defang


### PR DESCRIPTION
I saw this warning while deploying the rails sample today, which is just under 100 files in the docker build context (after applying the ignore rules). It's a pretty small stock rails app, so lots of files, but also completely reasonable.

I think this warning adds more friction than value at this low limit. I propose we increase it to 100, which will get us out of the way for many legitimate use-cases while still catching problematic scenarios.