### PR TITLE
Fix for defang upgrade

### DIFF
--- a/src/pkg/cli/upgrade.go
+++ b/src/pkg/cli/upgrade.go
@@ -25,7 +25,8 @@ func Upgrade(ctx context.Context) error {
 	}
 	term.Debugf(" - Evaluated: %s\n", ex)
 
-	if prefix, err := homebrewPrefix(ctx); err == nil && strings.HasPrefix(ex, prefix) {
+	prefix, err := homebrewPrefix(ctx)
+	if err == nil && strings.HasPrefix(ex, prefix) {
 		printInstructions("brew upgrade defang")
 		return nil
 	}

--- a/src/pkg/cli/upgrade.go
+++ b/src/pkg/cli/upgrade.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -24,7 +25,7 @@ func Upgrade(ctx context.Context) error {
 	}
 	term.Debugf(" - Evaluated: %s\n", ex)
 
-	if strings.HasPrefix(ex, homebrewPrefix(ctx)) {
+	if prefix, err := homebrewPrefix(ctx); err == nil && strings.HasPrefix(ex, prefix) {
 		printInstructions("brew upgrade defang")
 		return nil
 	}
@@ -52,25 +53,23 @@ func Upgrade(ctx context.Context) error {
 	return nil
 }
 
-func homebrewPrefix(ctx context.Context) string {
+func homebrewPrefix(ctx context.Context) (string, error) {
 	output, err := exec.CommandContext(ctx, "brew", "config").Output()
 	if err != nil {
-		return ""
+		return "", err
 	}
-	homebrewPrefix := ""
 	// filter out the line which includes HOMEBREW_PREFIX
+	const HOMEBREW_PREFIX = "HOMEBREW_PREFIX: "
 	for _, line := range strings.Split(string(output), "\n") {
-		config_key := "HOMEBREW_PREFIX: "
-		if strings.HasPrefix(line, config_key) {
-			// remove the prefix from the line
-			homebrewPrefix = strings.TrimPrefix(line, config_key)
-			break
+		// remove the prefix from the line
+		if homebrewPrefix, ok := strings.CutPrefix(line, HOMEBREW_PREFIX); ok {
+			return homebrewPrefix, nil
 		}
 	}
-	return homebrewPrefix
+	return "", errors.New("HOMEBREW_PREFIX not found in brew config")
 }
 
 func printInstructions(cmd string) {
 	term.Info("To upgrade defang, run the following command:")
-	term.Print("\n\n  ", cmd)
+	term.Print("\n  ", cmd, "\n\n")
 }


### PR DESCRIPTION
Fixes #658

If you don't have `brew`, it would check whether the executable has the brew prefix `""` which is always true.