### PR TITLE
Print real error, not missing tail perm

### DIFF
--- a/src/cmd/cli/command/compose.go
+++ b/src/cmd/cli/command/compose.go
@@ -131,6 +131,8 @@ func makeComposeUpCmd() *cobra.Command {
 					// If tail fails because of missing permission, we wait for the deployment to finish
 					term.Warn("Unable to tail logs. Waiting for the deployment to finish.")
 					<-tailCtx.Done()
+					// Get the actual error from the context so we won't print "Error: missing tail permission"
+					err = context.Cause(tailCtx)
 				} else if !errors.Is(tailCtx.Err(), context.Canceled) {
 					return err // any error other than cancelation
 				}


### PR DESCRIPTION
This fixes the red-herring `Error: missing tail permission` in GitHub Action output when the deployment fails because of a build/deployment error.

The CI does not have permission to `tail` so it'll wait for the deployment to succeed or fail, but if the deployment does fail, it ends up printing the "missing tail permission" error and not the error that caused the failure.

From https://discord.com/channels/1233224785450897561/1236397762929627157/1295947226283245601
![image](https://github.com/user-attachments/assets/e763b0ad-f86e-49a8-884e-895dadf6d964)

