### PR TITLE
Add DEFANG_PULUMI_DIR env for local Pulumi runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ The Defang CLI recognizes the following environment variables:
 - `DEFANG_HIDE_UPDATE` - If set to `true`, hides the update notification; defaults to `false`
 - `DEFANG_PREFIX` - The prefix to use for all BYOC resources; defaults to `Defang`
 - `DEFANG_PROVIDER` - The name of the cloud provider to use, `auto` (default), `aws`, `digitalocean`, or `defang`
+- `DEFANG_PULUMI_DIR` - Run Pulumi from this folder, instead of spawning a cloud task; requires `--debug` (BYOC only)
 - `DEFANG_PULUMI_VERSION` - Override the version of the Pulumi image to use (`aws` provider only)
 - `NO_COLOR` - If set to any value, disables color output; by default, color output is enabled depending on the terminal
 - `TZ` - The timezone to use for log timestamps: an IANA TZ name like `UTC` or `Europe/Amsterdam`; defaults to `Local`

--- a/src/pkg/cli/client/byoc/aws/byoc.go
+++ b/src/pkg/cli/client/byoc/aws/byoc.go
@@ -454,14 +454,17 @@ func (b *ByocAws) runCdCommand(ctx context.Context, mode defangv1.DeploymentMode
 	}
 	env["DEFANG_MODE"] = strings.ToLower(mode.String())
 	if term.DoDebug() {
-		debugEnv := fmt.Sprintf("AWS_REGION=%q", b.driver.Region)
+		// Convert the environment to a human-readable array of KEY=VALUE strings for debugging
+		debugEnv := []string{"AWS_REGION=" + b.driver.Region.String()}
 		if awsProfile := os.Getenv("AWS_PROFILE"); awsProfile != "" {
-			debugEnv += fmt.Sprintf(" AWS_PROFILE=%q", awsProfile)
+			debugEnv = append(debugEnv, "AWS_PROFILE="+awsProfile)
 		}
 		for k, v := range env {
-			debugEnv += fmt.Sprintf(" %s=%q", k, v)
+			debugEnv = append(debugEnv, k+"="+v)
 		}
-		term.Debug(debugEnv, "npm run dev", strings.Join(cmd, " "))
+		if err := byoc.DebugPulumi(ctx, debugEnv, cmd...); err != nil {
+			return nil, err
+		}
 	}
 	return b.driver.Run(ctx, env, cmd...)
 }

