### PR TITLE
Avoid duplicate defang config hints

### DIFF
--- a/src/cmd/cli/command/commands.go
+++ b/src/cmd/cli/command/commands.go
@@ -593,7 +593,7 @@ var generateCmd = &cobra.Command{
 		}
 
 		if len(envInstructions) > 0 {
-			printDefangHint("Check the files in your favorite editor.\nTo deploy the service, do "+cd, envInstructions...)
+			printDefangHint("Check the files in your favorite editor.\nTo configure the service, do "+cd, envInstructions...)
 		} else {
 			printDefangHint("Check the files in your favorite editor.\nTo deploy the service, do "+cd, "compose up")
 		}
@@ -621,7 +621,9 @@ func collectUnsetEnvVars(project *proj.Project) []string {
 			}
 		}
 	}
-	return envVars
+	// Deduplicate by sorting and then compacting (uniq)
+	slices.Sort(envVars)
+	return slices.Compact(envVars)
 }
 
 var getVersionCmd = &cobra.Command{


### PR DESCRIPTION
This fixes the printed hint when a user news a sample with a config used by many services:

```
 * Code generated successfully in folder bullmq-bullboard-redis

Check the files in your favorite editor.
To deploy the service, do `cd bullmq-bullboard-redis` and 

  defang config create QUEUE

  defang config create BOARD_PASSWORD

  defang config create QUEUE

  defang config create QUEUE

For help with warnings, check our FAQ at https://docs.defang.io/docs/faq
```