### PR TITLE
remove extraneous workingDir from Loader struct.

### DIFF
--- a/src/cmd/cli/command/commands.go
+++ b/src/cmd/cli/command/commands.go
@@ -582,7 +582,6 @@ var generateCmd = &cobra.Command{
 
 		// Load the project and check for empty environment variables
 		loaderOptions := compose.LoaderOptions{
-			WorkingDir:  prompt.Folder,
 			ConfigPaths: []string{filepath.Join(prompt.Folder, "compose.yaml")},
 		}
 		loader := compose.NewLoaderWithOptions(loaderOptions)

--- a/src/pkg/cli/compose/loader.go
+++ b/src/pkg/cli/compose/loader.go
@@ -20,7 +20,6 @@ import (
 
 type LoaderOptions struct {
 	ConfigPaths []string
-	WorkingDir  string
 	ProjectName string
 }
 


### PR DESCRIPTION
workingDir was removed in #756  as it was interfering with current working directory flag. Cleaning up missed code.