### PR TITLE
fix: tcp+ingress is ok

### DIFF
--- a/src/pkg/quota/service.go
+++ b/src/pkg/quota/service.go
@@ -44,8 +44,8 @@ func (q ServiceQuotas) Validate(service *types.ServiceConfig) error {
 		}
 		if port.Mode == compose.Mode_INGRESS {
 			hasIngress = true
-			if port.Protocol == compose.Protocol_TCP || port.Protocol == compose.Protocol_UDP {
-				return fmt.Errorf("mode:INGRESS is not supported by protocol:%s", port.Protocol) // CodeInvalidArgument
+			if port.Protocol == compose.Protocol_UDP {
+				return fmt.Errorf("`mode: ingress` is not supported by `protocol: %s`", port.Protocol) // CodeInvalidArgument
 			}
 		}
 		if uniquePorts[port.Target] {

--- a/src/pkg/quota/service_test.go
+++ b/src/pkg/quota/service_test.go
@@ -47,12 +47,7 @@ func TestValidate(t *testing.T) {
 		{
 			name:    "ingress with UDP",
 			service: &types.ServiceConfig{Name: "test", Image: "asdf", Ports: []types.ServicePortConfig{{Target: 53, Mode: compose.Mode_INGRESS, Protocol: compose.Protocol_UDP}}},
-			wantErr: "mode:INGRESS is not supported by protocol:udp",
-		},
-		{
-			name:    "ingress with UDP",
-			service: &types.ServiceConfig{Name: "test", Image: "asdf", Ports: []types.ServicePortConfig{{Target: 80, Mode: compose.Mode_INGRESS, Protocol: compose.Protocol_TCP}}},
-			wantErr: "mode:INGRESS is not supported by protocol:tcp",
+			wantErr: "`mode: ingress` is not supported by `protocol: udp`",
 		},
 		{
 			name: "invalid healthcheck interval",


### PR DESCRIPTION
Previously with our own protobuf we'd change the protocol to `HTTP`, but that is not a valid value for the compose `protocol` field, so the "tcp" + "ingress" is a valid combination. 

Eventually we should use the new `app_protocol` field (was added to Compose recently) and set it in fixup phase, then we can revive this check. 

- [ ] uptake into MVP