### PR TITLE
Collect interpolated vars

### DIFF
--- a/src/cmd/cli/command/collectUnsetEnvVars_test.go
+++ b/src/cmd/cli/command/collectUnsetEnvVars_test.go
@@ -150,7 +150,7 @@ func TestCollectUnsetEnvVars(t *testing.T) {
 			expected: []string{"config", "CONFIG"},
 		},
 		{
-			name: "Service with interpolcated var",
+			name: "Service with interpolated var",
 			project: &types.Project{
 				Services: map[string]types.ServiceConfig{
 					"service1": {

--- a/src/cmd/cli/command/collectUnsetEnvVars_test.go
+++ b/src/cmd/cli/command/collectUnsetEnvVars_test.go
@@ -149,6 +149,20 @@ func TestCollectUnsetEnvVars(t *testing.T) {
 			},
 			expected: []string{"config", "CONFIG"},
 		},
+		{
+			name: "Service with interpolcated var",
+			project: &types.Project{
+				Services: map[string]types.ServiceConfig{
+					"service1": {
+						Name: "service1",
+						Environment: types.MappingWithEquals{
+							"ENV1": stringPtr("${ENV2}"),
+						},
+					},
+				},
+			},
+			expected: []string{"ENV2"},
+		},
 	}
 
 	for _, tt := range tests {

--- a/src/cmd/cli/command/commands.go
+++ b/src/cmd/cli/command/commands.go
@@ -608,19 +608,17 @@ var newCmd = &cobra.Command{
 }
 
 func collectUnsetEnvVars(project *composeTypes.Project) []string {
-	var envVars []string
-	if project != nil {
-		for _, service := range project.Services {
-			for key, value := range service.Environment {
-				if value == nil {
-					envVars = append(envVars, key)
-				}
-			}
-		}
+	if project == nil {
+		return nil // in case loading failed
 	}
-	// Deduplicate by sorting and then compacting (uniq)
-	slices.Sort(envVars)
-	return slices.Compact(envVars)
+	err := compose.ValidateProjectConfig(context.TODO(), project, func(ctx context.Context) ([]string, error) {
+		return nil, nil // assume no config
+	})
+	var missingConfig compose.ErrMissingConfig
+	if errors.As(err, &missingConfig) {
+		return missingConfig
+	}
+	return nil
 }
 
 var getVersionCmd = &cobra.Command{

--- a/src/pkg/cli/client/playground.go
+++ b/src/pkg/cli/client/playground.go
@@ -78,6 +78,8 @@ func (g *PlaygroundProvider) Destroy(ctx context.Context, req *defangv1.DestroyR
 	for _, service := range servicesList.Services {
 		names = append(names, service.Service.Name)
 	}
+
+	// FIXME: use Destroy rpc instead of Delete rpc
 	resp, err := g.Delete(ctx, &defangv1.DeleteRequest{Project: req.Project, Names: names})
 	if err != nil {
 		return "", err


### PR DESCRIPTION
## Description

<!-- Concise description of what this PR is tackling. -->
After `defang new` we show the user which configs must be added, but this was missing interpolated vars.

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

