### PR TITLE
Use pipefail to fix exit code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,7 @@ install-git-hooks:
 	chmod +x .git/hooks/pre-push
 
 .PHONY: pre-commit
-pre-commit:
-	make lint-fix
+pre-commit: lint-fix
 
 .PHONY: pre-push
 pre-push:
@@ -15,8 +14,8 @@ pre-push:
 
 .PHONY: lint
 lint:
-	cd src && golangci-lint run
+	make -C src lint
 
 .PHONY: lint-fix
 lint-fix:
-	cd src && golangci-lint run --fix
+	make -C src lint-fix

--- a/src/Makefile
+++ b/src/Makefile
@@ -20,11 +20,11 @@ install: $(BINARY_NAME)
 .PHONY: test
 test: $(PROTOS)
 	go mod tidy
-	go test -test.short ./... | sed -e 's/\(--- FAIL.*\)/[0;31m\1[0m/g'
+	set -o pipefail ; go test -test.short ./... | sed -e 's/\(--- FAIL.*\)/[0;31m\1[0m/g'
 
 .PHONY: integ
 integ: $(PROTOS)
-	go test -v -tags=integration ./... | sed -e 's/\(--- FAIL.*\)/[0;31m\1[0m/g'
+	set -o pipefail ; go test -v -tags=integration ./... | sed -e 's/\(--- FAIL.*\)/[0;31m\1[0m/g'
 
 .PHONY: linux-amd64
 linux-amd64: test
@@ -61,3 +61,11 @@ pull:
 release: pull test no-diff
 	git tag $$(git tag -l 'v*' --sort=-v:refname | head -n1 | awk -F. '{$$NF = $$NF + 1;} 1' OFS=.)
 	git push --follow-tags --tags
+
+.PHONY: lint
+lint:
+	golangci-lint run
+
+.PHONY: lint-fix
+lint-fix:
+	golangci-lint run --fix


### PR DESCRIPTION
`go test … | sed …` is used to color the failures red, but it would erase the exit code from `go test`. Using `set -o pipefail` to make the pipe fail if the LHS fails.