### PR TITLE
LogType bitfield

### DIFF
--- a/src/pkg/logs/fluent.go
+++ b/src/pkg/logs/fluent.go
@@ -19,4 +19,5 @@ type FirelensMessage struct {
 	EcsCluster        string `json:"ecs_cluster,omitempty"`         // ECS metadata
 	Etag              string `json:"etag,omitempty"`                // added by us
 	Host              string `json:"host,omitempty"`                // added by us
+	Service           string `json:"service,omitempty"`             // added by us
 }

--- a/src/pkg/logs/log_type.go
+++ b/src/pkg/logs/log_type.go
@@ -1,0 +1,104 @@
+package logs
+
+import (
+	"fmt"
+	"strings"
+)
+
+type LogType uint32
+
+type InvalidLogTypeError struct {
+	Value string
+}
+
+func (e InvalidLogTypeError) Error() string {
+	return fmt.Sprintf("invalid log type: %q, must be one of %v", e.Value, AllLogTypes)
+}
+
+const (
+	LogTypeUnspecified LogType = 0
+	LogTypeRun         LogType = 1 << iota
+	LogTypeBuild
+
+	LogTypeAll LogType = 0xFFFFFFFF
+)
+
+var AllLogTypes = []LogType{
+	LogTypeRun,
+	LogTypeBuild,
+}
+
+var (
+	LogType_name = map[LogType]string{
+		LogTypeUnspecified: "UNSPECIFIED",
+		LogTypeRun:         "RUN",
+		LogTypeBuild:       "BUILD",
+		LogTypeAll:         "ALL",
+	}
+	LogType_value = map[string]LogType{
+		"UNSPECIFIED": LogTypeUnspecified,
+		"RUN":         LogTypeRun,
+		"BUILD":       LogTypeBuild,
+		"ALL":         LogTypeAll,
+	}
+)
+
+func (c *LogType) Set(value string) error {
+	value = strings.TrimSpace(strings.ToUpper(value))
+
+	if value == "" {
+		*c = LogTypeUnspecified
+		return nil
+	}
+
+	if value == "ALL" {
+		*c = LogTypeAll
+		return nil
+	}
+
+	parts := strings.Split(value, ",")
+	for _, part := range parts {
+		logType, ok := LogType_value[part]
+		if !ok {
+			return InvalidLogTypeError{Value: value}
+		}
+
+		*c |= logType
+	}
+
+	return nil
+}
+
+func (c LogType) Has(logType LogType) bool {
+	return c&logType != 0
+}
+
+func (c LogType) Type() string {
+	return "log-type"
+}
+
+func (c LogType) Value() string {
+	return c.String()
+}
+
+func ParseLogType(value string) (LogType, error) {
+	var logType LogType
+	err := logType.Set(value)
+	return logType, err
+}
+
+func (c LogType) String() string {
+	// convert the bitfield into a comma-separated list of log types
+	var logTypes []string
+	for _, logType := range AllLogTypes {
+		if c&logType != 0 {
+			logTypes = append(logTypes, LogType_name[logType])
+		}
+	}
+
+	if len(logTypes) == 0 {
+		return LogType_name[LogTypeUnspecified]
+	}
+
+	return strings.Join(logTypes, ",")
+}

