### PR TITLE
add DEFANG_PULUMI_VERSION env

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ The Defang CLI recognizes the following environment variables:
 - `DEFANG_HIDE_UPDATE` - If set to `true`, hides the update notification; defaults to `false`
 - `DEFANG_PREFIX` - The prefix to use for all BYOC resources; defaults to `Defang`
 - `DEFANG_PROVIDER` - The name of the cloud provider to use, `auto` (default), `aws`, `digitalocean`, or `defang`
+- `DEFANG_PULUMI_VERSION` - Override the version of the Pulumi image to use (`aws` provider only)
 - `NO_COLOR` - If set to any value, disables color output; by default, color output is enabled depending on the terminal
 - `TZ` - The timezone to use for log timestamps: an IANA TZ name like `UTC` or `Europe/Amsterdam`; defaults to `Local`
 - `XDG_STATE_HOME` - The directory to use for storing state; defaults to `~/.local/state`

--- a/src/pkg/cli/client/byoc/aws/byoc.go
+++ b/src/pkg/cli/client/byoc/aws/byoc.go
@@ -40,6 +40,10 @@ const (
 	CdImageRepo = "public.ecr.aws/defang-io/cd"
 )
 
+var (
+	PulumiVersion = pkg.Getenv("DEFANG_PULUMI_VERSION", "3.136.1")
+)
+
 type ByocAws struct {
 	*byoc.ByocBaseClient
 
@@ -78,7 +82,7 @@ func (b *ByocAws) setUp(ctx context.Context) error {
 	cdTaskName := byoc.CdTaskPrefix
 	containers := []types.Container{
 		{
-			Image:     "public.ecr.aws/pulumi/pulumi-nodejs:latest",
+			Image:     "public.ecr.aws/pulumi/pulumi-nodejs:" + PulumiVersion,
 			Name:      ecs.ContainerName,
 			Cpus:      2.0,
 			Memory:    2048_000_000, // 2G


### PR DESCRIPTION
We were using `latest` on AWS (not on DO) and this can cause issues when Pulumi changes the schemas. 