### PR TITLE
Partition Build Logs from Service Logs

### DIFF
--- a/src/pkg/cli/client/byoc/aws/byoc.go
+++ b/src/pkg/cli/client/byoc/aws/byoc.go
@@ -546,7 +546,7 @@ func (b *ByocAws) Follow(ctx context.Context, req *defangv1.TailRequest) (client
 	} else {
 		groups := make([]ecs.LogGroupInput, 0, 4)
 		// tail build or service logs (this requires ProjectName to be set)
-		if req.Type == defangv1.LogType_BUILD {
+		if req.Type == defangv1.LogType_BUILD || req.Type == defangv1.LogType_ALL {
 			// Tail CD and build logs
 			buildTail := ecs.LogGroupInput{LogGroupARN: b.driver.MakeARN("logs", "log-group:"+b.stackDir("builds"))} // must match logic in ecs/common.ts
 			term.Debug("Tailing build logs", buildTail.LogGroupARN)
@@ -562,7 +562,8 @@ func (b *ByocAws) Follow(ctx context.Context, req *defangv1.TailRequest) (client
 			ecsTail := ecs.LogGroupInput{LogGroupARN: b.driver.MakeARN("logs", "log-group:"+b.stackDir("ecs"))} // must match logic in ecs/common.ts
 			term.Debug("Tailing ecs events logs", ecsTail.LogGroupARN)
 			groups = append(groups, ecsTail)
-		} else {
+		}
+		if req.Type == defangv1.LogType_RUN || req.Type == defangv1.LogType_ALL {
 			// Tail service logs
 			servicesTail := ecs.LogGroupInput{LogGroupARN: b.driver.MakeARN("logs", "log-group:"+b.stackDir("logs"))} // must match logic in ecs/common.ts
 			term.Debug("Tailing services logs", servicesTail.LogGroupARN)

--- a/src/pkg/cli/client/byoc/do/byoc.go
+++ b/src/pkg/cli/client/byoc/do/byoc.go
@@ -20,6 +20,7 @@ import (
 	"github.com/DefangLabs/defang/src/pkg"
 	"github.com/DefangLabs/defang/src/pkg/cli/client"
 	"github.com/DefangLabs/defang/src/pkg/cli/client/byoc"
+	"github.com/DefangLabs/defang/src/pkg/logs"
 
 	"github.com/DefangLabs/defang/src/pkg/clouds/aws"
 	"github.com/DefangLabs/defang/src/pkg/clouds/do"
@@ -432,7 +433,8 @@ func (b *ByocDo) Follow(ctx context.Context, req *defangv1.TailRequest) (client.
 		}
 
 		if deploymentInfo.GetPhase() == godo.DeploymentPhase_Active {
-			if req.Type == defangv1.LogType_BUILD || req.Type == defangv1.LogType_ALL {
+			logType := logs.LogType(req.LogType)
+			if logType.Has(logs.LogTypeBuild) {
 				// print cd logs
 				logs, _, err := b.client.Apps.GetLogs(ctx, cdApp.ID, deploymentID, "", godo.AppLogTypeDeploy, true, 50)
 				if err != nil {
@@ -442,7 +444,7 @@ func (b *ByocDo) Follow(ctx context.Context, req *defangv1.TailRequest) (client.
 				readHistoricalLogs(ctx, logs.HistoricURLs)
 			}
 
-			appLiveURL, err = b.processServiceLogs(ctx, req.Type)
+			appLiveURL, err = b.processServiceLogs(ctx, logType)
 			if err != nil {
 				return nil, err
 			}
@@ -718,7 +720,7 @@ func (b *ByocDo) processServiceInfo(service *godo.AppServiceSpec) *defangv1.Serv
 	return serviceInfo
 }
 
-func (b *ByocDo) processServiceLogs(ctx context.Context, logType defangv1.LogType) (string, error) {
+func (b *ByocDo) processServiceLogs(ctx context.Context, logType logs.LogType) (string, error) {
 	project, err := b.LoadProject(ctx)
 	appLiveURL := ""
 
@@ -729,17 +731,6 @@ func (b *ByocDo) processServiceLogs(ctx context.Context, logType defangv1.LogTyp
 	buildAppName := fmt.Sprintf("defang-%s-%s-build", project.Name, b.PulumiStack)
 	mainAppName := fmt.Sprintf("defang-%s-%s-app", project.Name, b.PulumiStack)
 
-	showBuildLogs := false
-	showRunLogs := false
-	if logType == defangv1.LogType_BUILD {
-		showBuildLogs = true
-	} else if logType == defangv1.LogType_RUN {
-		showRunLogs = true
-	} else {
-		showBuildLogs = true
-		showRunLogs = true
-	}
-
 	// If we can get projects working, we can add the project to the list options
 	currentApps, _, err := b.client.Apps.List(ctx, &godo.ListOptions{})
 	if err != nil {
@@ -747,7 +738,7 @@ func (b *ByocDo) processServiceLogs(ctx context.Context, logType defangv1.LogTyp
 	}
 
 	for _, app := range currentApps {
-		if logType == defangv1.LogType_BUILD && app.Spec.Name == buildAppName {
+		if logType.Has(logs.LogTypeBuild) && app.Spec.Name == buildAppName {
 			buildLogs, _, err := b.client.Apps.GetLogs(ctx, app.ID, "", "", godo.AppLogTypeDeploy, false, 50)
 			if err != nil {
 				return "", err
@@ -761,7 +752,7 @@ func (b *ByocDo) processServiceLogs(ctx context.Context, logType defangv1.LogTyp
 				return "", err
 			}
 
-			if showBuildLogs {
+			if logType.Has(logs.LogTypeBuild) {
 				mainDeployLogs, resp, err := b.client.Apps.GetLogs(ctx, app.ID, "", "", godo.AppLogTypeDeploy, true, 50)
 				if resp.StatusCode != 200 {
 					// godo has no concept of returning the "last deployment", only "Active", "Pending", etc
@@ -781,7 +772,7 @@ func (b *ByocDo) processServiceLogs(ctx context.Context, logType defangv1.LogTyp
 				}
 				readHistoricalLogs(ctx, mainDeployLogs.HistoricURLs)
 			}
-			if showRunLogs {
+			if logType.Has(logs.LogTypeRun) {
 				mainRunLogs, resp, err := b.client.Apps.GetLogs(ctx, app.ID, "", "", godo.AppLogTypeRun, true, 50)
 				if resp.StatusCode != 200 {
 					// Assume no deploy happened, return without an error

--- a/src/pkg/logs/log_type.go
+++ b/src/pkg/logs/log_type.go
@@ -68,6 +68,10 @@ func (c *LogType) Set(value string) error {
 	return InvalidLogTypeError{Value: value}
 }
 
+func (c LogType) Has(logType LogType) bool {
+	return c&logType != 0
+}
+
 func (c LogType) Value() string {
 	return c.String()
 }

--- a/src/pkg/logs/log_type_test.go
+++ b/src/pkg/logs/log_type_test.go
@@ -92,3 +92,36 @@ func TestLogTypeSet(t *testing.T) {
 		})
 	}
 }
+
+func TestLogTypeHas(t *testing.T) {
+	tests := []struct {
+		name  string
+		value LogType
+		arg   LogType
+		want  bool
+	}{
+		{"unspecified has unspecified", LogTypeUnspecified, LogTypeUnspecified, false},
+		{"unspecified has run", LogTypeUnspecified, LogTypeRun, false},
+		{"unspecified has build", LogTypeUnspecified, LogTypeBuild, false},
+		{"unspecified has all", LogTypeUnspecified, LogTypeAll, false},
+		{"run has unspecified", LogTypeRun, LogTypeUnspecified, false},
+		{"run has run", LogTypeRun, LogTypeRun, true},
+		{"run has build", LogTypeRun, LogTypeBuild, false},
+		{"run has all", LogTypeRun, LogTypeAll, true},
+		{"build has unspecified", LogTypeBuild, LogTypeUnspecified, false},
+		{"build has run", LogTypeBuild, LogTypeRun, false},
+		{"build has build", LogTypeBuild, LogTypeBuild, true},
+		{"build has all", LogTypeBuild, LogTypeAll, true},
+		{"all has unspecified", LogTypeAll, LogTypeUnspecified, false},
+		{"all has run", LogTypeAll, LogTypeRun, true},
+		{"all has build", LogTypeAll, LogTypeBuild, true},
+		{"all has all", LogTypeAll, LogTypeAll, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.value.Has(tt.arg); got != tt.want {
+				t.Errorf("LogType.Has() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Depends on https://github.com/DefangLabs/defang/pull/769 and https://github.com/DefangLabs/defang-mvp/pull/1016

This PR implements build log partitioning for AWS and DO BYOC clients.

### AWS

* [x] Build logs will print logs from these log groups:
  * [x] `/Defang/project-name/beta/builds`
  * [x] `defang-cd-LogGroup-*`
  * [x] `/Defang/nextjs/beta/ecs`
* [x] Runtime logs will print logs from this log group:
  * [x] `/Defang/project-name/beta/logs`

### Digital Ocean

* [x] Build logs will print logs from these groups:
  * [x] `AppLogTypeDeploy` logs for the `cd` app
  * [x]  `AppLogTypeDeploy` logs for the latest deployment
  * [ ] Should we be printing the `AppLogTypeRun` logs for the cd app?
* [x] Runtime logs will print the `AppLogTypeRun` for the latest deployment