### PR TITLE
hide /beta in cd ls output

### DIFF
--- a/src/pkg/cli/bootstrap.go
+++ b/src/pkg/cli/bootstrap.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/DefangLabs/defang/src/pkg/cli/client"
@@ -50,7 +51,7 @@ func BootstrapLocalList(ctx context.Context, provider client.Provider) error {
 	}
 
 	for _, stack := range stacks {
-		fmt.Println(" -", stack)
+		fmt.Println(" -", strings.Replace(stack, "/beta", "", -1))
 	}
 
 	return nil

--- a/src/pkg/cli/bootstrap.go
+++ b/src/pkg/cli/bootstrap.go
@@ -32,9 +32,8 @@ func BootstrapCommand(ctx context.Context, loader client.Loader, c client.Fabric
 }
 
 func SplitProjectStack(name string) (projectName string, stackName string) {
-	projectName = strings.Split(name, "/")[0] // get the project name
-	stackName = strings.Split(name, "/")[1]   // get the stack name
-	return projectName, stackName
+	parts := strings.Split(name, "/")
+	return parts[0], parts[1]
 }
 
 func BootstrapLocalList(ctx context.Context, provider client.Provider) error {

--- a/src/pkg/cli/bootstrap.go
+++ b/src/pkg/cli/bootstrap.go
@@ -32,7 +32,7 @@ func BootstrapCommand(ctx context.Context, loader client.Loader, c client.Fabric
 }
 
 func SplitProjectStack(name string) (projectName string, stackName string) {
-	parts := strings.Split(name, "/")
+	parts := strings.SplitN(name, "/", 2)
 	return parts[0], parts[1]
 }
 

--- a/src/pkg/cli/bootstrap.go
+++ b/src/pkg/cli/bootstrap.go
@@ -31,6 +31,12 @@ func BootstrapCommand(ctx context.Context, loader client.Loader, c client.Fabric
 	return tail(ctx, p, TailOptions{Project: projectName, Etag: etag, Since: since})
 }
 
+func SplitProjectStack(name string) (projectName string, stackName string) {
+	projectName = strings.Split(name, "/")[0] // get the project name
+	stackName = strings.Split(name, "/")[1]   // get the stack name
+	return projectName, stackName
+}
+
 func BootstrapLocalList(ctx context.Context, provider client.Provider) error {
 	term.Debug("Running CD list")
 	if DoDryRun {
@@ -51,7 +57,8 @@ func BootstrapLocalList(ctx context.Context, provider client.Provider) error {
 	}
 
 	for _, stack := range stacks {
-		fmt.Println(" -", strings.Replace(stack, "/beta", "", -1))
+		projectName, _ := SplitProjectStack(stack)
+		fmt.Println(" -", projectName)
 	}
 
 	return nil


### PR DESCRIPTION
## Description

Hides `/beta` that appears at the end (or middle, if there is something pending) of a service in `cd ls`

## Linked Issues

#846 

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [x] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

