### PR TITLE
dns fixup in build args

### DIFF
--- a/src/pkg/cli/compose/convert.go
+++ b/src/pkg/cli/compose/convert.go
@@ -120,7 +120,7 @@ func ConvertServices(ctx context.Context, c client.Client, serviceConfigs compos
 
 			// Check if the environment variable is an existing config; if so, mark it as such
 			if _, ok := slices.BinarySearch(config.Names, key); ok {
-				if svcNameReplacer.hasServiceName(svccfg.Name, *value) {
+				if svcNameReplacer.hasServiceName(*value) {
 					term.Warnf("service %q: environment variable %q will use the 'defang config' value instead of adjusted service name", svccfg.Name, key)
 				} else {
 					term.Warnf("service %q: environment variable %q will use the 'defang config' value instead", svccfg.Name, key)

--- a/src/pkg/cli/compose/convert.go
+++ b/src/pkg/cli/compose/convert.go
@@ -98,7 +98,7 @@ func ConvertServices(ctx context.Context, c client.Client, serviceConfigs compos
 						continue
 					}
 
-					build.Args[key] = svcNameReplacer.replaceServiceNameWithDNS(svccfg.Name, key, *value, BuildArgs)
+					build.Args[key] = svcNameReplacer.ReplaceServiceNameWithDNS(svccfg.Name, key, *value, BuildArgs)
 				}
 			}
 		}
@@ -120,7 +120,7 @@ func ConvertServices(ctx context.Context, c client.Client, serviceConfigs compos
 
 			// Check if the environment variable is an existing config; if so, mark it as such
 			if _, ok := slices.BinarySearch(config.Names, key); ok {
-				if svcNameReplacer.hasServiceName(*value) {
+				if svcNameReplacer.HasServiceName(*value) {
 					term.Warnf("service %q: environment variable %q will use the 'defang config' value instead of adjusted service name", svccfg.Name, key)
 				} else {
 					term.Warnf("service %q: environment variable %q will use the 'defang config' value instead", svccfg.Name, key)
@@ -129,7 +129,7 @@ func ConvertServices(ctx context.Context, c client.Client, serviceConfigs compos
 				continue
 			}
 
-			envs[key] = svcNameReplacer.replaceServiceNameWithDNS(svccfg.Name, key, *value, EnvironmentVars)
+			envs[key] = svcNameReplacer.ReplaceServiceNameWithDNS(svccfg.Name, key, *value, EnvironmentVars)
 		}
 
 		// Add unset environment variables as "secrets"

--- a/src/pkg/cli/compose/convert.go
+++ b/src/pkg/cli/compose/convert.go
@@ -76,7 +76,7 @@ func ConvertServices(ctx context.Context, c client.Client, serviceConfigs compos
 	var services []*defangv1.Service
 	for _, svccfg := range serviceConfigs {
 
-		nameReplacementService := &serviceNameReplacer{
+		svcNameReplacer := &serviceNameReplacer{
 			client:                     c,
 			nonReplaceServiceNameRegex: nonReplaceServiceNameRegex,
 			serviceName:                svccfg.Name,
@@ -151,7 +151,7 @@ func ConvertServices(ctx context.Context, c client.Client, serviceConfigs compos
 						continue
 					}
 
-					build.Args[key] = nameReplacementService.replaceServiceNameWithDNS(key, *value, false)
+					build.Args[key] = svcNameReplacer.replaceServiceNameWithDNS(key, *value, false)
 				}
 			}
 		}
@@ -182,7 +182,7 @@ func ConvertServices(ctx context.Context, c client.Client, serviceConfigs compos
 				continue
 			}
 
-			envs[key] = nameReplacementService.replaceServiceNameWithDNS(key, *value, true)
+			envs[key] = svcNameReplacer.replaceServiceNameWithDNS(key, *value, true)
 		}
 
 		// Add unset environment variables as "secrets"

--- a/src/pkg/cli/compose/serviceNameReplacer.go
+++ b/src/pkg/cli/compose/serviceNameReplacer.go
@@ -1,0 +1,81 @@
+package compose
+
+import (
+	"regexp"
+	"slices"
+	"strings"
+
+	"github.com/DefangLabs/defang/src/pkg/cli/client"
+	"github.com/DefangLabs/defang/src/pkg/term"
+	defangv1 "github.com/DefangLabs/defang/src/protos/io/defang/v1"
+	compose "github.com/compose-spec/compose-go/v2/types"
+)
+
+type ReplacementMode int
+
+const (
+	BuildArgs ReplacementMode = iota
+	EnvironmentVars
+)
+
+type ServiceNameReplacer struct {
+	client                     client.Client
+	nonReplaceServiceNameRegex *regexp.Regexp
+	serviceNameRegex           *regexp.Regexp
+}
+
+func NewServiceNameReplacer(client client.Client, services compose.Services) ServiceNameReplacer {
+	// Create a regexp to detect private service names in environment variable values
+	var serviceNames []string
+	var nonReplaceServiceNames []string
+	for _, svccfg := range services {
+		if network(&svccfg) == defangv1.Network_PRIVATE && slices.ContainsFunc(svccfg.Ports, func(p compose.ServicePortConfig) bool {
+			return p.Mode == "host" // only private services with host ports get DNS names
+		}) {
+			serviceNames = append(serviceNames, regexp.QuoteMeta(svccfg.Name))
+		} else {
+			nonReplaceServiceNames = append(nonReplaceServiceNames, regexp.QuoteMeta(svccfg.Name))
+		}
+	}
+
+	var serviceNameRegex *regexp.Regexp
+	if len(serviceNames) > 0 {
+		serviceNameRegex = regexp.MustCompile(`\b(?:` + strings.Join(serviceNames, "|") + `)\b`)
+	}
+	var nonReplaceServiceNameRegex *regexp.Regexp
+	if len(nonReplaceServiceNames) > 0 {
+		nonReplaceServiceNameRegex = regexp.MustCompile(`\b(?:` + strings.Join(nonReplaceServiceNames, "|") + `)\b`)
+	}
+
+	return ServiceNameReplacer{
+		client:                     client,
+		nonReplaceServiceNameRegex: nonReplaceServiceNameRegex,
+		serviceNameRegex:           serviceNameRegex,
+	}
+}
+
+func (s *ServiceNameReplacer) replaceServiceNameWithDNS(serviceName string, key, value string, replacementMode ReplacementMode) string {
+	val := value
+	if s.serviceNameRegex != nil {
+		// Replace service names with their actual DNS names; TODO: support public names too
+		val = s.serviceNameRegex.ReplaceAllStringFunc(value, func(serviceName string) string {
+			return s.client.ServiceDNS(NormalizeServiceName(serviceName))
+		})
+
+		fixupTarget := "environment variable"
+		if replacementMode == BuildArgs {
+			fixupTarget = "build argument"
+		}
+		if val != value {
+			term.Warnf("service %q: service name was fixed up: %s %q assigned value %q", serviceName, fixupTarget, key, val)
+		} else if s.nonReplaceServiceNameRegex != nil && s.nonReplaceServiceNameRegex.MatchString(value) {
+			term.Warnf("service %q: service name(s) in the %s %q were not adjusted, only references to other services with port mode set to 'host' will be fixed-up", serviceName, fixupTarget, key)
+		}
+	}
+
+	return val
+}
+
+func (s *ServiceNameReplacer) hasServiceName(serviceName string, value string) bool {
+	return s.serviceNameRegex != nil && s.serviceNameRegex.MatchString(value)
+}

--- a/src/pkg/cli/compose/serviceNameReplacer.go
+++ b/src/pkg/cli/compose/serviceNameReplacer.go
@@ -25,7 +25,7 @@ type ServiceNameReplacer struct {
 }
 
 func NewServiceNameReplacer(client client.Client, services compose.Services) ServiceNameReplacer {
-	// Create a regexp to detect private service names in environment variable values
+	// Create a regexp to detect private service names in environment variable and build arg values
 	var serviceNames []string
 	var nonReplaceServiceNames []string
 	for _, svccfg := range services {
@@ -56,7 +56,7 @@ func NewServiceNameReplacer(client client.Client, services compose.Services) Ser
 
 func (s *ServiceNameReplacer) replaceServiceNameWithDNS(serviceName string, key, value string, replacementMode ReplacementMode) string {
 	val := value
-	if s.serviceNameRegex != nil {
+	if s.serviceNameRegex != nil && s.nonReplaceServiceNameRegex != nil {
 		// Replace service names with their actual DNS names; TODO: support public names too
 		val = s.serviceNameRegex.ReplaceAllStringFunc(value, func(serviceName string) string {
 			return s.client.ServiceDNS(NormalizeServiceName(serviceName))
@@ -76,6 +76,6 @@ func (s *ServiceNameReplacer) replaceServiceNameWithDNS(serviceName string, key,
 	return val
 }
 
-func (s *ServiceNameReplacer) hasServiceName(serviceName string, value string) bool {
-	return s.serviceNameRegex != nil && s.serviceNameRegex.MatchString(value)
+func (s *ServiceNameReplacer) hasServiceName(name string) bool {
+	return s.serviceNameRegex != nil && s.serviceNameRegex.MatchString(name)
 }

--- a/src/pkg/cli/compose/serviceNameReplacer.go
+++ b/src/pkg/cli/compose/serviceNameReplacer.go
@@ -11,11 +11,11 @@ import (
 	compose "github.com/compose-spec/compose-go/v2/types"
 )
 
-type ReplacementMode int
+type FixupTarget string
 
 const (
-	BuildArgs ReplacementMode = iota
-	EnvironmentVars
+	BuildArgs       FixupTarget = "build argument"
+	EnvironmentVars FixupTarget = "environment variable"
 )
 
 type ServiceNameReplacer struct {
@@ -67,9 +67,9 @@ func (s *ServiceNameReplacer) replaceServiceNameWithDNS(serviceName string, key,
 			fixupTarget = "build argument"
 		}
 		if val != value {
-			term.Warnf("service %q: service name was fixed up: %s %q assigned value %q", serviceName, fixupTarget, key, val)
+			term.Warnf("service %q: service name was adjusted: %s %q assigned value %q", serviceName, fixupTarget, key, val)
 		} else if s.nonReplaceServiceNameRegex != nil && s.nonReplaceServiceNameRegex.MatchString(value) {
-			term.Warnf("service %q: service name(s) in the %s %q were not adjusted, only references to other services with port mode set to 'host' will be fixed-up", serviceName, fixupTarget, key)
+			term.Warnf("service %q: service name in the %s %q was not adjusted, only references to other services with port mode set to 'host' will be fixed-up", serviceName, fixupTarget, key)
 		}
 	}
 

--- a/src/pkg/cli/compose/serviceNameReplacer.go
+++ b/src/pkg/cli/compose/serviceNameReplacer.go
@@ -54,7 +54,7 @@ func NewServiceNameReplacer(client client.Client, services compose.Services) Ser
 	}
 }
 
-func (s *ServiceNameReplacer) replaceServiceNameWithDNS(serviceName string, key, value string, replacementMode ReplacementMode) string {
+func (s *ServiceNameReplacer) ReplaceServiceNameWithDNS(serviceName string, key, value string, fixupTarget FixupTarget) string {
 	val := value
 	if s.serviceNameRegex != nil && s.nonReplaceServiceNameRegex != nil {
 		// Replace service names with their actual DNS names; TODO: support public names too
@@ -62,10 +62,6 @@ func (s *ServiceNameReplacer) replaceServiceNameWithDNS(serviceName string, key,
 			return s.client.ServiceDNS(NormalizeServiceName(serviceName))
 		})
 
-		fixupTarget := "environment variable"
-		if replacementMode == BuildArgs {
-			fixupTarget = "build argument"
-		}
 		if val != value {
 			term.Warnf("service %q: service name was adjusted: %s %q assigned value %q", serviceName, fixupTarget, key, val)
 		} else if s.nonReplaceServiceNameRegex != nil && s.nonReplaceServiceNameRegex.MatchString(value) {
@@ -76,6 +72,6 @@ func (s *ServiceNameReplacer) replaceServiceNameWithDNS(serviceName string, key,
 	return val
 }
 
-func (s *ServiceNameReplacer) hasServiceName(name string) bool {
+func (s *ServiceNameReplacer) HasServiceName(name string) bool {
 	return s.serviceNameRegex != nil && s.serviceNameRegex.MatchString(name)
 }

--- a/src/pkg/cli/compose/serviceNameReplacer_test.go
+++ b/src/pkg/cli/compose/serviceNameReplacer_test.go
@@ -7,11 +7,11 @@ import (
 	compose "github.com/compose-spec/compose-go/v2/types"
 )
 
-type ServiceNameReplacerMockClient struct {
+type serviceNameReplacerMockClient struct {
 	client.Client
 }
 
-func (m ServiceNameReplacerMockClient) ServiceDNS(name string) string {
+func (m serviceNameReplacerMockClient) ServiceDNS(name string) string {
 	return "override-" + name
 }
 
@@ -45,8 +45,9 @@ func setup() ServiceNameReplacer {
 		},
 	}
 
-	return NewServiceNameReplacer(ServiceNameReplacerMockClient{}, services)
+	return NewServiceNameReplacer(serviceNameReplacerMockClient{}, services)
 }
+
 func TestServiceNameReplacer(t *testing.T) {
 	testCases := []struct {
 		service  string

--- a/src/pkg/cli/compose/serviceNameReplacer_test.go
+++ b/src/pkg/cli/compose/serviceNameReplacer_test.go
@@ -50,42 +50,42 @@ func setup() ServiceNameReplacer {
 
 func TestServiceNameReplacer(t *testing.T) {
 	testCases := []struct {
-		service  string
-		key      string
-		value    string
-		mode     ReplacementMode
-		expected string
+		service     string
+		key         string
+		value       string
+		fixUpTarget FixupTarget
+		expected    string
 	}{
 		// host - build args
-		{service: "host-serviceA", key: "BuildArg1", value: "value1", mode: BuildArgs, expected: "value1"},
-		{service: "host-serviceA", key: "BuildArg2", value: "host-serviceB", mode: BuildArgs, expected: "override-host-serviceb"},
-		{service: "host-serviceA", key: "BuildArg3", value: "ingress-serviceC", mode: BuildArgs, expected: "ingress-serviceC"},
-		{service: "host-serviceA", key: "BuildArg4", value: "ingress-serviceD", mode: BuildArgs, expected: "ingress-serviceD"},
+		{service: "host-serviceA", key: "BuildArg1", value: "value1", fixUpTarget: BuildArgs, expected: "value1"},
+		{service: "host-serviceA", key: "BuildArg2", value: "host-serviceB", fixUpTarget: BuildArgs, expected: "override-host-serviceb"},
+		{service: "host-serviceA", key: "BuildArg3", value: "ingress-serviceC", fixUpTarget: BuildArgs, expected: "ingress-serviceC"},
+		{service: "host-serviceA", key: "BuildArg4", value: "ingress-serviceD", fixUpTarget: BuildArgs, expected: "ingress-serviceD"},
 
 		// host - env args
-		{service: "host-serviceA", key: "env1", value: "value1", mode: EnvironmentVars, expected: "value1"},
-		{service: "host-serviceA", key: "env2", value: "host-serviceB", mode: EnvironmentVars, expected: "override-host-serviceb"},
-		{service: "host-serviceA", key: "env3", value: "ingress-serviceC", mode: EnvironmentVars, expected: "ingress-serviceC"},
-		{service: "host-serviceA", key: "env4", value: "ingress-serviceD", mode: EnvironmentVars, expected: "ingress-serviceD"},
+		{service: "host-serviceA", key: "env1", value: "value1", fixUpTarget: EnvironmentVars, expected: "value1"},
+		{service: "host-serviceA", key: "env2", value: "host-serviceB", fixUpTarget: EnvironmentVars, expected: "override-host-serviceb"},
+		{service: "host-serviceA", key: "env3", value: "ingress-serviceC", fixUpTarget: EnvironmentVars, expected: "ingress-serviceC"},
+		{service: "host-serviceA", key: "env4", value: "ingress-serviceD", fixUpTarget: EnvironmentVars, expected: "ingress-serviceD"},
 
 		// ingress - build args
-		{service: "ingress-serviceD", key: "BuildArg1", value: "value1", mode: BuildArgs, expected: "value1"},
-		{service: "ingress-serviceD", key: "BuildArg2", value: "host-serviceA", mode: BuildArgs, expected: "override-host-servicea"},
-		{service: "ingress-serviceD", key: "BuildArg3", value: "host-serviceB", mode: BuildArgs, expected: "override-host-serviceb"},
-		{service: "ingress-serviceD", key: "BuildArg4", value: "ingress-serviceC", mode: BuildArgs, expected: "ingress-serviceC"},
+		{service: "ingress-serviceD", key: "BuildArg1", value: "value1", fixUpTarget: BuildArgs, expected: "value1"},
+		{service: "ingress-serviceD", key: "BuildArg2", value: "host-serviceA", fixUpTarget: BuildArgs, expected: "override-host-servicea"},
+		{service: "ingress-serviceD", key: "BuildArg3", value: "host-serviceB", fixUpTarget: BuildArgs, expected: "override-host-serviceb"},
+		{service: "ingress-serviceD", key: "BuildArg4", value: "ingress-serviceC", fixUpTarget: BuildArgs, expected: "ingress-serviceC"},
 
 		// ingress - env args
-		{service: "ingress-serviceD", key: "env1", value: "value1", mode: EnvironmentVars, expected: "value1"},
-		{service: "ingress-serviceD", key: "env2", value: "host-serviceA", mode: EnvironmentVars, expected: "override-host-servicea"},
-		{service: "ingress-serviceD", key: "env3", value: "host-serviceB", mode: EnvironmentVars, expected: "override-host-serviceb"},
-		{service: "ingress-serviceD", key: "env4", value: "ingress-serviceC", mode: EnvironmentVars, expected: "ingress-serviceC"},
+		{service: "ingress-serviceD", key: "env1", value: "value1", fixUpTarget: EnvironmentVars, expected: "value1"},
+		{service: "ingress-serviceD", key: "env2", value: "host-serviceA", fixUpTarget: EnvironmentVars, expected: "override-host-servicea"},
+		{service: "ingress-serviceD", key: "env3", value: "host-serviceB", fixUpTarget: EnvironmentVars, expected: "override-host-serviceb"},
+		{service: "ingress-serviceD", key: "env4", value: "ingress-serviceC", fixUpTarget: EnvironmentVars, expected: "ingress-serviceC"},
 	}
 
 	// Create a service name replacer
 	replacer := setup()
 
 	for _, tc := range testCases {
-		got := replacer.replaceServiceNameWithDNS(tc.service, tc.key, tc.value, tc.mode)
+		got := replacer.ReplaceServiceNameWithDNS(tc.service, tc.key, tc.value, tc.fixUpTarget)
 		if got != tc.expected {
 			t.Errorf("Expected %q, got %q", tc.expected, got)
 		}
@@ -95,11 +95,11 @@ func TestServiceNameReplacer(t *testing.T) {
 func TestServiceNameReplacerHasService(t *testing.T) {
 	replacer := setup()
 
-	if !replacer.hasServiceName("host-serviceA") {
+	if !replacer.HasServiceName("host-serviceA") {
 		t.Error("Expected to have host-serviceA")
 	}
 
-	if replacer.hasServiceName("missing-service") {
+	if replacer.HasServiceName("missing-service") {
 		t.Error("Expected to not have missing-service")
 	}
 }

--- a/src/pkg/cli/compose/serviceNameReplacer_test.go
+++ b/src/pkg/cli/compose/serviceNameReplacer_test.go
@@ -1,0 +1,104 @@
+package compose
+
+import (
+	"testing"
+
+	"github.com/DefangLabs/defang/src/pkg/cli/client"
+	compose "github.com/compose-spec/compose-go/v2/types"
+)
+
+type ServiceNameReplacerMockClient struct {
+	client.Client
+}
+
+func (m ServiceNameReplacerMockClient) ServiceDNS(name string) string {
+	return "override-" + name
+}
+
+func setup() ServiceNameReplacer {
+	services := compose.Services{}
+	services["host-serviceA"] = compose.ServiceConfig{
+		Name: "host-serviceA",
+		Ports: []compose.ServicePortConfig{
+			{Mode: "host"},
+		},
+	}
+
+	services["host-serviceB"] = compose.ServiceConfig{
+		Name: "host-serviceB",
+		Ports: []compose.ServicePortConfig{
+			{Mode: "host"},
+		},
+	}
+
+	services["ingress-serviceC"] = compose.ServiceConfig{
+		Name: "ingress-serviceC",
+		Ports: []compose.ServicePortConfig{
+			{Mode: "ingress"},
+		},
+	}
+
+	services["ingress-serviceD"] = compose.ServiceConfig{
+		Name: "ingress-serviceD",
+		Ports: []compose.ServicePortConfig{
+			{Mode: "ingress"},
+		},
+	}
+
+	return NewServiceNameReplacer(ServiceNameReplacerMockClient{}, services)
+}
+func TestServiceNameReplacer(t *testing.T) {
+	testCases := []struct {
+		service  string
+		key      string
+		value    string
+		mode     ReplacementMode
+		expected string
+	}{
+		// host - build args
+		{service: "host-serviceA", key: "BuildArg1", value: "value1", mode: BuildArgs, expected: "value1"},
+		{service: "host-serviceA", key: "BuildArg2", value: "host-serviceB", mode: BuildArgs, expected: "override-host-serviceb"},
+		{service: "host-serviceA", key: "BuildArg3", value: "ingress-serviceC", mode: BuildArgs, expected: "ingress-serviceC"},
+		{service: "host-serviceA", key: "BuildArg4", value: "ingress-serviceD", mode: BuildArgs, expected: "ingress-serviceD"},
+
+		// host - env args
+		{service: "host-serviceA", key: "env1", value: "value1", mode: EnvironmentVars, expected: "value1"},
+		{service: "host-serviceA", key: "env2", value: "host-serviceB", mode: EnvironmentVars, expected: "override-host-serviceb"},
+		{service: "host-serviceA", key: "env3", value: "ingress-serviceC", mode: EnvironmentVars, expected: "ingress-serviceC"},
+		{service: "host-serviceA", key: "env4", value: "ingress-serviceD", mode: EnvironmentVars, expected: "ingress-serviceD"},
+
+		// ingress - build args
+		{service: "ingress-serviceD", key: "BuildArg1", value: "value1", mode: BuildArgs, expected: "value1"},
+		{service: "ingress-serviceD", key: "BuildArg2", value: "host-serviceA", mode: BuildArgs, expected: "override-host-servicea"},
+		{service: "ingress-serviceD", key: "BuildArg3", value: "host-serviceB", mode: BuildArgs, expected: "override-host-serviceb"},
+		{service: "ingress-serviceD", key: "BuildArg4", value: "ingress-serviceC", mode: BuildArgs, expected: "ingress-serviceC"},
+
+		// ingress - env args
+		{service: "ingress-serviceD", key: "env1", value: "value1", mode: EnvironmentVars, expected: "value1"},
+		{service: "ingress-serviceD", key: "env2", value: "host-serviceA", mode: EnvironmentVars, expected: "override-host-servicea"},
+		{service: "ingress-serviceD", key: "env3", value: "host-serviceB", mode: EnvironmentVars, expected: "override-host-serviceb"},
+		{service: "ingress-serviceD", key: "env4", value: "ingress-serviceC", mode: EnvironmentVars, expected: "ingress-serviceC"},
+	}
+
+	// Create a service name replacer
+	replacer := setup()
+
+	for _, tc := range testCases {
+		got := replacer.replaceServiceNameWithDNS(tc.service, tc.key, tc.value, tc.mode)
+		if got != tc.expected {
+			t.Errorf("Expected %q, got %q", tc.expected, got)
+		}
+	}
+}
+
+func TestServiceNameReplacerHasService(t *testing.T) {
+	replacer := setup()
+
+	if !replacer.hasServiceName("host-serviceA") {
+		t.Error("Expected to have host-serviceA")
+	}
+
+	if replacer.hasServiceName("missing-service") {
+		t.Error("Expected to not have missing-service")
+	}
+}

--- a/src/tests/fixupenv/Dockerfile
+++ b/src/tests/fixupenv/Dockerfile
@@ -1,0 +1,1 @@
+# This file intentionally left blank

--- a/src/tests/fixupenv/compose.yaml
+++ b/src/tests/fixupenv/compose.yaml
@@ -22,3 +22,7 @@ services:
     image: "service:latest"
     environment:
       - "CONFIG1=http://Mistral:8000"
+  fixup-args:
+    build:
+      args:
+        - "API_URL=http://Mistral:8000"

--- a/src/tests/fixupenv/compose.yaml.convert
+++ b/src/tests/fixupenv/compose.yaml.convert
@@ -24,6 +24,19 @@
     "networks": 1
   },
   {
+    "name": "fixup-args",
+    "platform": 2,
+    "internal": true,
+    "build": {
+      "context": ".",
+      "dockerfile": "Dockerfile",
+      "args": {
+        "API_URL": "http://mistral:8000"
+      }
+    },
+    "networks": 1
+  },
+  {
     "name": "mistral",
     "image": "mistral:latest",
     "platform": 2,

--- a/src/tests/fixupenv/compose.yaml.golden
+++ b/src/tests/fixupenv/compose.yaml.golden
@@ -22,6 +22,14 @@ services:
     image: service:latest
     networks:
       default: null
+  fixup-args:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        API_URL: http://Mistral:8000
+    networks:
+      default: null
   ui:
     environment:
       API_URL: http://Mistral:8000

--- a/src/tests/fixupenv/compose.yaml.warnings
+++ b/src/tests/fixupenv/compose.yaml.warnings
@@ -3,6 +3,8 @@
  ! service "bad-service": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors
  ! service "env-in-config": environment variable "CONFIG1" will use the 'defang config' value instead of adjusted service name
  ! service "env-in-config": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors
+ ! service "fixup-args": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors
+ ! service "fixup-args": service name was fixed up: build arg "API_URL" assigned value "http://mock-mistral:8000"
  ! service "ui": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors
  ! service "ui": service name was fixed up: environment variable "API_URL" assigned value "http://mock-mistral:8000"
  ! service "use-bad-service": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors

--- a/src/tests/fixupenv/compose.yaml.warnings
+++ b/src/tests/fixupenv/compose.yaml.warnings
@@ -4,10 +4,10 @@
  ! service "env-in-config": environment variable "CONFIG1" will use the 'defang config' value instead of adjusted service name
  ! service "env-in-config": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors
  ! service "fixup-args": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors
- ! service "fixup-args": service name was fixed up: build argument "API_URL" assigned value "http://mock-mistral:8000"
+ ! service "fixup-args": service name was adjusted: build argument "API_URL" assigned value "http://mock-mistral:8000"
  ! service "ui": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors
- ! service "ui": service name was fixed up: environment variable "API_URL" assigned value "http://mock-mistral:8000"
+ ! service "ui": service name was adjusted: environment variable "API_URL" assigned value "http://mock-mistral:8000"
  ! service "use-bad-service": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors
- ! service "use-bad-service": service name(s) in the environment variable "DB_URL" were not adjusted, only references to other services with port mode set to 'host' will be fixed-up
+ ! service "use-bad-service": service name in the environment variable "DB_URL" was not adjusted, only references to other services with port mode set to 'host' will be fixed-up
  ! service name "Mistral" was normalized to "mistral"
  * Packaging the project files for fixup-args at .

--- a/src/tests/fixupenv/compose.yaml.warnings
+++ b/src/tests/fixupenv/compose.yaml.warnings
@@ -4,9 +4,10 @@
  ! service "env-in-config": environment variable "CONFIG1" will use the 'defang config' value instead of adjusted service name
  ! service "env-in-config": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors
  ! service "fixup-args": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors
- ! service "fixup-args": service name was fixed up: build arg "API_URL" assigned value "http://mock-mistral:8000"
+ ! service "fixup-args": service name was fixed up: build argument "API_URL" assigned value "http://mock-mistral:8000"
  ! service "ui": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors
  ! service "ui": service name was fixed up: environment variable "API_URL" assigned value "http://mock-mistral:8000"
  ! service "use-bad-service": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors
- ! service "use-bad-service": service name(s) in the environment variable "DB_URL" were not updated, only references to other services with port mode set to 'host' will be fixed-up
+ ! service "use-bad-service": service name(s) in the environment variable "DB_URL" were not adjusted, only references to other services with port mode set to 'host' will be fixed-up
  ! service name "Mistral" was normalized to "mistral"
+ * Packaging the project files for fixup-args at .

--- a/src/tests/fixupenv/compose.yaml.warnings
+++ b/src/tests/fixupenv/compose.yaml.warnings
@@ -6,5 +6,5 @@
  ! service "ui": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors
  ! service "ui": service name was fixed up: environment variable "API_URL" assigned value "http://mock-mistral:8000"
  ! service "use-bad-service": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors
- ! service "use-bad-service": service name(s) in the environment variable "DB_URL" were not fixed up, only services with port mode set to 'host' will be fixed up
+ ! service "use-bad-service": service name(s) in the environment variable "DB_URL" were not updated, only references to other services with port mode set to 'host' will be fixed-up
  ! service name "Mistral" was normalized to "mistral"


### PR DESCRIPTION
fixes #394 

Extract out service name replacement into it's own struct and function
Use same service name replacement for build arguments
