### PR TITLE
Fix for old BYOC projects

### DIFF
--- a/src/pkg/cli/client/byoc/aws/byoc.go
+++ b/src/pkg/cli/client/byoc/aws/byoc.go
@@ -346,11 +346,14 @@ func (b *ByocAws) delegateSubdomain(ctx context.Context) (string, error) {
 		sort.Strings(nsServers)
 		sort.Strings(delegationSet.NameServers)
 		if !slices.Equal(delegationSet.NameServers, nsServers) {
-			b.Track("Compose-Up ListResourceRecords Diff", client.Property{"fromDS", delegationSet.NameServers}, client.Property{"fromZone", nsServers})
+			b.Track("Compose-Up delegateSubdomain diff", client.Property{"fromDS", delegationSet.NameServers}, client.Property{"fromZone", nsServers})
 			term.Debugf("NS records for the existing subdomain zone do not match the delegation set: %v <> %v", delegationSet.NameServers, nsServers)
 		}
 
 		nsServers = delegationSet.NameServers
+	} else {
+		// Case 2a: The zone was created by the older CLI, we'll use the existing NS records; track how many times this happens
+		b.Track("Compose-Up delegateSubdomain old", client.Property{"domain", b.ProjectDomain})
 	}
 
 	req := &defangv1.DelegateSubdomainZoneRequest{NameServerRecords: nsServers}

--- a/src/pkg/clouds/aws/route53.go
+++ b/src/pkg/clouds/aws/route53.go
@@ -65,13 +65,15 @@ func GetHostedZoneByName(ctx context.Context, domain string, r53 *route53.Client
 	return &zone, nil
 }
 
+const CreateHostedZoneComment = "Created by defang cli"
+
 // Deprecated: let Pulumi create the hosted zone
 func CreateHostedZone(ctx context.Context, domain string, r53 *route53.Client) (*types.HostedZone, error) {
 	params := &route53.CreateHostedZoneInput{
 		Name:            ptr.String(domain),
 		CallerReference: ptr.String(domain + time.Now().String()),
 		HostedZoneConfig: &types.HostedZoneConfig{
-			Comment: ptr.String("Created by Defang CLI"),
+			Comment: ptr.String(CreateHostedZoneComment),
 		},
 	}
 	resp, err := r53.CreateHostedZone(ctx, params)
@@ -101,7 +103,7 @@ func ListResourceRecords(ctx context.Context, zoneId, recordName string, recordT
 	records := listResp.ResourceRecordSets[0].ResourceRecords
 	values := make([]string, len(records))
 	for i, record := range records {
-		values[i] = *record.Value
+		values[i] = strings.TrimSuffix(*record.Value, ".") // normalize the value
 	}
 	return values, nil
 }


### PR DESCRIPTION
We need to stick to the old way (no delegation set) for existing BYOC project, because deployment would fail when CD tries to create an already existing private hosted zone.

Fixes regression from #770 