### PR TITLE
Don't show debugger on Ctrl-C

### DIFF
--- a/src/cmd/cli/command/commands.go
+++ b/src/cmd/cli/command/commands.go
@@ -85,8 +85,12 @@ func Execute(ctx context.Context) error {
 			printDefangHint("To manage sensitive service config, use:", "config")
 		}
 
-		if err.Error() == "resource_exhausted: maximum number of projects reached" {
-			printDefangHint("To deactivate a project, do:", "compose down --project-name <name>")
+		if strings.Contains(err.Error(), "maximum number of projects") {
+			projectName := "<name>"
+			if resp, err := client.GetServices(ctx); err == nil {
+				projectName = resp.Project
+			}
+			printDefangHint("To deactivate a project, do:", "compose down --project-name "+projectName)
 		}
 
 		var cerr *cli.CancelError
@@ -99,7 +103,7 @@ func Execute(ctx context.Context) error {
 			// All AWS errors are wrapped in OperationError
 			var oe *smithy.OperationError
 			if errors.As(err, &oe) {
-				fmt.Println("Could not authenticate to the AWS service. Please check your aws credentials and try again.")
+				fmt.Println("Could not authenticate to the AWS service. Please check your AWS credentials and try again.")
 			} else {
 				printDefangHint("Please use the following command to log in:", "login")
 			}

--- a/src/pkg/cli/compose/compose_test.go
+++ b/src/pkg/cli/compose/compose_test.go
@@ -43,7 +43,7 @@ func TestLoadProjectName(t *testing.T) {
 		}
 	})
 
-	t.Run("--project-name has precidence over COMPOSE_PROJECT_NAME env var", func(t *testing.T) {
+	t.Run("--project-name has precedence over COMPOSE_PROJECT_NAME env var", func(t *testing.T) {
 		t.Setenv("COMPOSE_PROJECT_NAME", "ignoreme")
 		options := LoaderOptions{ProjectName: "expectedname"}
 		loader := NewLoaderWithOptions(options)

--- a/src/pkg/clouds/aws/ecs/logs.go
+++ b/src/pkg/clouds/aws/ecs/logs.go
@@ -235,7 +235,7 @@ func GetTaskStatus(ctx context.Context, taskArn TaskArn) error {
 	return getTaskStatus(ctx, region, cluster, taskID)
 }
 
-func isTaskTerminalState(status string) bool {
+func isTaskTerminalStatus(status string) bool {
 	// From https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-lifecycle-explanation.html
 	switch status {
 	case "DELETED", "STOPPED", "DEPROVISIONING":
@@ -261,7 +261,7 @@ func getTaskStatus(ctx context.Context, region aws.Region, cluster, taskId strin
 		return nil // task doesn't exist yet; TODO: check the actual error from DescribeTasks
 	}
 	task := ti.Tasks[0]
-	if task.LastStatus == nil || !isTaskTerminalState(*task.LastStatus) {
+	if task.LastStatus == nil || !isTaskTerminalStatus(*task.LastStatus) {
 		return nil // still running
 	}
 


### PR DESCRIPTION
The AI debugger got some false-negatives, because users get prompted to use the debugger when they "cancel" the tail that follows a `compose up`, even though there are no reasons to debug. 