### PR TITLE
feat: change terminal time stamp color from bug bright red to improve readibility

### DIFF
--- a/src/pkg/cli/tail.go
+++ b/src/pkg/cli/tail.go
@@ -331,7 +331,7 @@ func tail(ctx context.Context, client client.Client, params TailOptions) error {
 				tsColor = termenv.ANSIWhite
 			}
 			if e.Stderr {
-				tsColor = termenv.ANSIBrightRed
+				tsColor = termenv.ansiCyan
 			}
 			var prefixLen int
 			trimmed := strings.TrimRight(e.Message, "\t\r\n ")


### PR DESCRIPTION
## Pull Request Type

Dictionary of Definitions here:
https://ben.balter.com/2015/12/08/types-of-pull-requests/

- [] Just a heads up 🙆
- [ ] Sanity check 🏃‍♂️
- [ ] Work in progress (WIP) 🏗️
- [ ] Early feedback ✍️
- [x] Line-by-line review 📝
- [ ] Pull request to a pull request 🔀

## Description

The terminal color change should improve Readability, reduced Confusion via by avoiding the use of red for timestamps, we can minimize the risk of false positives and streamline the debugging process, and overall abide by terminal UX best practices from what I understand about the objective of the time stamp purpose in the defang project.

This PR addresses this Github issue: https://github.com/DefangLabs/defang/issues/707

#### Caveats/Notes (optional)

I was not able to fully test the terminal UI as I did not run this specific defang version. Instructions on how to best run a local emulated version from VS code would be fantastic too! 

#### Prompts (optional)

### Screenshots (optional)

[Upload optional screenshots]

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] Extended the README / documentation, if necessary
- [x] My changes generate no new warnings
- [x] Is the code readable? Prefer to see more self-explanatory and consistency
- [ ] Is the code tested properly? i.e. where appropriate, we're testing well-explained failures, behaviours, fixes, etc

