### PR TITLE
update cert info when no domains found in compose file.

### DIFF
--- a/src/pkg/cli/cert.go
+++ b/src/pkg/cli/cert.go
@@ -102,7 +102,7 @@ func GenerateLetsEncryptCert(ctx context.Context, client cliClient.Client) error
 		}
 	}
 	if cnt == 0 {
-		term.Infof("No HTTPS services found; no TLS cert generation needed")
+		term.Infof("No HTTPS domains found in compose file; no TLS cert generation needed")
 	}
 
 	return nil

--- a/src/pkg/cli/cert.go
+++ b/src/pkg/cli/cert.go
@@ -102,7 +102,7 @@ func GenerateLetsEncryptCert(ctx context.Context, client cliClient.Client) error
 		}
 	}
 	if cnt == 0 {
-		term.Infof("No HTTPS domains found in compose file; no TLS cert generation needed")
+		term.Infof("No `domainname` found in compose file; no HTTPS cert generation needed")
 	}
 
 	return nil


### PR DESCRIPTION
Update text for when there are no domains in the compose files. Make it clear where the issue is.