--- a/src/pkg/logs/log_type_test.go
+++ b/src/pkg/logs/log_type_test.go
@@ -1,0 +1,127 @@
+package logs
+
+import "testing"
+
+func TestParseLogType(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   string
+		want    LogType
+		wantErr bool
+	}{
+		{"empty", "", LogTypeUnspecified, false},
+		{"unspecified", "unspecified", LogTypeUnspecified, true},
+		{"run", "run", LogTypeRun, false},
+		{"build", "build", LogTypeBuild, false},
+		{"all", "all", LogTypeAll, false},
+		{"invalid", "invalid", LogTypeUnspecified, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseLogType(tt.value)
+			if err != nil && !tt.wantErr {
+				t.Errorf("ParseLogType() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Errorf("ParseLogType() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLogTypeString(t *testing.T) {
+	tests := []struct {
+		name  string
+		value LogType
+		want  string
+	}{
+		{"unspecified", LogTypeUnspecified, "UNSPECIFIED"},
+		{"run", LogTypeRun, "RUN"},
+		{"build", LogTypeBuild, "BUILD"},
+		{"all", LogTypeAll, "RUN,BUILD"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.value.String(); got != tt.want {
+				t.Errorf("LogType.String() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLogTypeSet(t *testing.T) {
+	tests := []struct {
+		name    string
+		init    string
+		value   string
+		want    LogType
+		wantErr bool
+	}{
+		{"empty from unspecified", "", "", LogTypeUnspecified, true},
+		{"run from unspecified", "", "run", LogTypeRun, false},
+		{"build from unspecified", "", "build", LogTypeBuild, false},
+		{"all from unspecified", "", "all", LogTypeAll, false},
+		{"invalid from unspecified", "", "invalid", LogTypeUnspecified, true},
+		{"empty from run", "", "", LogTypeRun, true},
+		{"run from run", "", "run", LogTypeRun, false},
+		{"build from run", "", "build", LogTypeAll, false},
+		{"all from run", "", "all", LogTypeAll, false},
+		{"invalid from run", "", "invalid", LogTypeRun, true},
+		{"empty from build", "", "", LogTypeBuild, true},
+		{"run from build", "", "run", LogTypeAll, false},
+		{"build from build", "", "build", LogTypeBuild, false},
+		{"all from build", "", "all", LogTypeAll, false},
+		{"invalid from build", "", "invalid", LogTypeRun, true},
+		{"empty from all", "", "", LogTypeAll, true},
+		{"run from all", "", "run", LogTypeAll, false},
+		{"build from all", "", "build", LogTypeAll, false},
+		{"all from all", "", "all", LogTypeAll, false},
+		{"invalid from all", "", "invalid", LogTypeAll, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logType, err := ParseLogType(tt.init)
+			if err != nil {
+				t.Errorf("ParseLogType() error = %v", err)
+				return
+			}
+			err = logType.Set(tt.value)
+			if err != nil && !tt.wantErr {
+				t.Errorf("LogType.Set() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestLogTypeHas(t *testing.T) {
+	tests := []struct {
+		name  string
+		value LogType
+		arg   LogType
+		want  bool
+	}{
+		{"unspecified has unspecified", LogTypeUnspecified, LogTypeUnspecified, false},
+		{"unspecified has run", LogTypeUnspecified, LogTypeRun, false},
+		{"unspecified has build", LogTypeUnspecified, LogTypeBuild, false},
+		{"unspecified has all", LogTypeUnspecified, LogTypeAll, false},
+		{"run has unspecified", LogTypeRun, LogTypeUnspecified, false},
+		{"run has run", LogTypeRun, LogTypeRun, true},
+		{"run has build", LogTypeRun, LogTypeBuild, false},
+		{"run has all", LogTypeRun, LogTypeAll, true},
+		{"build has unspecified", LogTypeBuild, LogTypeUnspecified, false},
+		{"build has run", LogTypeBuild, LogTypeRun, false},
+		{"build has build", LogTypeBuild, LogTypeBuild, true},
+		{"build has all", LogTypeBuild, LogTypeAll, true},
+		{"all has unspecified", LogTypeAll, LogTypeUnspecified, false},
+		{"all has run", LogTypeAll, LogTypeRun, true},
+		{"all has build", LogTypeAll, LogTypeBuild, true},
+		{"all has all", LogTypeAll, LogTypeAll, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.value.Has(tt.arg); got != tt.want {
+				t.Errorf("LogType.Has() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

Pre-requisite for logtype partitioning in https://github.com/DefangLabs/defang-mvp/pull/1205

* Setting up `LogType` as a bitfield which will be extracted from the `uint32` protobuf attribute `TailRequest.log_type`.
* Add `Service` attribute to `FirelensMessage`

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added appropriate tests
- [x] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

