### PR TITLE
Notify user if deployment will not be cancelled when terminating.

### DIFF
--- a/src/cmd/cli/command/commands.go
+++ b/src/cmd/cli/command/commands.go
@@ -104,7 +104,7 @@ func Execute(ctx context.Context) error {
 
 		var cerr *cli.CancelError
 		if errors.As(err, &cerr) {
-			printDefangHint("Detached. The process will keep running.\nTo continue the logs from where you left off, do:", cerr.Error())
+			printDefangHint("To continue the logs from where you left off, do:", cerr.Error())
 		}
 
 		code := connect.CodeOf(err)

--- a/src/cmd/cli/command/compose.go
+++ b/src/cmd/cli/command/compose.go
@@ -157,11 +157,7 @@ func makeComposeUpCmd() *cobra.Command {
 				}
 
 				// The tail was canceled; check if it was because of deployment failure or explicit cancelation or wait-timeout reached
-				if errors.Is(context.Cause(ctx), context.Canceled) {
-					// Tail was canceled by the user before deployment completion/failure; show a warning and exit with an error
-					term.Warn("Deployment is not finished. Service(s) might not be running.")
-					return err
-				} else if errors.Is(context.Cause(ctx), context.DeadlineExceeded) {
+				if errors.Is(context.Cause(ctx), context.DeadlineExceeded) {
 					// Tail was canceled when wait-timeout is reached; show a warning and exit with an error
 					term.Warn("Wait-timeout exceeded, detaching from logs. Deployment still in progress.")
 					return err

--- a/src/cmd/cli/command/compose.go
+++ b/src/cmd/cli/command/compose.go
@@ -64,8 +64,11 @@ func makeComposeUpCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			deploy, project, err := cli.ComposeUp(cmd.Context(), loader, client, provider, upload, mode.Value())
 
+			ctx, cancelTail := context.WithCancelCause(cmd.Context())
+			defer cancelTail(nil) // to cancel WaitServiceState and clean-up context
+
+			deploy, project, err := cli.ComposeUp(ctx, loader, client, provider, upload, mode.Value())
 			if err != nil {
 				if !nonInteractive && strings.Contains(err.Error(), "maximum number of projects") {
 					if resp, err2 := provider.GetServices(cmd.Context(), &defangv1.GetServicesRequest{Project: project.Name}); err2 == nil {
@@ -102,12 +105,9 @@ func makeComposeUpCmd() *cobra.Command {
 				return nil
 			}
 
-			tailCtx, cancelTail := context.WithCancelCause(cmd.Context())
-			defer cancelTail(nil) // to cancel WaitServiceState and clean-up context
-
 			if waitTimeout >= 0 {
 				var cancelTimeout context.CancelFunc
-				tailCtx, cancelTimeout = context.WithTimeout(tailCtx, time.Duration(waitTimeout)*time.Second)
+				ctx, cancelTimeout = context.WithTimeout(ctx, time.Duration(waitTimeout)*time.Second)
 				defer cancelTimeout()
 			}
 
@@ -115,7 +115,7 @@ func makeComposeUpCmd() *cobra.Command {
 			const targetState = defangv1.ServiceState_DEPLOYMENT_COMPLETED
 
 			go func() {
-				if err := cli.WaitServiceState(tailCtx, provider, targetState, deploy.Etag, unmanagedServices); err != nil {
+				if err := cli.WaitServiceState(ctx, provider, targetState, deploy.Etag, unmanagedServices); err != nil {
 					var errDeploymentFailed cli.ErrDeploymentFailed
 					if errors.As(err, &errDeploymentFailed) {
 						cancelTail(err)
@@ -143,38 +143,38 @@ func makeComposeUpCmd() *cobra.Command {
 			}
 
 			// blocking call to tail
-			if err := cli.Tail(tailCtx, loader, provider, tailParams); err != nil {
+			if err := cli.Tail(ctx, loader, provider, tailParams); err != nil {
 				term.Debug("Tail stopped with", err)
 
 				if connect.CodeOf(err) == connect.CodePermissionDenied {
 					// If tail fails because of missing permission, we wait for the deployment to finish
 					term.Warn("Unable to tail logs. Waiting for the deployment to finish.")
-					<-tailCtx.Done()
+					<-ctx.Done()
 					// Get the actual error from the context so we won't print "Error: missing tail permission"
-					err = context.Cause(tailCtx)
-				} else if !(errors.Is(tailCtx.Err(), context.Canceled) || errors.Is(tailCtx.Err(), context.DeadlineExceeded)) {
+					err = context.Cause(ctx)
+				} else if !(errors.Is(ctx.Err(), context.Canceled) || errors.Is(ctx.Err(), context.DeadlineExceeded)) {
 					return err // any error other than cancelation
 				}
 
 				// The tail was canceled; check if it was because of deployment failure or explicit cancelation or wait-timeout reached
-				if errors.Is(context.Cause(tailCtx), context.Canceled) {
+				if errors.Is(context.Cause(ctx), context.Canceled) {
 					// Tail was canceled by the user before deployment completion/failure; show a warning and exit with an error
 					term.Warn("Deployment is not finished. Service(s) might not be running.")
 					return err
-				} else if errors.Is(context.Cause(tailCtx), context.DeadlineExceeded) {
+				} else if errors.Is(context.Cause(ctx), context.DeadlineExceeded) {
 					// Tail was canceled when wait-timeout is reached; show a warning and exit with an error
 					term.Warn("Wait-timeout exceeded, detaching from logs. Deployment still in progress.")
 					return err
 				}
 
 				var errDeploymentFailed cli.ErrDeploymentFailed
-				if errors.As(context.Cause(tailCtx), &errDeploymentFailed) {
+				if errors.As(context.Cause(ctx), &errDeploymentFailed) {
 					// Tail got canceled because of deployment failure: prompt to show the debugger
 					term.Warn(errDeploymentFailed)
 					if !nonInteractive {
 						failedServices := []string{errDeploymentFailed.Service}
 						track.Evt("Debug Prompted", P("failedServices", failedServices), P("etag", deploy.Etag), P("reason", errDeploymentFailed))
-						// Call the AI debug endpoint using the original command context (not the tailCtx which is canceled)
+						// Call the AI debug endpoint using the original command context (not the ctx which is canceled)
 						_ = cli.InteractiveDebug(cmd.Context(), loader, client, provider, deploy.Etag, project, failedServices)
 					}
 					return err
@@ -182,7 +182,7 @@ func makeComposeUpCmd() *cobra.Command {
 			}
 
 			// Print the current service states of the deployment
-			if errors.Is(context.Cause(tailCtx), errCompleted) {
+			if errors.Is(context.Cause(ctx), errCompleted) {
 				for _, service := range deploy.Services {
 					service.State = targetState
 				}

--- a/src/pkg/cli/composeUp.go
+++ b/src/pkg/cli/composeUp.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/DefangLabs/defang/src/pkg/cli/client"
@@ -96,6 +97,13 @@ func ComposeUp(ctx context.Context, loader client.Loader, c client.FabricClient,
 			}
 			deployRequest.DelegationSetId = delegation.DelegationSetId
 		}
+		go func() {
+			<-ctx.Done()
+
+			if errors.Is(ctx.Err(), context.Canceled) || errors.Is(ctx.Err(), context.DeadlineExceeded) {
+				term.Warn("Deployment will not be cancelled.")
+			}
+		}()
 		resp, err = p.Deploy(ctx, deployRequest)
 		if err != nil {
 			return nil, project, err


### PR DESCRIPTION
## Description

We have been printing a message `Detached. The process will keep running` if the deployment process was terminated after the tail began, but this left a small window of time (between the deployment request being sent and the tail being initiated) where termination of the process would fail to cancel the deployment and we would not notify the user. This change covers that gap by sharing a cancellable context for both sending the deployment request and the tail.

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

