### PR TITLE
Fix TaskDefinition inactive error

### DIFF
--- a/src/pkg/clouds/aws/ecs/cfn/waiter.go
+++ b/src/pkg/clouds/aws/ecs/cfn/waiter.go
@@ -1,0 +1,24 @@
+package cfn
+
+import (
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/service/cloudformation"
+)
+
+const minDelay = 1 * time.Second
+
+// update1s is a functional option for cloudformation.StackUpdateCompleteWaiter that sets the MinDelay to 1s
+func update1s(o *cloudformation.StackUpdateCompleteWaiterOptions) {
+	o.MinDelay = minDelay
+}
+
+// delete1s is a functional option for cloudformation.StackDeleteCompleteWaiter that sets the MinDelay to 1s
+func delete1s(o *cloudformation.StackDeleteCompleteWaiterOptions) {
+	o.MinDelay = minDelay
+}
+
+// create1s is a functional option for cloudformation.StackCreateCompleteWaiter that sets the MinDelay to 1s
+func create1s(o *cloudformation.StackCreateCompleteWaiterOptions) {
+	o.MinDelay = minDelay
+}


### PR DESCRIPTION
because when a new TaskDef (eg. when an image tag is changed) is created, the ARN in the driver was not updated.

This fixes the following error:
```
Error: operation error ECS: RunTask, https response error StatusCode: 400, RequestID: eda80292-edce-428d-b040-410665f3c619, InvalidParameterException: TaskDefinition is inactive
```