### PR TITLE
Do not wait on managed resource status to complete.

### DIFF
--- a/src/cmd/cli/command/compose.go
+++ b/src/cmd/cli/command/compose.go
@@ -27,8 +27,8 @@ func isManagedService(service compose.ServiceConfig) bool {
 }
 
 func splitProjectServicesByManageType(serviceInfos compose.Services) ([]string, []string) {
-	managedServices := make([]string, 0)
-	unmanagedServices := make([]string, 0)
+	var managedServices []string
+	var unmanagedServices []string
 	for _, service := range serviceInfos {
 		if isManagedService(service) {
 			managedServices = append(managedServices, service.Name)

--- a/src/cmd/cli/command/compose.go
+++ b/src/cmd/cli/command/compose.go
@@ -109,7 +109,7 @@ func makeComposeUpCmd() *cobra.Command {
 				monitoredServices := make([]string, 0, len(deploy.Services)-len(managedResources))
 				for _, serviceInfo := range deploy.Services {
 
-					// do not monitor managed services, they do not currently update their status
+					// do not monitor managed resources, they do not currently update their status
 					if !slices.Contains(managedResources, serviceInfo.Service.Name) {
 						monitoredServices = append(monitoredServices, serviceInfo.Service.Name)
 					}

--- a/src/cmd/cli/command/compose_test.go
+++ b/src/cmd/cli/command/compose_test.go
@@ -10,7 +10,7 @@ func TestGetUnreferencedManagedResources(t *testing.T) {
 	t.Run("no services", func(t *testing.T) {
 		project := types.Services{}
 
-		managed, unmanaged := splitProjectServicesByManageType(project)
+		managed, unmanaged := splitManagedAndUnmanagedServices(project)
 		if len(managed) != 0 {
 			t.Errorf("Expected 0 managed resources, got %d (%v)", len(managed), managed)
 		}
@@ -27,7 +27,7 @@ func TestGetUnreferencedManagedResources(t *testing.T) {
 			},
 		}
 
-		managed, unmanaged := splitProjectServicesByManageType(project)
+		managed, unmanaged := splitManagedAndUnmanagedServices(project)
 		if len(managed) != 1 {
 			t.Errorf("Expected 1 managed resource, got %d (%v)", len(managed), managed)
 		}
@@ -42,7 +42,7 @@ func TestGetUnreferencedManagedResources(t *testing.T) {
 			"service1": types.ServiceConfig{},
 		}
 
-		managed, unmanaged := splitProjectServicesByManageType(project)
+		managed, unmanaged := splitManagedAndUnmanagedServices(project)
 		if len(managed) != 0 {
 			t.Errorf("Expected 0 managed resource, got %d (%v)", len(managed), managed)
 		}
@@ -61,7 +61,7 @@ func TestGetUnreferencedManagedResources(t *testing.T) {
 			},
 		}
 
-		managed, unmanaged := splitProjectServicesByManageType(project)
+		managed, unmanaged := splitManagedAndUnmanagedServices(project)
 		if len(managed) != 1 {
 			t.Errorf("Expected 1 managed resource, got %d (%v)", len(managed), managed)
 		}
@@ -77,7 +77,7 @@ func TestGetUnreferencedManagedResources(t *testing.T) {
 			"service2": types.ServiceConfig{},
 		}
 
-		managed, unmanaged := splitProjectServicesByManageType(project)
+		managed, unmanaged := splitManagedAndUnmanagedServices(project)
 		if len(managed) != 0 {
 			t.Errorf("Expected 0 managed resource, got %d (%v)", len(managed), managed)
 		}
@@ -98,7 +98,7 @@ func TestGetUnreferencedManagedResources(t *testing.T) {
 			},
 		}
 
-		managed, unmanaged := splitProjectServicesByManageType(project)
+		managed, unmanaged := splitManagedAndUnmanagedServices(project)
 		if len(managed) != 2 {
 			t.Errorf("Expected 2 managed resource, got %d (%s)", len(managed), managed)
 		}

--- a/src/cmd/cli/command/compose_test.go
+++ b/src/cmd/cli/command/compose_test.go
@@ -10,9 +10,13 @@ func TestGetUnreferencedManagedResources(t *testing.T) {
 	t.Run("no services", func(t *testing.T) {
 		project := types.Services{}
 
-		managed := getUnreferencedManagedResources(project)
+		managed, unmanaged := splitProjectServicesByManageType(project)
 		if len(managed) != 0 {
 			t.Errorf("Expected 0 managed resources, got %d (%v)", len(managed), managed)
+		}
+
+		if len(unmanaged) != 0 {
+			t.Errorf("Expected 0 unmanaged resources, got %d (%v)", len(unmanaged), unmanaged)
 		}
 	})
 
@@ -23,9 +27,13 @@ func TestGetUnreferencedManagedResources(t *testing.T) {
 			},
 		}
 
-		managed := getUnreferencedManagedResources(project)
+		managed, unmanaged := splitProjectServicesByManageType(project)
 		if len(managed) != 1 {
 			t.Errorf("Expected 1 managed resource, got %d (%v)", len(managed), managed)
+		}
+
+		if len(unmanaged) != 0 {
+			t.Errorf("Expected 0 unmanaged resource, got %d (%v)", len(unmanaged), unmanaged)
 		}
 	})
 
@@ -34,10 +42,15 @@ func TestGetUnreferencedManagedResources(t *testing.T) {
 			"service1": types.ServiceConfig{},
 		}
 
-		managed := getUnreferencedManagedResources(project)
+		managed, unmanaged := splitProjectServicesByManageType(project)
 		if len(managed) != 0 {
 			t.Errorf("Expected 0 managed resource, got %d (%v)", len(managed), managed)
 		}
+
+		if len(unmanaged) != 1 {
+			t.Errorf("Expected 1 unmanaged resource, got %d (%v)", len(unmanaged), unmanaged)
+		}
+
 	})
 
 	t.Run("one service unmanaged, one service managed", func(t *testing.T) {
@@ -48,9 +61,13 @@ func TestGetUnreferencedManagedResources(t *testing.T) {
 			},
 		}
 
-		managed := getUnreferencedManagedResources(project)
+		managed, unmanaged := splitProjectServicesByManageType(project)
 		if len(managed) != 1 {
 			t.Errorf("Expected 1 managed resource, got %d (%v)", len(managed), managed)
+		}
+
+		if len(unmanaged) != 1 {
+			t.Errorf("Expected 1 unmanaged resource, got %d (%v)", len(unmanaged), unmanaged)
 		}
 	})
 
