### PR TITLE
Add CLI version to panic/interrupt

### DIFF
--- a/src/cmd/cli/main.go
+++ b/src/cmd/cli/main.go
@@ -14,7 +14,7 @@ import (
 func main() {
 	defer func() {
 		if r := recover(); r != nil {
-			command.Track("Panic", command.P{"error", r}, command.P{"stack", string(skipLines(debug.Stack(), 6))})
+			command.Track("Panic", command.P{"version", version}, command.P{"error", r}, command.P{"stack", string(skipLines(debug.Stack(), 6))})
 			command.FlushAllTracking()
 			panic(r)
 		}
@@ -29,7 +29,7 @@ func main() {
 		<-sigs
 		signal.Stop(sigs)
 		term.Debug("Received interrupt signal; canceling...")
-		command.Track("User Interrupted")
+		command.Track("User Interrupted", command.P{"version", version})
 		cancel()
 	}()
 


### PR DESCRIPTION
These are not Cobra commands so version property was not added. 
```json
{
  "event": "User Interrupted",
  "properties": {
    "$source": "segment",
    "event_original_name": "User Interrupted",
    "id": "eb5a9180-658d-56cb-9dc6-b6d356b503f4",
    "segment_source_name": ""
  }
}
```