### PR TITLE
Avoid running lint --fix on pre-commit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,16 +6,9 @@ install-git-hooks:
 	chmod +x .git/hooks/pre-push
 
 .PHONY: pre-commit
-pre-commit: lint-fix
+pre-commit:
+	make -C src lint-fix
 
 .PHONY: pre-push
 pre-push:
 	make -C src test
-
-.PHONY: lint
-lint:
-	make -C src lint
-
-.PHONY: lint-fix
-lint-fix:
-	make -C src lint-fix

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ install-git-hooks:
 
 .PHONY: pre-commit
 pre-commit:
-	make -C src lint-fix
+	make -C src lint
 
 .PHONY: pre-push
 pre-push:

--- a/src/Makefile
+++ b/src/Makefile
@@ -66,7 +66,7 @@ release: pull test no-diff
 
 .PHONY: lint
 lint:
-	golangci-lint run
+	golangci-lint run || (echo "Run 'make lint-fix' to try to fix the linting errors" && exit 1)
 
 .PHONY: lint-fix
 lint-fix:

--- a/src/pkg/cli/debug_test.go
+++ b/src/pkg/cli/debug_test.go
@@ -77,5 +77,4 @@ func TestQueryHasProject(t *testing.T) {
 			t.Errorf("expected error %q, got %q", "project name is missing", err.Error())
 		}
 	}
-
 }


### PR DESCRIPTION
## Description

Running `golangci-lint run --fix` leaves dirty changes in the working directory if fixes are made. To avoid this, at the cost of more friction, run `golangci-lint run` without `--fix` on pre-commit. Then warn the user to run it again with `--fix` if it fails.
