### PR TITLE
fix "cd ls" output for zero projects

### DIFF
--- a/src/pkg/cli/bootstrap.go
+++ b/src/pkg/cli/bootstrap.go
@@ -40,6 +40,9 @@ func BootstrapLocalList(ctx context.Context, provider client.Provider) error {
 	if err != nil {
 		return err
 	}
+	if len(stacks) == 0 {
+		fmt.Println("No projects found.")
+	}
 	for _, stack := range stacks {
 		fmt.Println(" -", stack)
 	}

--- a/src/pkg/cli/bootstrap.go
+++ b/src/pkg/cli/bootstrap.go
@@ -40,11 +40,18 @@ func BootstrapLocalList(ctx context.Context, provider client.Provider) error {
 	if err != nil {
 		return err
 	}
+
 	if len(stacks) == 0 {
-		fmt.Println("No projects found.")
+		accountInfo, err := provider.AccountInfo(ctx)
+		if err != nil {
+			return err
+		}
+		fmt.Printf("No projects found for account '%s' at region '%s'\n", accountInfo.AccountID(), accountInfo.Region())
 	}
+
 	for _, stack := range stacks {
 		fmt.Println(" -", stack)
 	}
+
 	return nil
 }


### PR DESCRIPTION
## Description

When running `defang cd ls`, prints a message if there are no projects in CD cluster: `No projects found` along with the account ID and region. 

## Linked Issues

Fixes part of #846 

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [x] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