@@ -60,25 +77,33 @@ func TestGetUnreferencedManagedResources(t *testing.T) {
 			"service2": types.ServiceConfig{},
 		}
 
-		managed := getUnreferencedManagedResources(project)
+		managed, unmanaged := splitProjectServicesByManageType(project)
 		if len(managed) != 0 {
 			t.Errorf("Expected 0 managed resource, got %d (%v)", len(managed), managed)
+		}
+
+		if len(unmanaged) != 2 {
+			t.Errorf("Expected 2 unmanaged resource, got %d (%v)", len(unmanaged), unmanaged)
 		}
 	})
 
 	t.Run("one service two managed", func(t *testing.T) {
 		project := types.Services{
-			"service1": types.ServiceConfig{
+			"service1": types.ServiceConfig{},
+			"service2": types.ServiceConfig{
 				Extensions: map[string]any{"x-defang-postgres": true},
 			},
-			"service2": types.ServiceConfig{
+			"service3": types.ServiceConfig{
 				Extensions: map[string]any{"x-defang-redis": true},
 			},
 		}
 
-		managed := getUnreferencedManagedResources(project)
+		managed, unmanaged := splitProjectServicesByManageType(project)
 		if len(managed) != 2 {
 			t.Errorf("Expected 2 managed resource, got %d (%s)", len(managed), managed)
+		}
+		if len(unmanaged) != 1 {
+			t.Errorf("Expected 1 unmanaged resource, got %d (%s)", len(unmanaged), unmanaged)
 		}
 	})
 }

--- a/src/pkg/cli/client/byoc/aws/byoc.go
+++ b/src/pkg/cli/client/byoc/aws/byoc.go
@@ -52,21 +52,21 @@ type ByocAws struct {
 	*byoc.ByocBaseClient
 
 	cdImageTag      string
-	cdTasks         map[string]ecs.TaskArn
 	delegationSetId string
 	driver          *cfn.AwsEcs
 
 	ecsEventHandlers []ECSEventHandler
 	handlersLock     sync.RWMutex
+	lastCdEtag       types.ETag
 	lastCdStart      time.Time
+	lastCdTaskArn    ecs.TaskArn
 }
 
 var _ client.Provider = (*ByocAws)(nil)
 
 func NewByocProvider(ctx context.Context, grpcClient client.GrpcClient, tenantId types.TenantID) *ByocAws {
 	b := &ByocAws{
-		cdTasks: make(map[string]ecs.TaskArn),
-		driver:  cfn.New(byoc.CdTaskPrefix, aws.Region("")), // default region
+		driver: cfn.New(byoc.CdTaskPrefix, aws.Region("")), // default region
 	}
 	b.ByocBaseClient = byoc.NewByocBaseClient(ctx, grpcClient, tenantId, b)
 	return b
@@ -253,8 +253,9 @@ func (b *ByocAws) deploy(ctx context.Context, req *defangv1.DeployRequest, cmd s
 	if err != nil {
 		return nil, err
 	}
-	b.cdTasks[etag] = taskArn
+	b.lastCdEtag = etag
 	b.lastCdStart = time.Now()
+	b.lastCdTaskArn = taskArn
 
 	for _, si := range serviceInfos {
 		if si.UseAcmeCert {
@@ -479,7 +480,9 @@ func (b *ByocAws) Delete(ctx context.Context, req *defangv1.DeleteRequest) (*def
 		return nil, byoc.AnnotateAwsError(err)
 	}
 	etag := ecs.GetTaskID(taskArn) // TODO: this is the CD task ID, not the etag
-	b.cdTasks[etag] = taskArn
+	b.lastCdEtag = etag
+	b.lastCdStart = time.Now()
+	b.lastCdTaskArn = taskArn
 	return &defangv1.DeleteResponse{Etag: etag}, nil
 }
 
@@ -679,6 +682,7 @@ func (b *ByocAws) Follow(ctx context.Context, req *defangv1.TailRequest) (client
 			service = req.Services[0]
 		}
 		eventStream, err = ecs.TailLogGroups(ctx, req.Since.AsTime(), b.getLogGroupInputs(etag, service)...)
+		taskArn = b.lastCdTaskArn
 	}
 	if err != nil {
 		return nil, byoc.AnnotateAwsError(err)
@@ -716,9 +720,9 @@ func (b *ByocAws) getLogGroupInputs(etag types.ETag, service string) []ecs.LogGr
 	ecsTail := ecs.LogGroupInput{LogGroupARN: b.makeLogGroupARN(b.stackDir("ecs"))} // must match logic in ecs/common.ts; TODO: filter by etag/service/deploymentId
 	term.Debug("Query ecs events logs", ecsTail.LogGroupARN)
 	cdTail := ecs.LogGroupInput{LogGroupARN: b.driver.LogGroupARN} // TODO: filter by etag
-	// If we know the CD task ARN, only tail the logstream for the CD task
-	if taskArn := b.cdTasks[etag]; taskArn != nil {
-		cdTail.LogStreamNames = []string{ecs.GetCDLogStreamForTaskID(ecs.GetTaskID(taskArn))}
+	// If we know the CD task ARN, only tail the logstream for that CD task
+	if b.lastCdTaskArn != nil && b.lastCdEtag == etag {
+		cdTail.LogStreamNames = []string{ecs.GetCDLogStreamForTaskID(ecs.GetTaskID(b.lastCdTaskArn))}
 	}
 	term.Debug("Query CD logs", cdTail.LogGroupARN, cdTail.LogStreamNames)
 	return []ecs.LogGroupInput{cdTail, kanikoTail, servicesTail, ecsTail} // more or less in chronological order

--- a/src/pkg/cli/subscribe.go
+++ b/src/pkg/cli/subscribe.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -19,7 +20,7 @@ func (e ErrDeploymentFailed) Error() string {
 	return fmt.Sprintf("deployment failed for service %q", e.Service)
 }
 
-var ErrNothingToDeploy = errors.New("no services to deploy")
+var ErrNothingToMonitor = errors.New("no services to monitor")
 
 func WaitServiceState(ctx context.Context, provider client.Provider, targetState defangv1.ServiceState, etag string, services []string) error {
 	term.Debugf("waiting for services %v to reach state %s\n", services, targetState) // TODO: don't print in Go-routine
@@ -29,7 +30,7 @@ func WaitServiceState(ctx context.Context, provider client.Provider, targetState
 	}
 
 	if len(services) == 0 {
-		return ErrNothingToDeploy
+		return ErrNothingToMonitor
 	}
 
 	// Assume "services" are normalized service names

--- a/src/pkg/cli/subscribe.go
+++ b/src/pkg/cli/subscribe.go
@@ -26,6 +26,10 @@ func WaitServiceState(ctx context.Context, provider client.Provider, targetState
 		return ErrDryRun
 	}
 
+	if len(services) == 0 {
+		return nil
+	}
+
 	// Assume "services" are normalized service names
 	subscribeRequest := defangv1.SubscribeRequest{Etag: etag, Services: services}
 	serverStream, err := provider.Subscribe(ctx, &subscribeRequest)

--- a/src/pkg/cli/subscribe.go
+++ b/src/pkg/cli/subscribe.go
@@ -19,13 +19,7 @@ func (e ErrDeploymentFailed) Error() string {
 	return fmt.Sprintf("deployment failed for service %q", e.Service)
 }
 
-type ErrNothingToDeploy struct {
-	Service string
-}
-
-func (e ErrNothingToDeploy) Error() string {
-	return "no services to deploy"
-}
+var ErrNothingToDeploy = errors.New("no services to deploy")
 
 func WaitServiceState(ctx context.Context, provider client.Provider, targetState defangv1.ServiceState, etag string, services []string) error {
 	term.Debugf("waiting for services %v to reach state %s\n", services, targetState) // TODO: don't print in Go-routine
@@ -35,7 +29,7 @@ func WaitServiceState(ctx context.Context, provider client.Provider, targetState
 	}
 
 	if len(services) == 0 {
-		return ErrNothingToDeploy{}
+		return ErrNothingToDeploy
 	}
 
 	// Assume "services" are normalized service names

--- a/src/pkg/cli/subscribe.go
+++ b/src/pkg/cli/subscribe.go
@@ -19,6 +19,14 @@ func (e ErrDeploymentFailed) Error() string {
 	return fmt.Sprintf("deployment failed for service %q", e.Service)
 }
 
+type ErrNothingToDeploy struct {
+	Service string
+}
+
+func (e ErrNothingToDeploy) Error() string {
+	return "no services to deploy"
+}
+
 func WaitServiceState(ctx context.Context, provider client.Provider, targetState defangv1.ServiceState, etag string, services []string) error {
 	term.Debugf("waiting for services %v to reach state %s\n", services, targetState) // TODO: don't print in Go-routine
 
@@ -27,7 +35,7 @@ func WaitServiceState(ctx context.Context, provider client.Provider, targetState
 	}
 
 	if len(services) == 0 {
-		return nil
+		return ErrNothingToDeploy{}
 	}
 
 	// Assume "services" are normalized service names

--- a/src/pkg/clouds/aws/ecs/tail.go
+++ b/src/pkg/clouds/aws/ecs/tail.go
@@ -86,7 +86,11 @@ func (a *AwsEcs) TailTaskID(ctx context.Context, taskID string) (EventStream, er
 }
 
 func GetCDLogStreamForTaskID(taskID string) string {
-	return path.Join(AwsLogsStreamPrefix, CdContainerName, taskID) // per "awslogs" driver
+	return GetLogStreamForTaskID(CrunProjectName, CdContainerName, taskID)
+}
+
+func GetLogStreamForTaskID(awslogsStreamPrefix, containerName, taskID string) string {
+	return path.Join(awslogsStreamPrefix, containerName, taskID) // per "awslogs" driver
 }
 
 func GetTaskID(taskArn TaskArn) string {

--- a/src/pkg/clouds/aws/ecs/tail_test.go
+++ b/src/pkg/clouds/aws/ecs/tail_test.go
@@ -5,9 +5,9 @@ import (
 )
 
 func TestGetLogStreamForTaskID(t *testing.T) {
-	expectedLogStream := "crun/main/12345678123412341234123456789012"
+	expectedLogStream := "prefix/main_app/12345678123412341234123456789012"
 
-	logStream := GetCDLogStreamForTaskID("12345678123412341234123456789012")
+	logStream := GetLogStreamForTaskID("prefix", "main_app", "12345678123412341234123456789012")
 
 	if logStream != expectedLogStream {
 		t.Errorf("Expected log stream %q, but got %q", expectedLogStream, logStream)


### PR DESCRIPTION
fixes #659 

When doing ```defang compose up``` the CLI will not exit until all services are complete. Because we do not get managed resources (ElastiCache redis/RDS postgres) statuses we will assume they are already up and it'll be up to the service apps to complete before exiting the CLI.