--- a/src/pkg/cli/client/byoc/aws/byoc_integration_test.go
+++ b/src/pkg/cli/client/byoc/aws/byoc_integration_test.go
@@ -15,7 +15,7 @@ import (
 var ctx = context.Background()
 
 func TestDeploy(t *testing.T) {
-	b := NewByocClient(ctx, client.GrpcClient{}, "ten ant") // no domain
+	b := NewByocProvider(ctx, client.GrpcClient{}, "ten ant") // no domain
 	b.ProjectName = "byoc_integration_test"
 
 	t.Run("multiple ingress without domain", func(t *testing.T) {
@@ -41,7 +41,7 @@ func TestDeploy(t *testing.T) {
 }
 
 func TestTail(t *testing.T) {
-	b := NewByocClient(ctx, client.GrpcClient{}, "TestTail")
+	b := NewByocProvider(ctx, client.GrpcClient{}, "TestTail")
 	b.ProjectName = "byoc_integration_test"
 	b.ProjectDomain = "example.com" // avoid rpc call
 
@@ -69,7 +69,7 @@ func TestTail(t *testing.T) {
 }
 
 func TestGetServices(t *testing.T) {
-	b := NewByocClient(ctx, client.GrpcClient{}, "TestGetServices")
+	b := NewByocProvider(ctx, client.GrpcClient{}, "TestGetServices")
 	b.ProjectName = "byoc_integration_test"
 
 	services, err := b.GetServices(context.Background())
@@ -89,7 +89,7 @@ func TestGetServices(t *testing.T) {
 func TestPutSecret(t *testing.T) {
 	const secretName = "hello"
 
-	b := NewByocClient(ctx, client.GrpcClient{}, "TestPutSecret")
+	b := NewByocProvider(ctx, client.GrpcClient{}, "TestPutSecret")
 	b.ProjectName = "byoc_integration_test"
 
 	t.Run("delete non-existent", func(t *testing.T) {
@@ -141,7 +141,7 @@ func TestPutSecret(t *testing.T) {
 }
 
 func TestListSecrets(t *testing.T) {
-	b := NewByocClient(ctx, client.GrpcClient{}, "TestListSecrets")
+	b := NewByocProvider(ctx, client.GrpcClient{}, "TestListSecrets")
 	b.ProjectName = "byoc_integration_test2" // ensure we don't accidentally see the secrets from the other test
 
 	t.Run("list", func(t *testing.T) {

--- a/src/pkg/cli/client/byoc/baseclient.go
+++ b/src/pkg/cli/client/byoc/baseclient.go
@@ -3,6 +3,9 @@ package byoc
 import (
 	"context"
 	"errors"
+	"fmt"
+	"os"
+	"os/exec"
 	"strings"
 
 	"github.com/DefangLabs/defang/src/pkg"
@@ -97,6 +100,41 @@ func NewByocBaseClient(ctx context.Context, grpcClient client.GrpcClient, tenant
 		bootstrapLister: bl,
 	}
 	return b
+}
+
+func MakeEnv(key string, value any) string {
+	return fmt.Sprintf("%s=%q", key, value)
+}
+
+func runLocalCommand(ctx context.Context, dir string, env []string, cmd ...string) error {
+	command := exec.CommandContext(ctx, cmd[0], cmd[1:]...)
+	command.Dir = dir
+	command.Env = env
+	command.Stdout = os.Stdout
+	command.Stderr = os.Stderr
+	return command.Run()
+}
+
+func DebugPulumi(ctx context.Context, env []string, cmd ...string) error {
+	// Locally we use the "dev" script from package.json to run Pulumi commands, which uses ts-node
+	localCmd := append([]string{"npm", "run", "dev"}, cmd...)
+	term.Debug(strings.Join(append(env, localCmd...), " "))
+
+	dir := os.Getenv("DEFANG_PULUMI_DIR")
+	if dir == "" {
+		return nil // show the shell command, but use regular Pulumi command in cloud task
+	}
+
+	// Run the Pulumi command locally
+	env = append([]string{
+		"PATH=" + os.Getenv("PATH"),
+		"USER=" + os.Getenv("USER"), // needed for Pulumi
+	}, env...)
+	if err := runLocalCommand(ctx, dir, env, localCmd...); err != nil {
+		return err
+	}
+	// We always return an error to stop the CLI from "tailing" the cloud logs
+	return errors.New("local pulumi command succeeded; stopping")
 }
 
 func GetCdImage(repo string, tag string) string {

--- a/src/pkg/cli/client/byoc/do/byoc.go
+++ b/src/pkg/cli/client/byoc/do/byoc.go
@@ -515,39 +515,17 @@ func (b *ByocDo) Subscribe(context.Context, *defangv1.SubscribeRequest) (client.
 	return nil, errors.New("please check the Activity tab in the DigitalOcean App Platform console")
 }
 
-func (b *ByocDo) runLocalPulumiCommand(ctx context.Context, dir string, cmd ...string) error {
-	return errors.ErrUnsupported // TODO: implement for Windows
-	// driver := local.New()
-	// if err := driver.SetUp(ctx, []types.Container{{
-	// 	EntryPoint: []string{"npm", "run", "dev"},
-	// 	WorkDir:    dir,
-	// }}); err != nil {
-	// 	return err
-	// }
-	// localEnv := map[string]string{
-	// 	"PATH": os.Getenv("PATH"),
-	// }
-	// for _, v := range b.environment() {
-	// 	localEnv[v.Key] = v.Value
-	// }
-	// pid, err := driver.Run(ctx, localEnv, cmd...)
-	// if err != nil {
-	// 	return err
-	// }
-	// return driver.Tail(ctx, pid)
-}
-
 func (b *ByocDo) runCdCommand(ctx context.Context, cmd ...string) (*godo.App, error) { // nolint:unparam
 	env := b.environment()
 	if term.DoDebug() {
-		debugEnv := " -"
-		for _, v := range env {
-			debugEnv += " " + v.Key + "=" + v.Value
+		// Convert the environment to a human-readable array of KEY=VALUE strings for debugging
+		debugEnv := make([]string, len(env))
+		for i, v := range env {
+			debugEnv[i] = v.Key + "=" + v.Value
 		}
-		term.Debug(debugEnv, "npm run dev", strings.Join(cmd, " "))
-	}
-	if dir := os.Getenv("DEFANG_PULUMI_DIR"); dir != "" {
-		return nil, b.runLocalPulumiCommand(ctx, dir, cmd...)
+		if err := byoc.DebugPulumi(ctx, debugEnv, cmd...); err != nil {
+			return nil, err
+		}
 	}
 	app, err := b.driver.Run(ctx, env, append([]string{"node", "lib/index.js"}, cmd...)...)
 	return app, err


### PR DESCRIPTION
Adding an env var `DEFANG_PULUMI_DIR` for faster testing of Pulumi CD code. You'd set this var to the folder with the Pulumi code, ie. `…/pulumi` and then when `--debug` it would run Pulumi locally, as opposed to running it in the cloud.