### PR TITLE
avoid redeclaring --type flag on logs cmd

### DIFF
--- a/src/cmd/cli/command/compose.go
+++ b/src/cmd/cli/command/compose.go
@@ -381,8 +381,7 @@ func makeComposeLogsCmd() *cobra.Command {
 			if !cmd.Flags().Changed("verbose") {
 				verbose = true // default verbose for explicit tail command
 			}
-			var logType logs.LogType
-			cmd.Flags().Var(&logType, "type", fmt.Sprintf(`show logs of type; one of %v`, logs.AllLogTypes))
+			logType := cmd.Flag("type").Value.(*logs.LogType) // nolint:forcetypeassert
 
 			if utc {
 				os.Setenv("TZ", "") // used by Go's "time" package, see https://pkg.go.dev/time#Location
@@ -404,8 +403,8 @@ func makeComposeLogsCmd() *cobra.Command {
 				services = strings.Split(name, ",")
 			}
 
-			if logType == logs.LogTypeUnspecified {
-				logType = logs.LogTypeRun
+			if *logType == logs.LogTypeUnspecified {
+				*logType = logs.LogTypeRun
 			}
 
 			term.Debug("logType", logType)
@@ -416,7 +415,7 @@ func makeComposeLogsCmd() *cobra.Command {
 				Since:    ts,
 				Raw:      raw,
 				Verbose:  verbose,
-				LogType:  logType,
+				LogType:  *logType,
 			}
 
 			loader := configureLoader(cmd)

--- a/src/cmd/cli/command/compose_test.go
+++ b/src/cmd/cli/command/compose_test.go
@@ -6,6 +6,17 @@ import (
 	"github.com/compose-spec/compose-go/v2/types"
 )
 
+func TestInitializeTailCmd(t *testing.T) {
+	t.Run("", func(t *testing.T) {
+		for _, cmd := range RootCmd.Commands() {
+			if cmd.Use == "logs" {
+				cmd.Execute()
+				return
+			}
+		}
+	})
+}
+
 func TestGetUnreferencedManagedResources(t *testing.T) {
 	t.Run("no services", func(t *testing.T) {
 		project := types.Services{}


### PR DESCRIPTION
## Description

Fixing a bug I introduced in #769 which caused the `--type` flag to be redeclared. Added a test to execute the logs command to verify the fix.

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

