### PR TITLE
Hide useless "limits" warning

### DIFF
--- a/src/pkg/cli/compose/validation.go
+++ b/src/pkg/cli/compose/validation.go
@@ -251,7 +251,7 @@ func ValidateProject(project *composeTypes.Project) error {
 				return fmt.Errorf("service %q: unsupported compose directive: deploy endpoint_mode", svccfg.Name)
 			}
 			if svccfg.Deploy.Resources.Limits != nil && svccfg.Deploy.Resources.Reservations == nil {
-				term.Warnf("service %q: no reservations specified; using limits as reservations", svccfg.Name)
+				term.Debugf("service %q: no reservations specified; using limits as reservations", svccfg.Name)
 			}
 			reservations = getResourceReservations(svccfg.Deploy.Resources)
 			if reservations != nil && reservations.NanoCPUs < 0 { // "0" just means "as small as possible"

--- a/src/tests/alttestproj/altcomp.yaml
+++ b/src/tests/alttestproj/altcomp.yaml
@@ -13,9 +13,6 @@ services:
         limits:
           cpus: '0.50'
           memory: 512M
-        reservations:
-          cpus: '0.25'
-          memory: 256M
     ports:
       - target: 80
         mode: ingress

--- a/src/tests/alttestproj/compose.yaml
+++ b/src/tests/alttestproj/compose.yaml
@@ -5,5 +5,5 @@ services:
     build: .
     deploy:
       resources:
-        reservations:
+        limits:
           memory: 256M

--- a/src/tests/alttestproj/compose.yaml.fixup
+++ b/src/tests/alttestproj/compose.yaml.fixup
@@ -8,7 +8,7 @@
     "deploy": {
       "replicas": 1,
       "resources": {
-        "reservations": {
+        "limits": {
           "memory": "268435456"
         }
       },

--- a/src/tests/alttestproj/compose.yaml.golden
+++ b/src/tests/alttestproj/compose.yaml.golden
@@ -6,7 +6,7 @@ services:
       dockerfile: Dockerfile
     deploy:
       resources:
-        reservations:
+        limits:
           memory: "268435456"
     networks:
       default: null


### PR DESCRIPTION
That message is not very actionable, so hide it. 

```
 ! service "service1": no reservations specified; using limits as reservations
 ```