### PR TITLE
Fix for AWS BYOC empty WorkingDirectory

### DIFF
--- a/src/pkg/clouds/aws/ecs/cfn/template.go
+++ b/src/pkg/clouds/aws/ecs/cfn/template.go
@@ -395,12 +395,14 @@ func createTemplate(stack string, containers []types.Container, overrides Templa
 					"awslogs-stream-prefix": awsecs.AwsLogsStreamPrefix,
 				},
 			},
-			VolumesFrom:      volumesFrom,
-			MountPoints:      mountPoints,
-			EntryPoint:       container.EntryPoint,
-			Command:          container.Command,
-			WorkingDirectory: &container.WorkDir,
-			DependsOnProp:    dependsOn,
+			VolumesFrom:   volumesFrom,
+			MountPoints:   mountPoints,
+			EntryPoint:    container.EntryPoint,
+			Command:       container.Command,
+			DependsOnProp: dependsOn,
+		}
+		if container.WorkDir != "" {
+			def.WorkingDirectory = ptr.String(container.WorkDir)
 		}
 		containerDefinitions = append(containerDefinitions, def)
 	}


### PR DESCRIPTION
Regression from #594 (probably me)

```
Resource handler returned message: "Invalid request provided: Create TaskDefinition: workingDirectory should be at least 1 characters long. (Service: AmazonECS; Status Code: 400; Error Code: ClientException; Request ID: fed3bca4-6f8c-44e5-bcd0-752d40d941b6; Proxy: null)" (RequestToken: 918aaba1-1fa7-79cb-2133-49178aa8263d, HandlerErrorCode: InvalidRequest)
```