### PR TITLE
Added f and S flags to curl 

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Install defang (latest)
-        run: eval "$(curl -Ls https://s.defang.io/install)"
+        run: eval "$(curl -fsSL https://s.defang.io/install)"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }} # avoid rate limiting
 
@@ -24,7 +24,7 @@ jobs:
         run: defang --version
 
       - name: Install defang (specific version)
-        run: eval "$(curl -Ls https://s.defang.io/install)"
+        run: eval "$(curl -fsSL https://s.defang.io/install)"
         env:
           DEFANG_INSTALL_VERSION: v0.5.36
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # alt name

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Install the Defang CLI from one of the following sources:
 
 * Using a shell script:
   ```
-  eval "$(curl -Ls https://s.defang.io/install)"
+  eval "$(curl -fsSL https://s.defang.io/install)"
   ```
 
 * Using [Go](https://go.dev):

--- a/src/bin/install
+++ b/src/bin/install
@@ -3,7 +3,7 @@
 # This script installs the latest release of defang from GitHub. It is designed                #
 # to be run like this:                                                                         #
 #                                                                                              #
-# eval "$(curl -fsSL https://s.defang.io/install)"                                               #
+# eval "$(curl -fsSL https://s.defang.io/install)"                                             #
 #                                                                                              #
 # This allows us to do some interactive stuff where we can prompt the user for input.          #
 #                                                                                              #

--- a/src/bin/install
+++ b/src/bin/install
@@ -3,7 +3,7 @@
 # This script installs the latest release of defang from GitHub. It is designed                #
 # to be run like this:                                                                         #
 #                                                                                              #
-# eval "$(curl -Ls https://s.defang.io/install)"                                               #
+# eval "$(curl -fsSL https://s.defang.io/install)"                                               #
 #                                                                                              #
 # This allows us to do some interactive stuff where we can prompt the user for input.          #
 #                                                                                              #

--- a/src/pkg/cli/upgrade.go
+++ b/src/pkg/cli/upgrade.go
@@ -49,7 +49,7 @@ func Upgrade(ctx context.Context) error {
 	}
 
 	// Default to the shell script
-	printInstructions(`eval "$(curl -Ls https://s.defang.io/install)"`)
+	printInstructions(`eval "$(curl -fsSL https://s.defang.io/install)"`)
 
 	return nil
 }


### PR DESCRIPTION
## Description

`eval "$(curl -fsSL https://s.defang.io/install)"`

Added the `f` and `S` flags to the curl command in the install instructions. The `f` makes sure we don’t eval error messages, and the `S` ensures error messages are shown (even though we add `s` for “silent”).

## Linked Issues

Linked to #866
Updated /defang-docs repo https://github.com/DefangLabs/defang-docs/pull/115
Updated /samples repo https://github.com/DefangLabs/samples/pull/258
Updated /docs-chatbot repo https://github.com/DefangLabs/docs-chatbot/pull/19

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added appropriate tests
- [x] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

