### PR TITLE
Fix ai debug panic and wrong end point printed for byoc

### DIFF
--- a/src/pkg/cli/client/byoc/aws/byoc.go
+++ b/src/pkg/cli/client/byoc/aws/byoc.go
@@ -823,7 +823,7 @@ func (b *ByocAws) update(ctx context.Context, projectName, delegateDomain string
 		for _, port := range service.Ports {
 			hasIngress = hasIngress || port.Mode == compose.Mode_INGRESS
 			hasHost = hasHost || port.Mode == compose.Mode_HOST
-			si.Endpoints = append(si.Endpoints, b.getEndpoint(projectName, delegateDomain, fqn, &port))
+			si.Endpoints = append(si.Endpoints, b.getEndpoint(fqn, projectName, delegateDomain, &port))
 			mode := defangv1.Mode_INGRESS
 			if port.Mode == compose.Mode_HOST {
 				mode = defangv1.Mode_HOST

--- a/src/pkg/cli/debug.go
+++ b/src/pkg/cli/debug.go
@@ -72,6 +72,7 @@ func Debug(ctx context.Context, l client.Loader, c client.FabricClient, p client
 		Etag:     etag,
 		Files:    files,
 		Services: failedServices,
+		Project:  project.Name,
 	}
 	err := p.Query(ctx, &req)
 	if err != nil {


### PR DESCRIPTION
## Description

### 1. Fix the panic with ai debugger with no project name set:
```
panic: ProjectName not set [recovered]
        panic: ProjectName not set

goroutine 1 [running]:
main.main.func1()
        /Users/llunesu/dev/defang/src/cmd/cli/main.go:20 +0x144
panic({0x104154260?, 0x14000758430?})
        /nix/store/rfcwglhhspqx5v5h0sl4b3py14i6vpxa-go-1.22.7/share/go/src/runtime/panic.go:770 +0x124
github.com/DefangLabs/defang/src/pkg/cli/client/byoc/aws.ensure(...)
        /Users/llunesu/dev/defang/src/pkg/cli/client/byoc/aws/byoc.go:1023
github.com/DefangLabs/defang/src/pkg/cli/client/byoc/aws.(*ByocAws).stackDir(0x1400017cd40?, {0x0?, 0x1?}, {0x103c441d0?, 0x10446f620?})
        /Users/llunesu/dev/defang/src/pkg/cli/client/byoc/aws/byoc.go:556 +0x114
github.com/DefangLabs/defang/src/pkg/cli/client/byoc/aws.(*ByocAws).getLogGroupInputs(0x1400014e380, {0x140007da251?, 0xc?}, {0x0, 0x0}, {0x140002c604d?, 0x0?}, 0xffffffff)
        /Users/llunesu/dev/defang/src/pkg/cli/client/byoc/aws/byoc.go:791 +0x2fc
github.com/DefangLabs/defang/src/pkg/cli/client/byoc/aws.(*ByocAws).Query(0x140007f8120?, {0x104934080, 0x140003fe460}, 0x140007f87e0)
        /Users/llunesu/dev/defang/src/pkg/cli/client/byoc/aws/byoc.go:685 +0x104
github.com/DefangLabs/defang/src/pkg/cli.Debug({0x104934080, 0x140003fe460}, {0x104925878, 0x1400052c4e0}, {0x104941b88, 0x14000498120}, {0x104944898, 0x1400014e380}, {0x140007da251, 0xc}, ...)
        /Users/llunesu/dev/defang/src/pkg/cli/debug.go:76 +0x1d0
github.com/DefangLabs/defang/src/pkg/cli.InteractiveDebug({0x104934080, 0x140003fe460}, {0x104925878, 0x1400052c4e0}, {0x104941b88, 0x14000498120}, {0x104944898, 0x1400014e380}, {0x140007da251, 0xc}, ...)
        /Users/llunesu/dev/defang/src/pkg/cli/debug.go:47 +0x37c
github.com/DefangLabs/defang/src/cmd/cli/command.makeComposeUpCmd.func1(0x14000202c08, {0x1400008a700?, 0x0?, 0x4?})
        /Users/llunesu/dev/defang/src/cmd/cli/command/compose.go:178 +0xf24
github.com/spf13/cobra.(*Command).execute(0x14000202c08, {0x1400008a6c0, 0x4, 0x4})
        /Users/llunesu/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:983 +0x840
github.com/spf13/cobra.(*Command).ExecuteC(0x105621ee0)
        /Users/llunesu/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:1115 +0x344
github.com/spf13/cobra.(*Command).Execute(...)
```

### 2. Fix the wrong endpoint setup and printed for byoc
The order of parameters passed to getEndpoint was wrong.

## Linked Issues
Issue discovered and reported offline.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary --> bug fix, no doc change

