### PR TITLE
Return nil ProjectUpdate on no bucket

### DIFF
--- a/src/pkg/cli/client/byoc/do/byoc.go
+++ b/src/pkg/cli/client/byoc/do/byoc.go
@@ -116,6 +116,7 @@ func (b *ByocDo) getProjectUpdate(ctx context.Context) (*defangv1.ProjectUpdate,
 	}
 
 	if bucketName == "" {
+		// bucket is not created yet; return empty update in that case
 		return nil, nil // no services yet
 	}
 

--- a/src/pkg/cli/client/byoc/do/byoc.go
+++ b/src/pkg/cli/client/byoc/do/byoc.go
@@ -116,7 +116,7 @@ func (b *ByocDo) getProjectUpdate(ctx context.Context) (*defangv1.ProjectUpdate,
 	}
 
 	if bucketName == "" {
-		return nil, errors.New("no bucket found")
+		return nil, nil // no services yet
 	}
 
 	path := fmt.Sprintf("projects/%s/%s/project.pb", b.ProjectName, b.PulumiStack)


### PR DESCRIPTION
To match the AWS behavior, if no bucket is found we return a `nil` `ProjectUpdate` pointer.