### PR TITLE
Avoid "no bucket found" error on first DO deploy

### DIFF
--- a/src/cmd/cli/command/compose_test.go
+++ b/src/cmd/cli/command/compose_test.go
@@ -50,7 +50,6 @@ func TestGetUnreferencedManagedResources(t *testing.T) {
 		if len(unmanaged) != 1 {
 			t.Errorf("Expected 1 unmanaged resource, got %d (%v)", len(unmanaged), unmanaged)
 		}
-
 	})
 
 	t.Run("one service unmanaged, one service managed", func(t *testing.T) {

--- a/src/cmd/cli/command/compose_test.go
+++ b/src/cmd/cli/command/compose_test.go
@@ -50,6 +50,7 @@ func TestGetUnreferencedManagedResources(t *testing.T) {
 		if len(unmanaged) != 1 {
 			t.Errorf("Expected 1 unmanaged resource, got %d (%v)", len(unmanaged), unmanaged)
 		}
+
 	})
 
 	t.Run("one service unmanaged, one service managed", func(t *testing.T) {

--- a/src/pkg/cli/client/byoc/do/byoc.go
+++ b/src/pkg/cli/client/byoc/do/byoc.go
@@ -644,13 +644,32 @@ func (b *ByocDo) update(service composeTypes.ServiceConfig) *defangv1.ServiceInf
 	return si
 }
 
-func (b *ByocDo) setUp(ctx context.Context) error {
+func (b *ByocDo) needsSetup(ctx context.Context) (bool, error) {
 	projectCdImageTag, err := b.getCdImageTag(ctx)
+
+	if err != nil {
+		if strings.Contains(err.Error(), "no bucket found") {
+			return true, nil
+		} else {
+			return true, err
+		}
+	}
+
+	b.cdImageTag = projectCdImageTag
+	if b.SetupDone && b.cdImageTag == projectCdImageTag {
+		return false, nil
+	}
+
+	return true, nil
+}
+
+func (b *ByocDo) setUp(ctx context.Context) error {
+	needsSetup, err := b.needsSetup(ctx)
 	if err != nil {
 		return err
 	}
 
-	if b.SetupDone && b.cdImageTag == projectCdImageTag {
+	if !needsSetup {
 		return nil
 	}
 
@@ -678,6 +697,10 @@ func (b *ByocDo) setUp(ctx context.Context) error {
 	}
 
 	b.buildRepo = registry.Name + "/kaniko-build" // TODO: use/add b.PulumiProject but only if !starter
+	projectCdImageTag, err := b.getCdImageTag(ctx)
+	if err != nil {
+		return err
+	}
 
 	b.cdImageTag = projectCdImageTag
 	b.SetupDone = true

--- a/src/pkg/cli/client/byoc/do/byoc.go
+++ b/src/pkg/cli/client/byoc/do/byoc.go
@@ -644,32 +644,13 @@ func (b *ByocDo) update(service composeTypes.ServiceConfig) *defangv1.ServiceInf
 	return si
 }
 
-func (b *ByocDo) needsSetup(ctx context.Context) (bool, error) {
-	projectCdImageTag, err := b.getCdImageTag(ctx)
-
-	if err != nil {
-		if strings.Contains(err.Error(), "no bucket found") {
-			return true, nil
-		} else {
-			return true, err
-		}
-	}
-
-	b.cdImageTag = projectCdImageTag
-	if b.SetupDone && b.cdImageTag == projectCdImageTag {
-		return false, nil
-	}
-
-	return true, nil
-}
-
 func (b *ByocDo) setUp(ctx context.Context) error {
-	needsSetup, err := b.needsSetup(ctx)
+	projectCdImageTag, err := b.getCdImageTag(ctx)
 	if err != nil {
 		return err
 	}
 
-	if !needsSetup {
+	if b.SetupDone && b.cdImageTag == projectCdImageTag {
 		return nil
 	}
 
@@ -697,10 +678,6 @@ func (b *ByocDo) setUp(ctx context.Context) error {
 	}
 
 	b.buildRepo = registry.Name + "/kaniko-build" // TODO: use/add b.PulumiProject but only if !starter
-	projectCdImageTag, err := b.getCdImageTag(ctx)
-	if err != nil {
-		return err
-	}
 
 	b.cdImageTag = projectCdImageTag
 	b.SetupDone = true

--- a/src/pkg/cli/client/byoc/do/byoc.go
+++ b/src/pkg/cli/client/byoc/do/byoc.go
@@ -170,6 +170,11 @@ func (b *ByocDo) deploy(ctx context.Context, req *defangv1.DeployRequest, cmd st
 		return nil, err
 	}
 
+	cdImageTag, err := b.getCdImageTag(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	etag := pkg.RandomID()
 
 	serviceInfos := []*defangv1.ServiceInfo{}
@@ -192,7 +197,7 @@ func (b *ByocDo) deploy(ctx context.Context, req *defangv1.DeployRequest, cmd st
 	}
 
 	data, err := proto.Marshal(&defangv1.ProjectUpdate{
-		CdVersion: b.cdImageTag,
+		CdVersion: cdImageTag,
 		Compose:   req.Compose,
 		Services:  serviceInfos,
 	})
@@ -645,12 +650,7 @@ func (b *ByocDo) update(service composeTypes.ServiceConfig) *defangv1.ServiceInf
 }
 
 func (b *ByocDo) setUp(ctx context.Context) error {
-	projectCdImageTag, err := b.getCdImageTag(ctx)
-	if err != nil {
-		return err
-	}
-
-	if b.SetupDone && b.cdImageTag == projectCdImageTag {
+	if b.SetupDone {
 		return nil
 	}
 
@@ -678,8 +678,6 @@ func (b *ByocDo) setUp(ctx context.Context) error {
 	}
 
 	b.buildRepo = registry.Name + "/kaniko-build" // TODO: use/add b.PulumiProject but only if !starter
-
-	b.cdImageTag = projectCdImageTag
 	b.SetupDone = true
 
 	return nil


### PR DESCRIPTION
It looks like https://github.com/DefangLabs/defang/pull/746 introduced a regression where we try to read from an s3 bucket before we've created it. I noticed this trying to deploy a project to a fresh DO account this morning.

This PR permits the returned `"no bucket found"` error and continues with setup in this case.