### PR TITLE
Fix --dry-run flag

### DIFF
--- a/src/cmd/cli/command/compose.go
+++ b/src/cmd/cli/command/compose.go
@@ -302,7 +302,6 @@ func makeComposeConfigCmd() *cobra.Command {
 		Args:  cobra.NoArgs, // TODO: takes optional list of service names
 		Short: "Reads a Compose file and shows the generated config",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cli.DoDryRun = true // config is like start in a dry run
 			if _, _, err := cli.ComposeUp(cmd.Context(), provider, compose.UploadModeIgnore, defangv1.DeploymentMode_UNSPECIFIED_MODE); !errors.Is(err, cli.ErrDryRun) {
 				return err
 			}

--- a/src/pkg/cli/compose/context.go
+++ b/src/pkg/cli/compose/context.go
@@ -29,7 +29,7 @@ const (
 	UploadModeDigest  UploadMode = iota // the default: calculate the digest of the tarball so we can skip building the same image twice
 	UploadModeForce                     // force: always upload the tarball, even if it's the same as a previous one
 	UploadModeIgnore                    // dry-run: don't upload the tarball, just return the path
-	UploadModePreview                   // preview: like dry-run but also don't deploy
+	UploadModePreview                   // preview: like dry-run but does start the preview command
 )
 
 const (

--- a/src/pkg/cli/composeUp.go
+++ b/src/pkg/cli/composeUp.go
@@ -26,6 +26,10 @@ func ComposeUp(ctx context.Context, provider client.Provider, upload compose.Upl
 		return nil, project, err
 	}
 
+	if DoDryRun {
+		upload = compose.UploadModeIgnore
+	}
+
 	listConfigNamesFunc := func(ctx context.Context) ([]string, error) {
 		configs, err := provider.ListConfig(ctx)
 		if err != nil {


### PR DESCRIPTION
Regression from #520

This "broke" the Defang GitHub action CI test. 