### PR TITLE
Shorten panic stack to avoid trunca

### DIFF
--- a/src/cmd/cli/main.go
+++ b/src/cmd/cli/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"os"
 	"os/signal"
@@ -13,7 +14,7 @@ import (
 func main() {
 	defer func() {
 		if r := recover(); r != nil {
-			command.Track("Panic", command.P{"error", r}, command.P{"stack", string(debug.Stack())})
+			command.Track("Panic", command.P{"error", r}, command.P{"stack", string(skipLines(debug.Stack(), 6))})
 			command.FlushAllTracking()
 			panic(r)
 		}
@@ -44,4 +45,10 @@ func main() {
 		}
 		os.Exit(int(ec))
 	}
+}
+
+// skipLines returns buf with the first n lines removed.
+func skipLines(buf []byte, n int) []byte {
+	lines := bytes.SplitN(buf, []byte{'\n'}, n)
+	return lines[len(lines)-1]
 }

--- a/src/cmd/cli/main_test.go
+++ b/src/cmd/cli/main_test.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestSkipLines(t *testing.T) {
+	buf := []byte(`goroutine 1 [running]:
+main.main.func1()
+        /Users/user/dev/defang/src/cmd/cli/main.go:18 +0x100
+panic({0x105f35200?, 0x10670b530?})
+        /nix/store/v8llgr5prc0rawmgynacggg0q4pbvk5w-go-1.21.10/share/go/src/runtime/panic.go:914 +0x218
+github.com/DefangLabs/defang/src/pkg/clouds/do/appPlatform.newClient({0x106729288, 0x10743e240})
+        /Users/user/dev/defang/src/pkg/clouds/do/appPlatform/setup.go:224 +0xb0`)
+
+	expected := []byte(`github.com/DefangLabs/defang/src/pkg/clouds/do/appPlatform.newClient({0x106729288, 0x10743e240})
+        /Users/user/dev/defang/src/pkg/clouds/do/appPlatform/setup.go:224 +0xb0`)
+
+	actual := skipLines(buf, 6)
+	if !bytes.Equal(expected, actual) {
+		t.Errorf("Expected %q, got %q", expected, actual)
+	}
+}


### PR DESCRIPTION
The Panic stacks in Segment/Mixpanel are getting truncated:
```
{
  "event": "Panic",
  "properties": {
    "$identity_failure_reason": "errAnonDistinctIdAssignedAlready",
    "$source": "segment",
    "error": "runtime error: invalid memory address or nil pointer dereference",
    "event_original_name": "Panic",
    "id": "1b57f5d8-1ebf-5c76-8cce-d032ba015e37",
    "segment_source_name": "",
    "stack": "goroutine 1 [running]:\nruntime/debug.Stack()\n\t/opt/homebrew/Cellar/go/1.22.1/libexec/src/runtime/debug/stack.go:24 +0x64\nmain.main.func1()\n\t/Users/kevin/defang/defang/src/cmd/cli/main.go:16 +0x40\npanic({0x103750540?, 0x1049d2810?})\n\t/opt/homebrew/Cellar/g"
  }
}
```