### PR TITLE
fix current directory for commands

### DIFF
--- a/src/cmd/cli/command/commands.go
+++ b/src/cmd/cli/command/commands.go
@@ -986,7 +986,9 @@ func configureLoader(cmd *cobra.Command) compose.Loader {
 		panic(err)
 	}
 
-	o.WorkingDir, err = f.GetString("cwd")
+	// the cli changes to the working directory at the start of the command so just set
+	// the current directory as the working directory
+	o.WorkingDir, err = os.Getwd()
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
fixes #647 

cli changes directory to the -C "path" at start of command so do not assume the cwd value in flag passed in is the working directory.