### PR TITLE
Check for missing interpolation vars

### DIFF
--- a/src/pkg/cli/compose/validation_test.go
+++ b/src/pkg/cli/compose/validation_test.go
@@ -23,6 +23,18 @@ func TestValidationAndConvert(t *testing.T) {
 
 	t.Setenv("NODE_ENV", "test") // for interpolate/compose.yaml
 
+	mockClient := validationMockProvider{
+		configs: []string{"CONFIG1", "CONFIG2", "dummy", "ENV1", "SENSITIVE_DATA"},
+	}
+	listConfigNamesFunc := func(ctx context.Context) ([]string, error) {
+		configs, err := mockClient.ListConfig(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		return configs.Names, nil
+	}
+
 	testRunCompose(t, func(t *testing.T, path string) {
 		t.Helper()
 		logs := new(bytes.Buffer)
@@ -33,18 +45,6 @@ func TestValidationAndConvert(t *testing.T) {
 		project, err := loader.LoadProject(context.Background())
 		if err != nil {
 			t.Fatal(err)
-		}
-
-		mockClient := validationMockProvider{
-			configs: []string{"CONFIG1", "CONFIG2", "dummy", "ENV1", "SENSITIVE_DATA"},
-		}
-		listConfigNamesFunc := func(ctx context.Context) ([]string, error) {
-			configs, err := mockClient.ListConfig(ctx)
-			if err != nil {
-				return nil, err
-			}
-
-			return configs.Names, nil
 		}
 
 		if err := ValidateProjectConfig(context.Background(), project, listConfigNamesFunc); err != nil {
@@ -74,48 +74,42 @@ func TestValidationAndConvert(t *testing.T) {
 	})
 }
 
-func TestValidateConfig(t *testing.T) {
-	const ENV_VAR = "ENV_VAR"
+func makeListConfigNamesFunc(configs ...string) func(context.Context) ([]string, error) {
+	return func(context.Context) ([]string, error) {
+		return configs, nil
+	}
+}
 
+func TestValidateConfig(t *testing.T) {
 	ctx := context.Background()
-	mockClient := validationMockProvider{}
 
 	testProject := composeTypes.Project{
 		Services: composeTypes.Services{},
 	}
 
-	listConfigsNamesFunc := func(ctx context.Context) ([]string, error) {
-		configs, err := mockClient.ListConfig(ctx)
-		if err != nil {
-			return nil, err
-		}
-
-		return configs.Names, nil
-	}
 	t.Run("NOP", func(t *testing.T) {
 		env := map[string]*string{
-			ENV_VAR: ptr.String("blah"),
+			"ENV_VAR": ptr.String("blah"),
 		}
-
 		testProject.Services["service1"] = composeTypes.ServiceConfig{Environment: env}
-		if err := ValidateProjectConfig(ctx, &testProject, listConfigsNamesFunc); err != nil {
+
+		if err := ValidateProjectConfig(ctx, &testProject, makeListConfigNamesFunc()); err != nil {
 			t.Fatal(err)
 		}
 	})
 
 	t.Run("Missing Config", func(t *testing.T) {
-		var missing ErrMissingConfig
 		env := map[string]*string{
-			ENV_VAR: ptr.String("blah"),
-			"ASD":   nil,
-			"BSD":   nil,
-			"CSD":   nil,
+			"ENV_VAR": ptr.String("blah"),
+			"ASD":     nil,
+			"BSD":     nil,
+			"CSD":     nil,
 		}
-
-		ctx := context.Background()
 		testProject.Services["service1"] = composeTypes.ServiceConfig{Environment: env}
-		if err := ValidateProjectConfig(ctx, &testProject, listConfigsNamesFunc); !errors.As(err, &missing) {
-			t.Fatalf("uexpected ErrMissingConfig, got: %v", err)
+
+		var missing ErrMissingConfig
+		if err := ValidateProjectConfig(ctx, &testProject, makeListConfigNamesFunc()); !errors.As(err, &missing) {
+			t.Fatalf("expected ErrMissingConfig, got: %v", err)
 		} else {
 			if len(missing) != 3 {
 				t.Fatalf("unexpected error: number of missing, got: %d expected 3", len(missing))
@@ -131,14 +125,34 @@ func TestValidateConfig(t *testing.T) {
 
 	t.Run("Valid Config", func(t *testing.T) {
 		const CONFIG_VAR = "CONFIG_VAR"
-		mockClient.configs = []string{CONFIG_VAR}
 		env := map[string]*string{
-			ENV_VAR:    ptr.String("blah"),
+			"ENV_VAR":  ptr.String("blah"),
 			CONFIG_VAR: nil,
 		}
 		testProject.Services["service1"] = composeTypes.ServiceConfig{Environment: env}
-		if err := ValidateProjectConfig(ctx, &testProject, listConfigsNamesFunc); err != nil {
+
+		if err := ValidateProjectConfig(ctx, &testProject, makeListConfigNamesFunc(CONFIG_VAR)); err != nil {
 			t.Fatal(err)
+		}
+	})
+
+	t.Run("Missing interpolated variable", func(t *testing.T) {
+		env := map[string]*string{
+			"interpolated": ptr.String(`${CONFIG_VAR}`),
+		}
+		testProject.Services["service1"] = composeTypes.ServiceConfig{Environment: env}
+
+		var missing ErrMissingConfig
+		if err := ValidateProjectConfig(ctx, &testProject, makeListConfigNamesFunc()); !errors.As(err, &missing) {
+			t.Fatalf("expected ErrMissingConfig, got: %v", err)
+		} else {
+			if len(missing) != 1 {
+				t.Fatalf("unexpected error: number of missing, got: %d expected 1", len(missing))
+			}
+
+			if missing[0] != "CONFIG_VAR" {
+				t.Fatalf("unexpected error: missing, got: %s expected CONFIG_VAR", missing[0])
+			}
 		}
 	})
 }

--- a/src/tests/interpolate/compose.yaml.warnings
+++ b/src/tests/interpolate/compose.yaml.warnings
@@ -1,3 +1,4 @@
  ! Environment variable "NODE_ENV" is not used; add it to `.env` if needed
  ! Environment variable "NODE_ENV" is not used; add it to `.env` or it may be resolved from config during deployment
  ! service "interpolate": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors
+missing configs ["NODE_ENV" "POSTGRES_PASSWORD" "def"]


### PR DESCRIPTION
This fixes the issue @acote88 ran into when you use a var in an interpolated env. We don't check whether the var is actually added to config, so then this causes an exception during deployment (and on top of that CD keeps running forever.)

Alternatively, we could silently resolve these missing vars to empty string, which is what the shell/docker do, but I think an error avoid wasting time on wondering why something doesn't work.

Fixes https://github.com/DefangLabs/defang-mvp/issues/1148 