### PR TITLE
Call FillOutputs in AWS Follow

### DIFF
--- a/src/pkg/cli/client/byoc/aws/byoc.go
+++ b/src/pkg/cli/client/byoc/aws/byoc.go
@@ -696,6 +696,11 @@ func (b *ByocAws) Query(ctx context.Context, req *defangv1.DebugRequest) error {
 }
 
 func (b *ByocAws) Follow(ctx context.Context, req *defangv1.TailRequest) (client.ServerStream[defangv1.TailResponse], error) {
+	// FillOutputs is needed to get the CD task ARN
+	if err := b.driver.FillOutputs(ctx); err != nil {
+		return nil, AnnotateAwsError(err)
+	}
+
 	etag := req.Etag
 	// if etag == "" && req.Service == "cd" {
 	// 	etag = awsecs.GetTaskID(b.cdTaskArn); TODO: find the last CD task

--- a/src/pkg/clouds/aws/ecs/common.go
+++ b/src/pkg/clouds/aws/ecs/common.go
@@ -56,6 +56,7 @@ func (a *AwsEcs) GetVpcID() string {
 }
 
 func (a *AwsEcs) getAccountID() string {
+	// TaskDefARN was set by a call to FillOutputs
 	return aws.GetAccountID(a.TaskDefARN)
 }
 


### PR DESCRIPTION
## Description

<!-- Concise description of what this PR is tackling. -->
In AWS, `defang tail --etag …` would panic because it can't determine the AWS account ID from the TaskDefARN. 

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

