### PR TITLE
Need domain delegation for preview mode

### DIFF
--- a/src/pkg/cli/client/byoc/aws/byoc.go
+++ b/src/pkg/cli/client/byoc/aws/byoc.go
@@ -379,6 +379,7 @@ func (b *ByocAws) PrepareDomainDelegation(ctx context.Context, req client.Prepar
 		if zone != nil {
 			zoneId = zone.Id
 		}
+		// TODO: avoid creating the delegation set if we're in preview mode
 		delegationSet, err := aws.CreateDelegationSet(ctx, zoneId, r53Client)
 		var delegationSetAlreadyCreated *r53types.DelegationSetAlreadyCreated
 		var delegationSetAlreadyReusable *r53types.DelegationSetAlreadyReusable

--- a/src/pkg/cli/client/byoc/aws/byoc_integration_test.go
+++ b/src/pkg/cli/client/byoc/aws/byoc_integration_test.go
@@ -11,8 +11,6 @@ import (
 	"github.com/bufbuild/connect-go"
 )
 
-var ctx = context.Background()
-
 func TestDeploy(t *testing.T) {
 	b := NewByocProvider(ctx, "ten ant") // no domain
 

--- a/src/pkg/cli/client/provider.go
+++ b/src/pkg/cli/client/provider.go
@@ -103,6 +103,7 @@ type BootstrapCommandRequest struct {
 type PrepareDomainDelegationRequest struct {
 	Project        string
 	DelegateDomain string
+	Preview        bool
 }
 
 type PrepareDomainDelegationResponse struct {


### PR DESCRIPTION

## Description

`defang cd preview` is useful in BYOC to see what the diff is, but currently it fails because when there's no delegation ID, the CD TS code assumes a domain was created by the CLI, which is no longer the case, so the call to `getZone` fails. To add insult to injury, the error message does not show what domain is missing, but adding `DEFANG_DEBUG=1` will show the log from https://github.com/DefangLabs/defang-mvp/blob/c532d2431c1b887f5d557cace6624453908530a4/pulumi/shared/aws.ts#L151

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

