### PR TITLE
Gracefully handle abnormal EOF from DO log stream

### DIFF
--- a/src/pkg/cli/client/byoc/do/stream.go
+++ b/src/pkg/cli/client/byoc/do/stream.go
@@ -3,6 +3,7 @@ package do
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/url"
 	"strings"
 	"time"
@@ -90,6 +91,14 @@ func (bs *byocServerStream) Receive() bool {
 }
 
 func (bs *byocServerStream) Err() error {
+	var closeErr *websocket.CloseError
+	ok := errors.As(bs.err, &closeErr)
+	if !ok {
+		return bs.err
+	}
+	if closeErr.Text == "unexpected EOF" {
+		return nil
+	}
 	return bs.err
 }
 


### PR DESCRIPTION
When deploying to DO, we open a websocket connection to AppPlatform to tail logs to the user's shell. It seems like the websocket connection is hitting an idle timeout and closing, but our client doesn't expect it, so successful deploys to DO will tail the logs, then timeout and return a non-zero exit code.

I see two potential strategies here:

1. try to reopen the connect
2. anticipate that it will close after some time, and exit 0

This PR implements strategy (2). This means that successful deploys will tail the run logs for a period of time and then the websocket connection will eventually timeout and the process will exit successfully.

This also means that `defang tail` will not behave the same way, which may be surprising to users who expect it to block indefinitely. I think exiting cleanly on deploy is more important, so I say we circle back to `defang tail` blocking forever in a followup.
