### PR TITLE
Edw/fix put config panic

### DIFF
--- a/src/pkg/cli/configSet.go
+++ b/src/pkg/cli/configSet.go
@@ -19,5 +19,5 @@ func ConfigSet(ctx context.Context, loader client.Loader, provider client.Provid
 		return ErrDryRun
 	}
 
-	return provider.PutConfig(ctx, &defangv1.PutConfigRequest{Name: name, Value: value})
+	return provider.PutConfig(ctx, &defangv1.PutConfigRequest{Project: projectName, Name: name, Value: value})
 }

--- a/src/pkg/cli/configSet_test.go
+++ b/src/pkg/cli/configSet_test.go
@@ -16,8 +16,7 @@ func TestConfigSet(t *testing.T) {
 	provider := MustHaveProjectNamePutConfigProvider{}
 	err := ConfigSet(ctx, loader, provider, "test_name", "test_value")
 	if err != nil {
-		t.Errorf("ConfigSet() error = %v", err)
-		return
+		t.Fatalf("ConfigSet() error = %v", err)
 	}
 }
 

--- a/src/pkg/cli/configSet_test.go
+++ b/src/pkg/cli/configSet_test.go
@@ -1,0 +1,33 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/DefangLabs/defang/src/pkg/cli/client"
+	"github.com/DefangLabs/defang/src/pkg/cli/compose"
+	defangv1 "github.com/DefangLabs/defang/src/protos/io/defang/v1"
+)
+
+func TestConfigSet(t *testing.T) {
+	ctx := context.Background()
+	loader := client.MockLoader{Project: &compose.Project{Name: "test"}}
+	provider := MustHaveProjectNamePutConfigProvider{}
+	err := ConfigSet(ctx, loader, provider, "test_name", "test_value")
+	if err != nil {
+		t.Errorf("ConfigSet() error = %v", err)
+		return
+	}
+}
+
+type MustHaveProjectNamePutConfigProvider struct {
+	client.Provider
+}
+
+func (m MustHaveProjectNamePutConfigProvider) PutConfig(ctx context.Context, req *defangv1.PutConfigRequest) error {
+	if req.Project == "" {
+		return errors.New("project name is missing")
+	}
+	return nil
+}


### PR DESCRIPTION
## Description
Bug fix for PutConfig api call missing project name.
Also verified no other requests with Project field is not set properly from PR  https://github.com/DefangLabs/defang/pull/813

## Linked Issues
Fixing a panic with set config
```
$ defang config  set TEST_ARG
 * Using AWS provider from defang server
? Enter value for "TEST_ARG": [? for help] ****
panic: ProjectName not set [recovered]
        panic: ProjectName not set

goroutine 1 [running]:
main.main.func1()
        /defang/src/cmd/cli/main.go:20 +0x145
panic({0x177a3a0?, 0xc0004bf870?})
        /home/edw/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.3.linux-amd64/src/runtime/panic.go:770 +0x132
github.com/DefangLabs/defang/src/pkg/cli/client/byoc/aws.ensure(...)
        /defang/src/pkg/cli/client/byoc/aws/byoc.go:987
github.com/DefangLabs/defang/src/pkg/cli/client/byoc/aws.(*ByocAws).stackDir(0x0?, {0x0?, 0x0?}, {0x7fff226c1f9e?, 0xc0002978b8?})
        /defang/src/pkg/cli/client/byoc/aws/byoc.go:535 +0x145
github.com/DefangLabs/defang/src/pkg/cli/client/byoc/aws.(*ByocAws).getSecretID(...)
        /defang/src/pkg/cli/client/byoc/aws/byoc.go:609
github.com/DefangLabs/defang/src/pkg/cli/client/byoc/aws.(*ByocAws).PutConfig(0xc000222150, {0x21f6200, 0xc00038ad70}, 0xc000490600)
        /defang/src/pkg/cli/client/byoc/aws/byoc.go:616 +0x153
github.com/DefangLabs/defang/src/pkg/cli.ConfigSet({0x21f6200, 0xc00038ad70}, {0x21e78c0?, 0xc00069e180?}, {0x2207218, 0xc000222150}, {0x7fff226c1f9e, 0x8}, {0xc000014400, 0x4})
        /defang/src/pkg/cli/configSet.go:22 +0x17f
github.com/DefangLabs/defang/src/cmd/cli/command.init.func13(0x2f1fb60, {0xc00021cbc0, 0x1, 0x1?})
        /defang/src/cmd/cli/command/commands.go:723 +0x6d5
github.com/spf13/cobra.(*Command).execute(0x2f1fb60, {0xc00021cac0, 0x1, 0x1})
        /home/edw/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:983 +0xaca
github.com/spf13/cobra.(*Command).ExecuteC(0x2f1cd60)
        /home/edw/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:1115 +0x3ff
github.com/spf13/cobra.(*Command).Execute(...)
        /home/edw/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:1039
github.com/spf13/cobra.(*Command).ExecuteContext(...)
        /home/edw/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:1032
github.com/DefangLabs/defang/src/cmd/cli/command.Execute({0x21f6200, 0xc00038ad70})
        /defang/src/cmd/cli/command/commands.go:69 +0xb3
main.main()
        /defang/src/cmd/cli/main.go:38 +0x114

```

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [X] I have performed a self-review of my code
- [X] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary -> not needed, bug fix

