### PR TITLE
Avoid exiting if PutDeployment fails

### DIFF
--- a/src/pkg/cli/composeUp.go
+++ b/src/pkg/cli/composeUp.go
@@ -130,6 +130,7 @@ func ComposeUp(ctx context.Context, loader client.Loader, c client.FabricClient,
 			},
 		})
 		if err != nil {
+			term.Debug("PutDeployment failed:", err)
 			term.Warn("Unable to update deployment history, but deployment will proceed anyway.")
 		}
 	}

--- a/src/pkg/cli/composeUp.go
+++ b/src/pkg/cli/composeUp.go
@@ -130,7 +130,7 @@ func ComposeUp(ctx context.Context, loader client.Loader, c client.FabricClient,
 			},
 		})
 		if err != nil {
-			return nil, project, err
+			term.Warn("Unable to update deployment history, but deployment will proceed anyway.")
 		}
 	}
 


### PR DESCRIPTION
## Description

Avoid exiting if `PutDeployment` fails, because the deployment is already in flight.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added appropriate tests
- [x] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

