### PR TITLE
Make image Digest override Tag

### DIFF
--- a/src/pkg/cli/debug_test.go
+++ b/src/pkg/cli/debug_test.go
@@ -77,5 +77,4 @@ func TestQueryHasProject(t *testing.T) {
 			t.Errorf("expected error %q, got %q", "project name is missing", err.Error())
 		}
 	}
-
 }

--- a/src/pkg/clouds/do/appPlatform/setup.go
+++ b/src/pkg/clouds/do/appPlatform/setup.go
@@ -100,6 +100,7 @@ func shellQuote(args ...string) string {
 
 func getImageSourceSpec() (*godo.ImageSourceSpec, error) {
 	cdImagePath := byoc.GetCdImage(CdImageBase, byoc.CdLatestImageTag)
+	term.Debugf("Using CD image: %s", cdImagePath)
 	image, err := ParseImage(cdImagePath)
 	if err != nil {
 		return nil, err
@@ -108,7 +109,11 @@ func getImageSourceSpec() (*godo.ImageSourceSpec, error) {
 		image.Registry = path.Dir(image.Repo)
 		image.Repo = path.Base(image.Repo)
 	}
-	if image.Tag == "" && image.Digest == "" {
+	if image.Digest != "" {
+		// only one of jobs.image.tag or jobs.image.digest can be specified; digest takes precedence
+		image.Tag = ""
+	} else if image.Tag == "" {
+		// default to tag "latest"
 		image.Tag = "latest"
 	}
 	return &godo.ImageSourceSpec{

--- a/src/pkg/clouds/do/appPlatform/setup_test.go
+++ b/src/pkg/clouds/do/appPlatform/setup_test.go
@@ -1,6 +1,10 @@
 package appPlatform
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/digitalocean/godo"
+)
 
 func TestShellQuote(t *testing.T) {
 	// Given
@@ -31,5 +35,93 @@ func TestShellQuote(t *testing.T) {
 		if actual != test.expected {
 			t.Errorf("Expected `%s` but got: `%s`", test.expected, actual)
 		}
+	}
+}
+
+func Test_getImageSourceSpec(t *testing.T) {
+	// Given
+	tests := []struct {
+		imageURI string
+		expected *godo.ImageSourceSpec
+	}{
+		{
+			imageURI: "docker.io/library/nginx:tagx",
+			expected: &godo.ImageSourceSpec{
+				RegistryType: "DOCKER_HUB",
+				Registry:     "library",
+				Repository:   "nginx",
+				Tag:          "tagx",
+			},
+		},
+		{
+			imageURI: "docker.io/library/nginx",
+			expected: &godo.ImageSourceSpec{
+				RegistryType: "DOCKER_HUB",
+				Registry:     "library",
+				Repository:   "nginx",
+				Tag:          "latest",
+			},
+		},
+		{
+			imageURI: "nginx:latest",
+			expected: &godo.ImageSourceSpec{
+				RegistryType: "DOCKER_HUB",
+				// Registry:     "library",
+				Repository: "nginx",
+				Tag:        "latest",
+			},
+		},
+		{
+			imageURI: "nginx",
+			expected: &godo.ImageSourceSpec{
+				RegistryType: "DOCKER_HUB",
+				// Registry:     "library",
+				Repository: "nginx",
+				Tag:        "latest",
+			},
+		},
+		{
+			imageURI: "nginx@sha256:01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b",
+			expected: &godo.ImageSourceSpec{
+				RegistryType: "DOCKER_HUB",
+				// Registry:     "library",
+				Repository: "nginx",
+				Digest:     "sha256:01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b",
+			},
+		},
+		{
+			imageURI: "nginx:latest@sha256:01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b",
+			expected: &godo.ImageSourceSpec{
+				RegistryType: "DOCKER_HUB",
+				// Registry:     "library",
+				Repository: "nginx",
+				Digest:     "sha256:01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.imageURI, func(t *testing.T) {
+			t.Setenv("DEFANG_CD_IMAGE", test.imageURI)
+			actual, err := getImageSourceSpec()
+			if err != nil {
+				t.Fatalf("Expected no error but got: %s", err)
+			}
+			if expected, got := test.expected.RegistryType, actual.RegistryType; expected != got {
+				t.Errorf("Expected RegistryType `%s` but got: `%s`", expected, got)
+			}
+			if expected, got := test.expected.Registry, actual.Registry; expected != got {
+				t.Errorf("Expected Registry `%s` but got: `%s`", expected, got)
+			}
+			if expected, got := test.expected.Digest, actual.Digest; expected != got {
+				t.Errorf("Expected Digest `%s` but got: `%s`", expected, got)
+			}
+			if expected, got := test.expected.Repository, actual.Repository; expected != got {
+				t.Errorf("Expected Repository `%s` but got: `%s`", expected, got)
+			}
+			if expected, got := test.expected.Tag, actual.Tag; expected != got {
+				t.Errorf("Expected Tag `%s` but got: `%s`", expected, got)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Description

Fix for `only one of jobs.image.tag or jobs.image.digest can be specified` error in DO.

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

