### PR TITLE
Interactive prompt for provider

### DIFF
--- a/src/cmd/cli/command/compose.go
+++ b/src/cmd/cli/command/compose.go
@@ -191,7 +191,7 @@ func makeComposeUpCmd() *cobra.Command {
 	composeUpCmd.Flags().Bool("force", false, "force a build of the image even if nothing has changed")
 	composeUpCmd.Flags().Bool("tail", false, "tail the service logs after updating") // obsolete, but keep for backwards compatibility
 	_ = composeUpCmd.Flags().MarkHidden("tail")
-	composeUpCmd.Flags().VarP(&mode, "mode", "m", "deployment mode, possible values: "+strings.Join(allModes(), ", "))
+	composeUpCmd.Flags().VarP(&mode, "mode", "m", fmt.Sprintf("deployment mode; one of %v", allModes()))
 	composeUpCmd.Flags().Bool("build", true, "build the image before starting the service") // docker-compose compatibility
 	_ = composeUpCmd.Flags().MarkHidden("build")
 	composeUpCmd.Flags().Bool("wait", true, "wait for services to be running|healthy") // docker-compose compatibility

--- a/src/cmd/cli/command/mode.go
+++ b/src/cmd/cli/command/mode.go
@@ -32,7 +32,7 @@ func allModes() []string {
 	modes := make([]string, 0, len(defangv1.DeploymentMode_name)-1)
 	for i, mode := range defangv1.DeploymentMode_name {
 		if i == 0 {
-			continue
+			continue // skip the "unspecified" mode
 		}
 		modes = append(modes, strings.ToLower(mode))
 	}


### PR DESCRIPTION
```
defang compose up    
? Choose a cloud provider:  [Use arrows to move, type to filter, ? for more help]
> defang - The Defang Playground is a free environment for testing only.
  aws - Deploy to AWS using the AWS_* environment variables or the AWS CLI configuration.
  digitalocean - Deploy to DigitalOcean using the DIGITALOCEAN_TOKEN, SPACES_ACCESS_KEY_ID, and SPACES_SECRET_ACCESS_KEY environment variables.
```

WIP. Currently the prompt is shown even if the actual CLI command  doesn't care.