### PR TITLE
Send a deployment failure event to subscribe call when CD task fails in byoc

### DIFF
--- a/src/pkg/cli/client/byoc/aws/byoc.go
+++ b/src/pkg/cli/client/byoc/aws/byoc.go
@@ -308,6 +308,10 @@ func (b *ByocAws) GetService(ctx context.Context, s *defangv1.ServiceID) (*defan
 	return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("service %q not found", s.Name))
 }
 
+func (b *ByocAws) GetCDTaskArn(etag string) ecs.TaskArn {
+	return b.cdTasks[etag]
+}
+
 func (b *ByocAws) bucketName() string {
 	return pkg.Getenv("DEFANG_CD_BUCKET", b.driver.BucketName)
 }
@@ -785,6 +789,10 @@ func ensure(cond bool, msg string) {
 
 type ECSEventHandler interface {
 	HandleECSEvent(evt ecs.Event)
+}
+
+type CDTaskArnProvider interface {
+	GetCDTaskArn(etag string) ecs.TaskArn
 }
 
 func (b *ByocAws) Subscribe(ctx context.Context, req *defangv1.SubscribeRequest) (client.ServerStream[defangv1.SubscribeResponse], error) {

--- a/src/pkg/cli/client/byoc/aws/subscribe.go
+++ b/src/pkg/cli/client/byoc/aws/subscribe.go
@@ -28,7 +28,7 @@ func (s *byocSubscribeServerStream) HandleECSEvent(evt ecs.Event) {
 	if etag := evt.Etag(); etag == "" || etag != s.etag {
 		return
 	}
-	if service := evt.Service(); len(s.services) > 0 && !slices.Contains(s.services, service) {
+	if service := evt.Service(); len(s.services) > 0 && !slices.Contains(s.services, service) && service != "cd" {
 		return
 	}
 	s.send(&defangv1.SubscribeResponse{

--- a/src/pkg/cli/subscribe.go
+++ b/src/pkg/cli/subscribe.go
@@ -60,7 +60,7 @@ func WaitServiceState(ctx context.Context, client client.Client, targetState def
 
 		term.Debugf("service %s with state ( %s ) and status: %s\n", msg.Name, msg.State, msg.Status) // TODO: don't print in Go-routine
 
-		if _, ok := serviceStates[msg.Name]; !ok {
+		if _, ok := serviceStates[msg.Name]; !ok && msg.Name != "cd" {
 			term.Debugf("unexpected service %s update", msg.Name) // TODO: don't print in Go-routine
 			continue
 		}
@@ -71,7 +71,9 @@ func WaitServiceState(ctx context.Context, client client.Client, targetState def
 			return ErrDeploymentFailed{msg.Name}
 		}
 
-		serviceStates[msg.Name] = msg.State
+		if msg.Name != "cd" {
+			serviceStates[msg.Name] = msg.State
+		}
 
 		if allInState(targetState, serviceStates) {
 			return nil // all services are in the target state


### PR DESCRIPTION
Prevents cli kept running when cd task exits with error. Fixes https://github.com/DefangLabs/defang-mvp/issues/747

Test run output
```
2024-09-25T13:34:17.548000-07:00 cd pulumi Duration: 8s
2024-09-25T13:34:18.144000-07:00 cd pulumi  ** CommandError
2024-09-25T13:35:56.762000-07:00 cd pulumi Timeout waiting for children to exit, exiting
 - CD task arn:aws:ecs:us-west-2:381492210770:task/defang-cd-Cluster-pJqFhjwuklvm/dc5830e38a7f4997831d84246a789830 has stopped: UserInitiated: Task stopped by user
 - service cd with state ( DEPLOYMENT_FAILED ) and status: UserInitiated: Task stopped by user
 - Tail failed with deployment failed for service "cd"
 ! deployment failed for service "cd"
Error: deployment failed for service "cd"
```