### PR TITLE
Use a alternative description for stored provider preferrence

### DIFF
--- a/src/cmd/cli/command/commands.go
+++ b/src/cmd/cli/command/commands.go
@@ -1142,7 +1142,7 @@ func determineProviderID(ctx context.Context, loader *compose.Loader) (string, e
 			term.Warn("Unable to get selected provider:", err)
 		} else if resp.Provider != defangv1.Provider_PROVIDER_UNSPECIFIED {
 			providerID.SetEnumValue(resp.Provider)
-			return "defang server", nil
+			return "stored preference", nil
 		}
 	}
 


### PR DESCRIPTION
## Description
`Using AWS provider from defang server` is misleading and confusing. Choose a better description for the source:
```
 * Using AWS provider from stored preference
```

Feel free to propose better alternatives.