### PR TITLE
minor fix to warn about volumes definition in compose file

### DIFF
--- a/src/pkg/cli/compose/validation.go
+++ b/src/pkg/cli/compose/validation.go
@@ -312,6 +312,11 @@ func ValidateProject(project *composeTypes.Project) error {
 	for k := range project.Extensions {
 		term.Warnf("unsupported compose extension: %q", k)
 	}
+
+	if len(project.Volumes) > 0 {
+		term.Warn("unsupported \"volumes\" definition")
+	}
+
 	return nil
 }
 

--- a/src/pkg/cli/compose/validation.go
+++ b/src/pkg/cli/compose/validation.go
@@ -119,10 +119,10 @@ func ValidateProject(project *composeTypes.Project) error {
 			}
 		}
 		if len(svccfg.Volumes) > 0 {
-			term.Debugf("service %q: unsupported compose directive: volumes", svccfg.Name) // TODO: add support for volumes
+			term.Warnf("service %q: unsupported compose directive: volumes", svccfg.Name) // TODO: add support for volumes
 		}
 		if len(svccfg.VolumesFrom) > 0 {
-			term.Debugf("service %q: unsupported compose directive: volumes_from", svccfg.Name) // TODO: add support for volumes_from
+			term.Warnf("service %q: unsupported compose directive: volumes_from", svccfg.Name) // TODO: add support for volumes_from
 		}
 		if svccfg.Build != nil {
 			_, err := filepath.Abs(svccfg.Build.Context)
@@ -307,14 +307,6 @@ func ValidateProject(project *composeTypes.Project) error {
 				term.Warnf("service %q: unsupported compose extension: %q", svccfg.Name, k)
 			}
 		}
-	}
-
-	for k := range project.Extensions {
-		term.Warnf("unsupported compose extension: %q", k)
-	}
-
-	if len(project.Volumes) > 0 {
-		term.Warn("unsupported \"volumes\" definition")
 	}
 
 	return nil

--- a/src/tests/testproj/compose.yaml.warnings
+++ b/src/tests/testproj/compose.yaml.warnings
@@ -1,5 +1,4 @@
  ! port 4567: UDP ports default to 'host' mode (add 'mode: host' to silence)
  ! service "dfnx": secrets will be exposed as environment variables, not files (use 'environment' instead)
  ! service "dfnx": service name was adjusted: build argument "DNS" assigned value "mock-dfnx"
- ! unsupported compose extension: "x-unsupported"
  * Packaging the project files for dfnx at .


### PR DESCRIPTION
## Description

Warn users when there is "Volume" section in compose file. We do not support it.
## Linked Issues

None

## Checklist

- [X] I have performed a self-review of my code
- [X] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

