### PR TITLE
Consider redirection a success response for cert gen trigger

### DIFF
--- a/src/pkg/cli/cert.go
+++ b/src/pkg/cli/cert.go
@@ -244,9 +244,9 @@ func waitForCNAME(ctx context.Context, domain string, targets []string, client c
 	if err := verifyDNS(); err == nil {
 		return nil
 	}
-	term.Infof("Please set up a CNAME record for %v", domain)
-	fmt.Printf("  %v  CNAME or as an alias to [ %v ]\n", domain, strings.Join(targets, " or "))
-	term.Infof("Waiting for CNAME record setup and DNS propagation...")
+	term.Infof("Configure a CNAME or ALIAS record for the domain name: %v", domain)
+	fmt.Printf("  %v  -> %v\n", domain, strings.Join(targets, " or "))
+	term.Infof("Awaiting DNS record setup and propagation... This may take a while.")
 
 	for {
 		select {
@@ -283,7 +283,7 @@ func getWithRetries(ctx context.Context, url string, tries int) error {
 			}
 		} else if cve := new(tls.CertificateVerificationError); errors.As(err, &cve) {
 			term.Debugf("cert gen request success, received tls error: %v", cve)
-			return nil // tls error indicate a successful cert generation, as it has to be redirected to https
+			return nil // tls error indicate a successful cert gen trigger, as it has to be redirected to https
 		}
 
 		term.Debugf("Error fetching %v: %v, tries left %v", url, err, tries-i-1)

--- a/src/pkg/cli/cert_test.go
+++ b/src/pkg/cli/cert_test.go
@@ -32,6 +32,9 @@ func (c *testClient) Do(req *http.Request) (*http.Response, error) {
 	}
 	tr := c.tries[0]
 	c.tries = c.tries[1:]
+	if tr.result != nil && tr.result.Request == nil {
+		tr.result.Request = req
+	}
 	return tr.result, tr.err
 }
 
@@ -88,11 +91,27 @@ func TestGetWithRetries(t *testing.T) {
 		err := getWithRetries(context.Background(), "http://example.com", 3)
 		if err == nil {
 			t.Errorf("Expected error, got %v", err)
-		} else if !strings.Contains(err.Error(), "HTTP 503: Random Error") {
-			t.Errorf("Expected HTTP 503: Random Error, got %v", err)
+		} else if !strings.Contains(err.Error(), "HTTP: 503") {
+			t.Errorf("Expected HTTP 503:, got %v", err)
 		}
 		if tc.calls != 3 {
 			t.Errorf("Expected 3 calls, got %v", tc.calls)
+		}
+	})
+	t.Run("redirect to https considers success", func(t *testing.T) {
+		redirectURL, _ := url.Parse("https://example.com")
+		tc := &testClient{tries: []tryResult{
+			{result: &http.Response{StatusCode: 503, Request: &http.Request{URL: redirectURL}, Body: mockBody("Random Error")}, err: nil},
+		}}
+		originalClient := httpClient
+		t.Cleanup(func() { httpClient = originalClient })
+		httpClient = tc
+		err := getWithRetries(context.Background(), "http://example.com", 3)
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+		if tc.calls != 1 {
+			t.Errorf("Expected 1 call, got %v", tc.calls)
 		}
 	})
 	t.Run("handles all http errors", func(t *testing.T) {
@@ -107,7 +126,7 @@ func TestGetWithRetries(t *testing.T) {
 		err := getWithRetries(context.Background(), "http://example.com", 3)
 		if err == nil {
 			t.Errorf("Expected error, got %v", err)
-		} else if !strings.Contains(err.Error(), "HTTP 404: Random Error") || !strings.Contains(err.Error(), "HTTP 502: Random Error") || !strings.Contains(err.Error(), "HTTP 503: Random Error") {
+		} else if !strings.Contains(err.Error(), "HTTP: 404") || !strings.Contains(err.Error(), "HTTP: 502") || !strings.Contains(err.Error(), "HTTP: 503") {
 			t.Errorf("Expected HTTP 404,502,503 erros, got %v", err)
 		}
 		if tc.calls != 3 {


### PR DESCRIPTION
Also create fast path for DNS check success, so no need to display the DNS setup instructions.

### Example execution log:
#### Non-verbose:
```
 * Checking DNS setup for api21.defang.study
 * Please set up a CNAME record for api21.defang.study
  api21.defang.study  CNAME or as an alias to [ api.dayifunet.edwardrf.defang.app or api--80.dayifunet.edwardrf.defang.app ]
 * Waiting for CNAME record setup and DNS propagation...
 * api21.defang.study DNS is properly configured!
 * Triggering cert generation for api21.defang.study
 * Waiting for TLS cert to be online for api21.defang.study, this could take a few minutes
 * TLS cert for api21.defang.study is ready
 * Checking DNS setup for web21.defang.study
 * web21.defang.study DNS is properly configured!
 * Triggering cert generation for web21.defang.study
 * Waiting for TLS cert to be online for web21.defang.study, this could take a few minutes
 * TLS cert for web21.defang.study is ready
```
#### Verbose: 
```
- Generating TLS cert for project "dayifunet"
 - Getting services from bucket: defang-cd-bucket-cybpbzz8hzm7 projects/dayifunet/beta/project.pb
 - Found service api with domain api21.defang.study and targets [api.dayifunet.edwardrf.defang.app api--80.dayifunet.edwardrf.defang.app]
 * Checking DNS setup for api21.defang.study
 - Server side DNS verification negative result: DNS not ready
 * Please set up a CNAME record for api21.defang.study
  api21.defang.study  CNAME or as an alias to [ api.dayifunet.edwardrf.defang.app or api--80.dayifunet.edwardrf.defang.app ]
 * Waiting for CNAME record setup and DNS propagation...
 - Server side DNS verification negative result: DNS not ready
 - Server side DNS verification negative result: DNS not ready
 - Server side DNS verification negative result: DNS not ready
 - Server side DNS verification negative result: DNS not ready
 - Server side DNS verification negative result: DNS not ready
 - Server side DNS verification negative result: DNS not ready
 - Server side DNS verification negative result: DNS not ready
 - Server side DNS verification negative result: DNS not ready
 - Server side DNS verification negative result: DNS not ready
 - Server side DNS verification negative result: DNS not ready
 - Server side DNS verification negative result: DNS not ready
 - Server side DNS verification negative result: DNS not ready
 - Server side DNS verification for api21.defang.study successful
 - CNAME for api21.defang.study is: 'api.dayifunet.edwardrf.defang.app.', err: <nil>
 - CNAME for api21.defang.study is in sync: api.dayifunet.edwardrf.defang.app
 * api21.defang.study DNS is properly configured!
 * Triggering cert generation for api21.defang.study
 - Redirecting from http://api21.defang.study to https://api21.defang.study/
 * Waiting for TLS cert to be online for api21.defang.study, this could take a few minutes
 - Error checking TLS cert for api21.defang.study: Get "https://api21.defang.study": tls: failed to verify certificate: x509: certificate relies on legacy Common Name field, use SANs instead
 - Error checking TLS cert for api21.defang.study: Get "https://api21.defang.study": tls: failed to verify certificate: x509: certificate relies on legacy Common Name field, use SANs instead
 - Error checking TLS cert for api21.defang.study: Get "https://api21.defang.study": tls: failed to verify certificate: x509: certificate relies on legacy Common Name field, use SANs instead
 - Error checking TLS cert for api21.defang.study: Get "https://api21.defang.study": tls: failed to verify certificate: x509: certificate relies on legacy Common Name field, use SANs instead
 - Error checking TLS cert for api21.defang.study: Get "https://api21.defang.study": tls: failed to verify certificate: x509: certificate relies on legacy Common Name field, use SANs instead
 - Error checking TLS cert for api21.defang.study: Get "https://api21.defang.study": tls: failed to verify certificate: x509: certificate relies on legacy Common Name field, use SANs instead
 - Error checking TLS cert for api21.defang.study: Get "https://api21.defang.study": tls: failed to verify certificate: x509: certificate relies on legacy Common Name field, use SANs instead
 - Error checking TLS cert for api21.defang.study: Get "https://api21.defang.study": tls: failed to verify certificate: x509: certificate relies on legacy Common Name field, use SANs instead
 - Error checking TLS cert for api21.defang.study: Get "https://api21.defang.study": tls: failed to verify certificate: x509: certificate relies on legacy Common Name field, use SANs instead
 - Error checking TLS cert for api21.defang.study: Get "https://api21.defang.study": tls: failed to verify certificate: x509: certificate relies on legacy Common Name field, use SANs instead
 * TLS cert for api21.defang.study is ready
 - Found service web with domain web21.defang.study and targets [web.dayifunet.edwardrf.defang.app web--8080.dayifunet.edwardrf.defang.app]
 * Checking DNS setup for web21.defang.study
 - Server side DNS verification for web21.defang.study successful
 - CNAME for web21.defang.study is: 'web.dayifunet.edwardrf.defang.app.', err: <nil>
 - CNAME for web21.defang.study is in sync: web.dayifunet.edwardrf.defang.app
 * web21.defang.study DNS is properly configured!
 * Triggering cert generation for web21.defang.study
 - Redirecting from http://web21.defang.study to https://web21.defang.study/
 - cert gen request success, received redirect to https://web21.defang.study/
 * Waiting for TLS cert to be online for web21.defang.study, this could take a few minutes
 - Error checking TLS cert for web21.defang.study: Get "https://web21.defang.study": tls: failed to verify certificate: x509: certificate relies on legacy Common Name field, use SANs instead
 - Error checking TLS cert for web21.defang.study: Get "https://web21.defang.study": tls: failed to verify certificate: x509: certificate relies on legacy Common Name field, use SANs instead
 - Error checking TLS cert for web21.defang.study: Get "https://web21.defang.study": tls: failed to verify certificate: x509: certificate relies on legacy Common Name field, use SANs instead
 - Error checking TLS cert for web21.defang.study: Get "https://web21.defang.study": tls: failed to verify certificate: x509: certificate relies on legacy Common Name field, use SANs instead
 - Error checking TLS cert for web21.defang.study: Get "https://web21.defang.study": tls: failed to verify certificate: x509: certificate relies on legacy Common Name field, use SANs instead
 - Error checking TLS cert for web21.defang.study: Get "https://web21.defang.study": tls: failed to verify certificate: x509: certificate relies on legacy Common Name field, use SANs instead
 - Error checking TLS cert for web21.defang.study: Get "https://web21.defang.study": tls: failed to verify certificate: x509: certificate relies on legacy Common Name field, use SANs instead
 - Error checking TLS cert for web21.defang.study: Get "https://web21.defang.study": tls: failed to verify certificate: x509: certificate relies on legacy Common Name field, use SANs instead
 - Error checking TLS cert for web21.defang.study: Get "https://web21.defang.study": tls: failed to verify certificate: x509: certificate relies on legacy Common Name field, use SANs instead
 - Error checking TLS cert for web21.defang.study: Get "https://web21.defang.study": tls: failed to verify certificate: x509: certificate relies on legacy Common Name field, use SANs instead
 - Error checking TLS cert for web21.defang.study: Get "https://web21.defang.study": tls: failed to verify certificate: x509: certificate relies on legacy Common Name field, use SANs instead
 - Error checking TLS cert for web21.defang.study: Get "https://web21.defang.study": tls: failed to verify certificate: x509: certificate relies on legacy Common Name field, use SANs instead
 * TLS cert for web21.defang.study is ready
For help with warnings, check our FAQ at https://docs.defang.io/docs/faq
```