### PR TITLE
Revert "Stop the cli when CD task fails during deployment"

### DIFF
--- a/src/pkg/cli/client/byoc/aws/byoc.go
+++ b/src/pkg/cli/client/byoc/aws/byoc.go
@@ -468,13 +468,21 @@ func (b *ByocAws) Follow(ctx context.Context, req *defangv1.TailRequest) (client
 	var err error
 	var taskArn ecs.TaskArn
 	var eventStream ecs.EventStream
-	stopWhenCDTaskDone := false
-	if etag != "" && !pkg.IsValidRandomID(etag) { // Assume invalid "etag" is a task ID
+	if etag != "" && !pkg.IsValidRandomID(etag) {
+		// Assume "etag" is a task ID
 		eventStream, err = b.driver.TailTaskID(ctx, etag)
 		taskArn, _ = b.driver.GetTaskArn(etag)
 		term.Debugf("Tailing task %s", *taskArn)
 		etag = "" // no need to filter by etag
-		stopWhenCDTaskDone = true
+
+		var cancel context.CancelCauseFunc
+		ctx, cancel = context.WithCancelCause(ctx)
+		go func() {
+			if err := ecs.WaitForTask(ctx, taskArn, 3*time.Second); err != nil {
+				time.Sleep(time.Second) // make sure we got all the logs from the task before cancelling
+				cancel(err)
+			}
+		}()
 	} else {
 		// Tail CD, kaniko, and all services (this requires ProjectName to be set)
 		kanikoTail := ecs.LogGroupInput{LogGroupARN: b.driver.MakeARN("logs", "log-group:"+b.stackDir("builds"))} // must match logic in ecs/common.ts
@@ -495,16 +503,6 @@ func (b *ByocAws) Follow(ctx context.Context, req *defangv1.TailRequest) (client
 	if err != nil {
 		return nil, annotateAwsError(err)
 	}
-	var cancel context.CancelCauseFunc
-	ctx, cancel = context.WithCancelCause(ctx)
-	go func() {
-		if err := ecs.WaitForTask(ctx, taskArn, 3*time.Second); err != nil {
-			if stopWhenCDTaskDone || errors.As(err, &ecs.TaskFailure{}) {
-				time.Sleep(time.Second) // make sure we got all the logs from the task before cancelling
-				cancel(err)
-			}
-		}
-	}()
 
 	return newByocServerStream(ctx, eventStream, etag, req.GetServices(), b), nil
 }

--- a/src/pkg/clouds/aws/ecs/logs.go
+++ b/src/pkg/clouds/aws/ecs/logs.go
@@ -267,12 +267,12 @@ func getTaskStatus(ctx context.Context, region aws.Region, cluster, taskId strin
 
 	switch task.StopCode {
 	default:
-		return TaskFailure{string(task.StopCode), *task.StoppedReason}
+		return taskFailure{string(task.StopCode), *task.StoppedReason}
 	case ecsTypes.TaskStopCodeEssentialContainerExited:
 		for _, c := range task.Containers {
 			if c.ExitCode != nil && *c.ExitCode != 0 {
 				reason := fmt.Sprintf("%s with code %d", *task.StoppedReason, *c.ExitCode)
-				return TaskFailure{string(task.StopCode), reason}
+				return taskFailure{string(task.StopCode), reason}
 			}
 		}
 		fallthrough

--- a/src/pkg/clouds/aws/ecs/run.go
+++ b/src/pkg/clouds/aws/ecs/run.go
@@ -101,7 +101,7 @@ func (a *AwsEcs) Run(ctx context.Context, env map[string]string, cmd ...string) 
 	}
 	failures := make([]error, len(ecsOutput.Failures))
 	for i, f := range ecsOutput.Failures {
-		failures[i] = TaskFailure{*f.Reason, *f.Detail}
+		failures[i] = taskFailure{*f.Reason, *f.Detail}
 	}
 	if err := errors.Join(failures...); err != nil || len(ecsOutput.Tasks) == 0 {
 		return nil, err
@@ -140,12 +140,12 @@ func getSubnetVPCId(ctx context.Context, cfg aws.Config, subnetId string) (strin
 	return *subnetsOutput.Subnets[0].VpcId, nil // TODO: make configurable/deterministic
 }
 
-type TaskFailure struct {
+type taskFailure struct {
 	Reason string
 	Detail string
 }
 
-func (t TaskFailure) Error() string {
+func (t taskFailure) Error() string {
 	return t.Reason + ": " + t.Detail
 }
 


### PR DESCRIPTION
Reverts DefangLabs/defang#690

This caused a panic:
```
panic: taskArn is nil

goroutine 183 [running]:
github.com/DefangLabs/defang/src/pkg/clouds/aws/ecs.WaitForTask({0x101cc6e60?, 0x140003aae60?}, 0x0?, 0xb2d05e00?)
	/Users/llunesu/dev/defang/src/pkg/clouds/aws/ecs/logs.go:439 +0x148
github.com/DefangLabs/defang/src/pkg/cli/client/byoc/aws.(*ByocAws).Follow.func1()
	/Users/llunesu/dev/defang/src/pkg/cli/client/byoc/aws/byoc.go:501 +0x40
created by github.com/DefangLabs/defang/src/pkg/cli/client/byoc/aws.(*ByocAws).Follow in goroutine 1
	/Users/llunesu/dev/defang/src/pkg/cli/client/byoc/aws/byoc.go:500 +0x774
```

The right fix is to have BYOC `Subscribe` check the CD task status (or ECS events) in addition to the services.