### PR TITLE
Add DEFANG_NO_CACHE env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ The Defang CLI recognizes the following environment variables:
 - `DEFANG_FABRIC` - The address of the Defang Fabric to use; defaults to `fabric-prod1.defang.dev`
 - `DEFANG_HIDE_HINTS` - If set to `true`, hides hints in the CLI output; defaults to `false`
 - `DEFANG_HIDE_UPDATE` - If set to `true`, hides the update notification; defaults to `false`
+- `DEFANG_NO_CACHE` - If set to `true`, disables pull-through caching of container images; defaults to `false`
 - `DEFANG_PREFIX` - The prefix to use for all BYOC resources; defaults to `Defang`
 - `DEFANG_PROVIDER` - The name of the cloud provider to use, `auto` (default), `aws`, `digitalocean`, or `defang`
 - `DEFANG_PULUMI_DIR` - Run Pulumi from this folder, instead of spawning a cloud task; requires `--debug` (BYOC only)

--- a/src/pkg/cli/client/byoc/aws/byoc.go
+++ b/src/pkg/cli/client/byoc/aws/byoc.go
@@ -143,7 +143,7 @@ func (b *ByocAws) getCdImageTag(ctx context.Context) (string, error) {
 		return b.cdImageTag, nil
 	}
 
-	// see if we already have a deployment running; use the same cd image tag
+	// see if we have a previous deployment; use the same cd image tag
 	projUpdate, err := b.getProjectUpdate(ctx)
 	if err != nil {
 		return "", err

--- a/src/pkg/cli/client/byoc/aws/byoc.go
+++ b/src/pkg/cli/client/byoc/aws/byoc.go
@@ -143,7 +143,7 @@ func (b *ByocAws) getCdImageTag(ctx context.Context) (string, error) {
 		return b.cdImageTag, nil
 	}
 
-	// see if we already have a deployment running
+	// see if we already have a deployment running; use the same cd image tag
 	projUpdate, err := b.getProjectUpdate(ctx)
 	if err != nil {
 		return "", err
@@ -490,6 +490,10 @@ func (b *ByocAws) stackDir(name string) string {
 }
 
 func (b *ByocAws) getProjectUpdate(ctx context.Context) (*defangv1.ProjectUpdate, error) {
+	if b.ProjectName == "" {
+		return nil, nil // no services yet
+	}
+
 	bucketName := b.bucketName()
 	if bucketName == "" {
 		if err := b.driver.FillOutputs(ctx); err != nil {

--- a/src/pkg/cli/client/byoc/aws/byoc_test.go
+++ b/src/pkg/cli/client/byoc/aws/byoc_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/DefangLabs/defang/src/pkg/cli/client"
+	"github.com/DefangLabs/defang/src/pkg/cli/client/byoc"
 	"github.com/DefangLabs/defang/src/pkg/cli/compose"
 	"github.com/DefangLabs/defang/src/pkg/clouds/aws/ecs"
 	"github.com/DefangLabs/defang/src/pkg/types"
@@ -163,4 +164,33 @@ func TestSubscribe(t *testing.T) {
 			wg.Wait()
 		})
 	}
+}
+
+func TestGetCDImageTag(t *testing.T) {
+	ctx := context.Background()
+	b := NewByocProvider(ctx, client.GrpcClient{}, "tenant1")
+
+	t.Run("no project should use latest", func(t *testing.T) {
+		const expected = byoc.CdLatestImageTag
+		tag, err := b.getCdImageTag(ctx)
+		if err != nil {
+			t.Fatalf("getCdImageTag() failed: %v", err)
+		}
+		if tag != expected {
+			t.Errorf("expected tag %q, got %q", expected, tag)
+		}
+	})
+
+	t.Run("can be overridden by DEFANG_CD_IMAGE", func(t *testing.T) {
+		const expected = "abc"
+		t.Setenv("DEFANG_CD_IMAGE", "defanglabs/cd:"+expected)
+
+		tag, err := b.getCdImageTag(ctx)
+		if err != nil {
+			t.Fatalf("getCdImageTag() failed: %v", err)
+		}
+		if tag != expected {
+			t.Errorf("expected tag %q, got %q", expected, tag)
+		}
+	})
 }

--- a/src/pkg/cli/client/byoc/baseclient.go
+++ b/src/pkg/cli/client/byoc/baseclient.go
@@ -205,12 +205,12 @@ func (b *ByocBaseClient) loadProjectNameFromRemote(ctx context.Context) (string,
 		return "", errors.New("no projects found")
 	}
 	if len(projectNames) == 1 {
-		term.Debug("Using default project: ", projectNames[0])
+		term.Debug("Using default project:", projectNames[0])
 		b.SetProjectName(projectNames[0])
 		return projectNames[0], nil
 	}
 
-	term.Warn("Multiple projects found: ", projectNames)
+	term.Warn("Multiple projects found:", projectNames)
 
 	return "", errors.New("use the --project-name flag to specify a project")
 }


### PR DESCRIPTION
We should discuss if we want to enable pull-through caching by default (it saves $$ and is "faster"), especially considering that the pull-through cache repos do not have image lifecycle rules, ie. images never get purged. This is something we'll have to add to the CloudFormation template eventually. See https://github.com/aws/containers-roadmap/issues/1758 