### PR TITLE
add link to invalid healthcheck error

### DIFF
--- a/src/pkg/quota/service.go
+++ b/src/pkg/quota/service.go
@@ -71,12 +71,12 @@ func (q ServiceQuotas) Validate(service *defangv1.Service) error {
 					}
 				}
 				if !hasLocalhostUrl {
-					return errors.New("invalid healthcheck: ingress ports require an HTTP healthcheck on `localhost`")
+					return errors.New("invalid healthcheck: ingress ports require an HTTP healthcheck on `localhost`, see https://s.defang.io/healthchecks")
 				}
 			}
 		case "NONE": // OK iff there are no ingress ports
 			if hasIngress {
-				return fmt.Errorf("invalid healthcheck: ingress ports require a CMD or CMD-SHELL healthcheck")
+				return fmt.Errorf("invalid healthcheck: ingress ports require a CMD or CMD-SHELL healthcheck, see https://s.defang.io/healthchecks")
 			}
 		default:
 			return fmt.Errorf("unsupported healthcheck: %v", service.Healthcheck.Test) // this will have been caught by compose-go

--- a/src/pkg/quota/service_test.go
+++ b/src/pkg/quota/service_test.go
@@ -75,7 +75,7 @@ func TestValidate(t *testing.T) {
 					Test: []string{"CMD", "echo 1"},
 				},
 			},
-			wantErr: "invalid healthcheck: ingress ports require an HTTP healthcheck on `localhost`",
+			wantErr: "invalid healthcheck: ingress ports require an HTTP healthcheck on `localhost`, see https://s.defang.io/healthchecks",
 		},
 		{
 			name: "CMD without curl or wget",
@@ -87,7 +87,7 @@ func TestValidate(t *testing.T) {
 					Test: []string{"CMD", "echo", "1"},
 				},
 			},
-			wantErr: "invalid healthcheck: ingress ports require an HTTP healthcheck on `localhost`",
+			wantErr: "invalid healthcheck: ingress ports require an HTTP healthcheck on `localhost`, see https://s.defang.io/healthchecks",
 		},
 		{
 			name: "CMD without HTTP URL",
@@ -99,7 +99,7 @@ func TestValidate(t *testing.T) {
 					Test: []string{"CMD", "curl", "1"},
 				},
 			},
-			wantErr: "invalid healthcheck: ingress ports require an HTTP healthcheck on `localhost`",
+			wantErr: "invalid healthcheck: ingress ports require an HTTP healthcheck on `localhost`, see https://s.defang.io/healthchecks",
 		},
 		{
 			name: "NONE with arguments",
@@ -122,7 +122,7 @@ func TestValidate(t *testing.T) {
 					Test: []string{"CMD-SHELL", "echo 1"},
 				},
 			},
-			wantErr: "invalid healthcheck: ingress ports require an HTTP healthcheck on `localhost`",
+			wantErr: "invalid healthcheck: ingress ports require an HTTP healthcheck on `localhost`, see https://s.defang.io/healthchecks",
 		},
 		{
 			name: "NONE with ingress",
@@ -134,7 +134,7 @@ func TestValidate(t *testing.T) {
 					Test: []string{"NONE"},
 				},
 			},
-			wantErr: "invalid healthcheck: ingress ports require a CMD or CMD-SHELL healthcheck",
+			wantErr: "invalid healthcheck: ingress ports require a CMD or CMD-SHELL healthcheck, see https://s.defang.io/healthchecks",
 		},
 		{
 			name: "unsupported healthcheck test",


### PR DESCRIPTION
Fixed https://github.com/DefangLabs/defang/issues/668

The solution to this error is too complex to describe inline. Add a link to a docs page with more information.

**Todo**:

- [x] Add redirect entry for `https://s.defang.io/healthchecks` -> `https://docs.defang.io/docs/faq#invalid-healthcheck-ingress-ports-require-an-http-healthcheck-on-localhost` (https://github.com/DefangLabs/s.defang.io/pull/12)