### PR TITLE
Show project name in ls warning

### DIFF
--- a/src/cmd/cli/command/compose.go
+++ b/src/cmd/cli/command/compose.go
@@ -320,11 +320,11 @@ func makeComposeLsCmd() *cobra.Command {
 
 			err := cli.GetServices(cmd.Context(), provider, long)
 			if err != nil {
-				if !errors.Is(err, cli.ErrNoServices) {
+				if errNoServices := new(cli.ErrNoServices); !errors.As(err, errNoServices) {
 					return err
 				}
 
-				term.Warn("No services found")
+				term.Warn(err)
 
 				printDefangHint("To start a new project, do:", "new")
 				return nil

--- a/src/pkg/cli/getServices.go
+++ b/src/pkg/cli/getServices.go
@@ -2,14 +2,20 @@ package cli
 
 import (
 	"context"
-	"errors"
+	"fmt"
 
 	"github.com/DefangLabs/defang/src/pkg/cli/client"
 	"github.com/DefangLabs/defang/src/pkg/term"
 	defangv1 "github.com/DefangLabs/defang/src/protos/io/defang/v1"
 )
 
-var ErrNoServices = errors.New("no services found")
+type ErrNoServices struct {
+	ProjectName string
+}
+
+func (e ErrNoServices) Error() string {
+	return fmt.Sprintf("no services found in project %q", e.ProjectName)
+}
 
 func GetServices(ctx context.Context, provider client.Provider, long bool) error {
 	projectName, err := provider.LoadProjectName(ctx)
@@ -24,7 +30,7 @@ func GetServices(ctx context.Context, provider client.Provider, long bool) error
 	}
 
 	if len(serviceList.Services) == 0 {
-		return ErrNoServices
+		return ErrNoServices{ProjectName: projectName}
 	}
 
 	if !long {

--- a/src/pkg/cli/getServices_test.go
+++ b/src/pkg/cli/getServices_test.go
@@ -1,0 +1,38 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/DefangLabs/defang/src/pkg/cli/client"
+	defangv1 "github.com/DefangLabs/defang/src/protos/io/defang/v1"
+)
+
+type mockGetServicesProvider struct {
+	client.Provider
+}
+
+func (mockGetServicesProvider) LoadProjectName(ctx context.Context) (string, error) {
+	return "TestGetServices", nil
+}
+
+func (mockGetServicesProvider) GetServices(ctx context.Context) (*defangv1.ListServicesResponse, error) {
+	return &defangv1.ListServicesResponse{}, nil
+}
+
+func TestGetServices(t *testing.T) {
+	ctx := context.Background()
+	provider := mockGetServicesProvider{}
+
+	t.Run("ErrNoServices", func(t *testing.T) {
+		err := GetServices(ctx, provider, false)
+		if err == nil {
+			t.Error("expected error")
+		}
+		var e ErrNoServices
+		if !errors.As(err, &e) {
+			t.Errorf("expected %T, got %T", e, err)
+		}
+	})
+}


### PR DESCRIPTION
Currently, you don't notice when there's a compose file in a parent folder:
```
 * Using AWS provider
 ! No services found
 ```
 
By showing the project name it is obvious which project is being listed:
```
 * Using AWS provider
 ! no services found in project "dev"
 ```
(lower case because we print the Go err as-is)