### PR TITLE
Added pycache to ignore files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,7 @@ node_modules/
 /result
 .idea
 
+**/__pycache__/
+
 *.log
 *.txt

--- a/src/tests/testproj/.dockerignore
+++ b/src/tests/testproj/.dockerignore
@@ -1,5 +1,5 @@
 # Default .dockerignore file for Defang
-**/__pycache__
+**/__pycache__/
 **/.direnv
 **/.DS_Store
 **/.envrc


### PR DESCRIPTION
Fixes #781 for the `defang` repo

- added `**/__pycache__/` to top-level `.gitignore` file
- added a trailing slash `/` (for consistency with the other repos) to `**/__pycache__` in the `.dockerignore` file
