### PR TITLE
cd preview needs login

### DIFF
--- a/src/cmd/cli/command/commands.go
+++ b/src/cmd/cli/command/commands.go
@@ -954,9 +954,10 @@ var cdListCmd = &cobra.Command{
 }
 
 var cdPreviewCmd = &cobra.Command{
-	Use:   "preview",
-	Args:  cobra.NoArgs,
-	Short: "Preview the changes that will be made by the CD task",
+	Use:         "preview",
+	Args:        cobra.NoArgs,
+	Annotations: authNeededAnnotation, // FIXME: because it still needs a delegated domain
+	Short:       "Preview the changes that will be made by the CD task",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		resp, _, err := cli.ComposeUp(cmd.Context(), provider, compose.UploadModePreview, defangv1.DeploymentMode_UNSPECIFIED_MODE)
 		if err != nil {


### PR DESCRIPTION
`defang cd preview` would fail when the user is not already logged into Fabric, because the gRPC call to Fabric for the delegated domain would fail silently and return an empty `DOMAIN` string, which would cause an exception within CD.