### PR TITLE
move validate config code to CLI from mvp for BYOC use

### DIFF
--- a/src/pkg/cli/compose/validation.go
+++ b/src/pkg/cli/compose/validation.go
@@ -38,7 +38,7 @@ func ValidateProject(client client.Client, project *compose.Project) error {
 		return services[i].Name < services[j].Name
 	})
 
-	if err := validateProjectConfig(context.Background(), client, project); err != nil {
+	if err := ValidateProjectConfig(context.Background(), client, project); err != nil {
 		return err
 	}
 
@@ -365,7 +365,7 @@ func validatePort(port compose.ServicePortConfig) error {
 	return nil
 }
 
-func validateProjectConfig(ctx context.Context, client client.Client, composeProject *compose.Project) error {
+func ValidateProjectConfig(ctx context.Context, client client.Client, composeProject *compose.Project) error {
 	var names []string
 	// make list of secrets
 	for _, service := range composeProject.Services {

--- a/src/pkg/cli/compose/validation_test.go
+++ b/src/pkg/cli/compose/validation_test.go
@@ -29,19 +29,23 @@ func TestValidationAndConvert(t *testing.T) {
 
 		options := LoaderOptions{ConfigPaths: []string{path}}
 		loader := Loader{options: options}
-		proj, err := loader.LoadProject(context.Background())
+
+		// this is all the configs that are used in the test compose files
+		mockClient := validationMockClient{
+			configs: []string{"CONFIG1", "CONFIG2", "dummy", "ENV1", "SENSITIVE_DATA"},
+		}
+
+		project, err := loader.LoadProject(context.Background())
 		if err != nil {
 			t.Fatal(err)
 		}
-		if err := ValidateProject(client.MockClient{}, proj); err != nil {
+
+		if err := ValidateProject(mockClient, project); err != nil {
 			t.Logf("Project validation failed: %v", err)
 			logs.WriteString(err.Error() + "\n")
 		}
 
-		mockClient := validationMockClient{
-			configs: []string{"CONFIG1", "CONFIG2"},
-		}
-		if _, err = ConvertServices(context.Background(), mockClient, proj.Services, UploadModeIgnore); err != nil {
+		if _, err = ConvertServices(context.Background(), mockClient, project.Services, UploadModeIgnore); err != nil {
 			t.Logf("Service conversion failed: %v", err)
 			logs.WriteString(err.Error() + "\n")
 		}

--- a/src/pkg/cli/compose/validation_test.go
+++ b/src/pkg/cli/compose/validation_test.go
@@ -77,7 +77,7 @@ func TestValidateConfig(t *testing.T) {
 		}
 
 		testProject.Services["service1"] = compose.ServiceConfig{Environment: env}
-		if err := validateProjectConfig(ctx, mockClient, &testProject); err != nil {
+		if err := ValidateProjectConfig(ctx, mockClient, &testProject); err != nil {
 			t.Fatal(err)
 		}
 	})
@@ -94,7 +94,7 @@ func TestValidateConfig(t *testing.T) {
 		ctx := context.Background()
 		mockClient := validationMockClient{}
 		testProject.Services["service1"] = compose.ServiceConfig{Environment: env}
-		if err := validateProjectConfig(ctx, mockClient, &testProject); !errors.As(err, &missing) {
+		if err := ValidateProjectConfig(ctx, mockClient, &testProject); !errors.As(err, &missing) {
 			t.Fatalf("uexpected ErrMissingConfig, got: %v", err)
 		} else {
 			if len(missing) != 3 {
@@ -117,7 +117,7 @@ func TestValidateConfig(t *testing.T) {
 			CONFIG_VAR: nil,
 		}
 		testProject.Services["service1"] = compose.ServiceConfig{Environment: env}
-		if err := validateProjectConfig(ctx, mockClient, &testProject); err != nil {
+		if err := ValidateProjectConfig(ctx, mockClient, &testProject); err != nil {
 			t.Fatal(err)
 		}
 	})

--- a/src/pkg/cli/composeUp.go
+++ b/src/pkg/cli/composeUp.go
@@ -26,7 +26,7 @@ func ComposeUp(ctx context.Context, c client.Client, upload compose.UploadMode, 
 		return nil, project, err
 	}
 
-	if err := compose.ValidateProject(project); err != nil {
+	if err := compose.ValidateProject(c, project); err != nil {
 		return nil, project, &ComposeError{err}
 	}
 


### PR DESCRIPTION
Moved the project config validation code so BYOC will show all missing config in one error rather than one missing config per deployment attempt.