### PR TITLE
Added warning when published and target port are different

### DIFF
--- a/src/pkg/cli/compose/convert_test.go
+++ b/src/pkg/cli/compose/convert_test.go
@@ -70,14 +70,14 @@ func TestConvertPort(t *testing.T) {
 			expected: &defangv1.Port{Target: 1234, Mode: defangv1.Mode_HOST},
 		},
 		{
-			name:    "Host mode and protocol, published range xfail",
-			input:   types.ServicePortConfig{Mode: "host", Target: 1234, Published: "1511-2222"},
-			wantErr: "port 1234: 'published' range must include 'target': 1511-2222",
+			name:     "Host mode and protocol, published range xfail",
+			input:    types.ServicePortConfig{Mode: "host", Target: 1234, Published: "1511-2222"},
+			expected: &defangv1.Port{Target: 1234, Mode: defangv1.Mode_HOST},
 		},
 		{
-			name:    "Host mode and protocol, published range xfail",
-			input:   types.ServicePortConfig{Mode: "host", Target: 1234, Published: "22222"},
-			wantErr: "port 1234: 'published' must be empty or equal to 'target': 22222",
+			name:     "Host mode and protocol, published not equals target",
+			input:    types.ServicePortConfig{Mode: "host", Target: 1234, Published: "22222"},
+			expected: &defangv1.Port{Target: 1234, Mode: defangv1.Mode_HOST},
 		},
 		{
 			name:     "Host mode and protocol, target in published range",

--- a/src/pkg/cli/compose/validation.go
+++ b/src/pkg/cli/compose/validation.go
@@ -325,26 +325,23 @@ func validatePort(port compose.ServicePortConfig) error {
 	if !validModes[port.Mode] {
 		return fmt.Errorf("port %d: 'mode' not one of [host ingress]: %v", port.Target, port.Mode)
 	}
-	if port.Published != "" && (port.Mode == "host" || port.Protocol == "udp") {
+	if port.Published != "" {
 		portRange := strings.SplitN(port.Published, "-", 2)
 		start, err := strconv.ParseUint(portRange[0], 10, 16)
 		if err != nil {
-			return fmt.Errorf("port %d: 'published' start must be an integer: %v", port.Target, portRange[0])
-		}
-		if len(portRange) == 2 {
+			term.Warnf("port %d: 'published' range start should be an integer; ignoring 'published: %v'", port.Target, portRange[0])
+		} else if len(portRange) == 2 {
 			end, err := strconv.ParseUint(portRange[1], 10, 16)
 			if err != nil {
-				return fmt.Errorf("port %d: 'published' end must be an integer: %v", port.Target, portRange[1])
-			}
-			if start > end {
-				return fmt.Errorf("port %d: 'published' start must be less than end: %v", port.Target, port.Published)
-			}
-			if port.Target < uint32(start) || port.Target > uint32(end) {
-				return fmt.Errorf("port %d: 'published' range must include 'target': %v", port.Target, port.Published)
+				term.Warnf("port %d: 'published' range end should be an integer; ignoring 'published: %v'", port.Target, portRange[1])
+			} else if start > end {
+				term.Warnf("port %d: 'published' range start should be less than end; ignoring 'published: %v'", port.Target, port.Published)
+			} else if port.Target < uint32(start) || port.Target > uint32(end) {
+				term.Warnf("port %d: 'published' range should include 'target'; ignoring 'published: %v'", port.Target, port.Published)
 			}
 		} else {
 			if start != uint64(port.Target) {
-				return fmt.Errorf("port %d: 'published' must be empty or equal to 'target': %v", port.Target, port.Published)
+				term.Warnf("port %d: 'published' should be equal to 'target'; ignoring 'published: %v'", port.Target, port.Published)
 			}
 		}
 	}

--- a/src/tests/ports/compose.yaml.warnings
+++ b/src/tests/ports/compose.yaml.warnings
@@ -1,4 +1,7 @@
+ ! port 81: 'published' should be equal to 'target'; ignoring 'published: 8081'
+ ! port 83: 'published' should be equal to 'target'; ignoring 'published: 8083'
  ! port 84: UDP ports default to 'host' mode (add 'mode: host' to silence)
+ ! port 85: 'published' should be equal to 'target'; ignoring 'published: 8085'
  ! port 85: UDP ports default to 'host' mode (add 'mode: host' to silence)
  ! service "long": ingress port without healthcheck defaults to GET / HTTP/1.1
  ! service "long": missing compose directive: restart; assuming 'unless-stopped' (add 'restart' to silence)
@@ -15,5 +18,6 @@
  ! service "short-udp": ingress port without healthcheck defaults to GET / HTTP/1.1
  ! service "short-udp": missing compose directive: restart; assuming 'unless-stopped' (add 'restart' to silence)
  ! service "short-udp": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors
+ ! service "short-udp-published": ingress port without healthcheck defaults to GET / HTTP/1.1
  ! service "short-udp-published": missing compose directive: restart; assuming 'unless-stopped' (add 'restart' to silence)
-port 85: 'published' must be empty or equal to 'target': 8085
+ ! service "short-udp-published": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors


### PR DESCRIPTION
Fixes #700 

Details below:
- Revised port matching validation 
   - Gives warnings when `published` and `target` ports are different or out of range
   - Applies to all `published` port types rather than only `host` or `udp` 
   - Some errors are now terminal warnings; tests are changed to account for this
- Fixed an incorrect naming for a test in `convert_test.go` 