### PR TITLE
Print empty state messages instead of empty lists

### DIFF
--- a/src/pkg/cli/common.go
+++ b/src/pkg/cli/common.go
@@ -3,8 +3,8 @@ package cli
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 
+	"github.com/DefangLabs/defang/src/pkg/term"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 	"gopkg.in/yaml.v3"
@@ -38,6 +38,6 @@ func PrintObject(root string, data proto.Message) error {
 		return err
 	}
 	// TODO: add color
-	fmt.Println(string(bytes))
+	term.Info(string(bytes))
 	return nil
 }

--- a/src/pkg/cli/common.go
+++ b/src/pkg/cli/common.go
@@ -38,6 +38,6 @@ func PrintObject(root string, data proto.Message) error {
 		return err
 	}
 	// TODO: add color
-	term.Info(string(bytes))
+	term.Println(string(bytes))
 	return nil
 }

--- a/src/pkg/cli/common.go
+++ b/src/pkg/cli/common.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 
 	"github.com/DefangLabs/defang/src/pkg/term"
 	"google.golang.org/protobuf/encoding/protojson"
@@ -37,7 +38,6 @@ func PrintObject(root string, data proto.Message) error {
 	if err != nil {
 		return err
 	}
-	// TODO: add color
-	term.Println(string(bytes))
+	term.Println(fmt.Sprintf("%s%s", term.ResetColorStr, string(bytes)))
 	return nil
 }

--- a/src/pkg/cli/common.go
+++ b/src/pkg/cli/common.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 
 	"github.com/DefangLabs/defang/src/pkg/term"
 	"google.golang.org/protobuf/encoding/protojson"
@@ -38,6 +37,6 @@ func PrintObject(root string, data proto.Message) error {
 	if err != nil {
 		return err
 	}
-	term.Println(fmt.Sprintf("%s%s", term.ResetColorStr, string(bytes)))
+	term.Println(string(bytes))
 	return nil
 }

--- a/src/pkg/cli/configList.go
+++ b/src/pkg/cli/configList.go
@@ -24,7 +24,13 @@ func ConfigList(ctx context.Context, loader client.Loader, provider client.Provi
 		return err
 	}
 
-	configNames := make([]PrintConfig, 0, len(config.Names))
+	numConfigs := len(config.Names)
+	if numConfigs == 0 {
+		_, err := term.Warnf("No configs found")
+		return err
+	}
+
+	configNames := make([]PrintConfig, 0, numConfigs)
 	for _, c := range config.Names {
 		configNames = append(configNames, PrintConfig{Name: c})
 	}

--- a/src/pkg/cli/configList.go
+++ b/src/pkg/cli/configList.go
@@ -30,9 +30,9 @@ func ConfigList(ctx context.Context, loader client.Loader, provider client.Provi
 		return err
 	}
 
-	configNames := make([]PrintConfig, 0, numConfigs)
-	for _, c := range config.Names {
-		configNames = append(configNames, PrintConfig{Name: c})
+	configNames := make([]PrintConfig, numConfigs)
+	for i, c := range config.Names {
+		configNames[i] = PrintConfig{Name: c}
 	}
 
 	return term.Table(configNames, []string{"Name"})

--- a/src/pkg/cli/deploymentsList.go
+++ b/src/pkg/cli/deploymentsList.go
@@ -28,8 +28,14 @@ func DeploymentsList(ctx context.Context, loader client.Loader, client client.Gr
 		return err
 	}
 
+	numDeployments := len(response.Deployments)
+	if numDeployments == 0 {
+		_, err := term.Warnf("No deployments found for project %q", projectName)
+		return err
+	}
+
 	// map to Deployment struct
-	deployments := make([]PrintDeployment, 0, len(response.Deployments))
+	deployments := make([]PrintDeployment, 0, numDeployments)
 	for _, d := range response.Deployments {
 		deployments = append(deployments, PrintDeployment{
 			Id:         d.Id,

--- a/src/pkg/cli/deploymentsList.go
+++ b/src/pkg/cli/deploymentsList.go
@@ -35,13 +35,13 @@ func DeploymentsList(ctx context.Context, loader client.Loader, client client.Gr
 	}
 
 	// map to Deployment struct
-	deployments := make([]PrintDeployment, 0, numDeployments)
-	for _, d := range response.Deployments {
-		deployments = append(deployments, PrintDeployment{
+	deployments := make([]PrintDeployment, numDeployments)
+	for i, d := range response.Deployments {
+		deployments[i] = PrintDeployment{
 			Id:         d.Id,
 			Provider:   d.Provider,
 			DeployedAt: d.Timestamp.AsTime().Format(time.RFC3339),
-		})
+		}
 	}
 
 	return term.Table(deployments, []string{"Id", "Provider", "DeployedAt"})

--- a/src/pkg/cli/getServices.go
+++ b/src/pkg/cli/getServices.go
@@ -60,15 +60,15 @@ func GetServices(ctx context.Context, loader client.Loader, provider client.Prov
 		return PrintObject("", servicesResponse)
 	}
 
-	printServices := make([]PrintService, 0, numServices)
+	printServices := make([]PrintService, numServices)
 	for i, si := range servicesResponse.Services {
-		printServices = append(printServices, PrintService{
+		printServices[i] = PrintService{
 			Name:        si.Service.Name,
 			Etag:        si.Etag,
 			PublicFqdn:  si.PublicFqdn,
 			PrivateFqdn: si.PrivateFqdn,
 			Status:      si.Status,
-		})
+		}
 		servicesResponse.Services[i] = nil
 	}
 

--- a/src/pkg/cli/getServices.go
+++ b/src/pkg/cli/getServices.go
@@ -2,10 +2,13 @@ package cli
 
 import (
 	"context"
+	"fmt"
+	"time"
 
 	"github.com/DefangLabs/defang/src/pkg/cli/client"
 	"github.com/DefangLabs/defang/src/pkg/term"
 	defangv1 "github.com/DefangLabs/defang/src/protos/io/defang/v1"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 type ErrNoServices struct {
@@ -13,7 +16,7 @@ type ErrNoServices struct {
 }
 
 func (e ErrNoServices) Error() string {
-	return "no services found in project " + e.ProjectName
+	return fmt.Sprintf("no services found in project %q", e.ProjectName)
 }
 
 type PrintService struct {
@@ -36,25 +39,38 @@ func GetServices(ctx context.Context, loader client.Loader, provider client.Prov
 		return err
 	}
 
-	if len(servicesResponse.Services) == 0 {
-		return ErrNoServices{ProjectName: projectName}
+	numServices := len(servicesResponse.Services)
+
+	if numServices == 0 {
+		err := ErrNoServices{ProjectName: projectName}
+		term.Warnf(err.Error())
+		return err
 	}
 
 	if long {
-		return PrintObject("", servicesResponse)
-	} else {
-		printServices := make([]PrintService, 0, len(servicesResponse.Services))
-		for i, si := range servicesResponse.Services {
-			printServices = append(printServices, PrintService{
-				Name:        si.Service.Name,
-				Etag:        si.Etag,
-				PublicFqdn:  si.PublicFqdn,
-				PrivateFqdn: si.PrivateFqdn,
-				Status:      si.Status,
-			})
-			servicesResponse.Services[i] = nil
+		// Truncate nanoseconds from timestamps for readability.
+		services := make([]*defangv1.ServiceInfo, 0, len(servicesResponse.Services))
+		for _, si := range servicesResponse.Services {
+			si.CreatedAt = timestamppb.New(si.CreatedAt.AsTime().Truncate(time.Second))
+			services = append(services, si)
 		}
 
-		return term.Table(printServices, []string{"Name", "Etag", "PublicFqdn", "PrivateFqdn", "Status"})
+		servicesResponse.Services = services
+		servicesResponse.ExpiresAt = timestamppb.New(servicesResponse.ExpiresAt.AsTime().Truncate(time.Second))
+		return PrintObject("", servicesResponse)
 	}
+
+	printServices := make([]PrintService, 0, numServices)
+	for i, si := range servicesResponse.Services {
+		printServices = append(printServices, PrintService{
+			Name:        si.Service.Name,
+			Etag:        si.Etag,
+			PublicFqdn:  si.PublicFqdn,
+			PrivateFqdn: si.PrivateFqdn,
+			Status:      si.Status,
+		})
+		servicesResponse.Services[i] = nil
+	}
+
+	return term.Table(printServices, []string{"Name", "Etag", "PublicFqdn", "PrivateFqdn", "Status"})
 }

--- a/src/pkg/cli/getServices_test.go
+++ b/src/pkg/cli/getServices_test.go
@@ -16,8 +16,8 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-var mockCreatedAt = timestamppb.Now()
-var mockExpiresAt = timestamppb.New(time.Now().Add(1 * time.Hour))
+var mockCreatedAt, _ = time.Parse(time.RFC3339, "2021-09-01T12:34:56Z")
+var mockExpiresAt, _ = time.Parse(time.RFC3339, "2021-09-02T12:34:56Z")
 
 type mockGetServicesHandler struct {
 	defangv1connect.UnimplementedFabricControllerHandler
@@ -41,7 +41,7 @@ func (g *mockGetServicesHandler) GetServices(ctx context.Context, req *connect.R
 				Status:      "UNKNOWN",
 				PublicFqdn:  "test-foo.prod1.defang.dev",
 				PrivateFqdn: "",
-				CreatedAt:   mockCreatedAt,
+				CreatedAt:   timestamppb.New(mockCreatedAt),
 			},
 		}
 	}
@@ -49,7 +49,7 @@ func (g *mockGetServicesHandler) GetServices(ctx context.Context, req *connect.R
 	return connect.NewResponse(&defangv1.GetServicesResponse{
 		Project:   project,
 		Services:  services,
-		ExpiresAt: mockExpiresAt,
+		ExpiresAt: timestamppb.New(mockExpiresAt),
 	}), nil
 }
 
@@ -134,18 +134,17 @@ foo   a1b2c3  test-foo.prod1.defang.dev               UNKNOWN
 		if err != nil {
 			t.Fatalf("GetServices() error = %v", err)
 		}
-		expectedOutput := "expiresAt: \"" + mockExpiresAt.AsTime().Format(time.RFC3339) + `"
-project: test
-services:
-    - createdAt: "` + mockCreatedAt.AsTime().Format(time.RFC3339) + `"
-      etag: a1b2c3
-      project: test
-      publicFqdn: test-foo.prod1.defang.dev
-      service:
-        name: foo
-      status: UNKNOWN
-
-`
+		expectedOutput := "\x1b[95m * expiresAt: \"2021-09-02T12:34:56Z\"\n" +
+			"project: test\n" +
+			"services:\n" +
+			"    - createdAt: \"2021-09-01T12:34:56Z\"\n" +
+			"      etag: a1b2c3\n" +
+			"      project: test\n" +
+			"      publicFqdn: test-foo.prod1.defang.dev\n" +
+			"      service:\n" +
+			"        name: foo\n" +
+			"      status: UNKNOWN\n\n" +
+			"\x1b[0m"
 
 		receivedLines := stdout.String()
 		expectedLines := expectedOutput

--- a/src/pkg/cli/getServices_test.go
+++ b/src/pkg/cli/getServices_test.go
@@ -134,7 +134,7 @@ foo   a1b2c3  test-foo.prod1.defang.dev               UNKNOWN
 		if err != nil {
 			t.Fatalf("GetServices() error = %v", err)
 		}
-		expectedOutput := "\x1b[95m * expiresAt: \"2021-09-02T12:34:56Z\"\n" +
+		expectedOutput := "\x1b[0mexpiresAt: \"2021-09-02T12:34:56Z\"\n" +
 			"project: test\n" +
 			"services:\n" +
 			"    - createdAt: \"2021-09-01T12:34:56Z\"\n" +
@@ -143,8 +143,7 @@ foo   a1b2c3  test-foo.prod1.defang.dev               UNKNOWN
 			"      publicFqdn: test-foo.prod1.defang.dev\n" +
 			"      service:\n" +
 			"        name: foo\n" +
-			"      status: UNKNOWN\n\n" +
-			"\x1b[0m"
+			"      status: UNKNOWN\n\n"
 
 		receivedLines := stdout.String()
 		expectedLines := expectedOutput

--- a/src/pkg/cli/getServices_test.go
+++ b/src/pkg/cli/getServices_test.go
@@ -2,39 +2,156 @@ package cli
 
 import (
 	"context"
-	"errors"
+	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
 
-	"github.com/DefangLabs/defang/src/pkg/cli/client"
+	cliClient "github.com/DefangLabs/defang/src/pkg/cli/client"
 	"github.com/DefangLabs/defang/src/pkg/cli/compose"
+	"github.com/DefangLabs/defang/src/pkg/term"
 	defangv1 "github.com/DefangLabs/defang/src/protos/io/defang/v1"
+	"github.com/DefangLabs/defang/src/protos/io/defang/v1/defangv1connect"
+	"github.com/bufbuild/connect-go"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-type mockGetServicesProvider struct {
-	client.Provider
+var mockCreatedAt = timestamppb.Now()
+var mockExpiresAt = timestamppb.New(time.Now().Add(1 * time.Hour))
+
+type mockGetServicesHandler struct {
+	defangv1connect.UnimplementedFabricControllerHandler
 }
 
-func (mockGetServicesProvider) LoadProjectName(ctx context.Context) (string, error) {
-	return "TestGetServices", nil
-}
+func (g *mockGetServicesHandler) GetServices(ctx context.Context, req *connect.Request[defangv1.GetServicesRequest]) (*connect.Response[defangv1.GetServicesResponse], error) {
+	project := req.Msg.Project
+	var services []*defangv1.ServiceInfo
 
-func (mockGetServicesProvider) GetServices(ctx context.Context, req *defangv1.GetServicesRequest) (*defangv1.GetServicesResponse, error) {
-	return &defangv1.GetServicesResponse{}, nil
+	if project == "empty" {
+		services = []*defangv1.ServiceInfo{}
+	} else {
+		services = []*defangv1.ServiceInfo{
+			{
+				Service: &defangv1.Service{
+					Name: "foo",
+				},
+				Endpoints:   []string{},
+				Project:     "test",
+				Etag:        "a1b2c3",
+				Status:      "UNKNOWN",
+				PublicFqdn:  "test-foo.prod1.defang.dev",
+				PrivateFqdn: "",
+				CreatedAt:   mockCreatedAt,
+			},
+		}
+	}
+
+	return connect.NewResponse(&defangv1.GetServicesResponse{
+		Project:   project,
+		Services:  services,
+		ExpiresAt: mockExpiresAt,
+	}), nil
 }
 
 func TestGetServices(t *testing.T) {
 	ctx := context.Background()
-	loader := client.MockLoader{Project: &compose.Project{Name: "TestGetServices"}}
-	provider := mockGetServicesProvider{}
 
-	t.Run("ErrNoServices", func(t *testing.T) {
-		err := GetServices(ctx, loader, provider, false)
+	fabricServer := &mockGetServicesHandler{}
+	_, handler := defangv1connect.NewFabricControllerHandler(fabricServer)
+	server := httptest.NewServer(handler)
+	t.Cleanup(func() {
+		server.Close()
+	})
+
+	url := strings.TrimPrefix(server.URL, "http://")
+	grpcClient := NewGrpcClient(ctx, url)
+	provider := cliClient.PlaygroundProvider{GrpcClient: grpcClient}
+
+	t.Run("no services", func(t *testing.T) {
+		stdout, _ := term.SetupTestTerm(t)
+		loader := cliClient.MockLoader{Project: &compose.Project{Name: "empty"}}
+		err := GetServices(ctx, loader, &provider, false)
 		if err == nil {
-			t.Error("expected error")
+			t.Fatalf("expected GetServices() error to not be nil")
 		}
-		var e ErrNoServices
-		if !errors.As(err, &e) {
-			t.Errorf("expected %T, got %T", e, err)
+
+		receivedOutput := stdout.String()
+		expectedOutput := "no services found in project \"empty\""
+
+		if !strings.Contains(stdout.String(), expectedOutput) {
+			t.Errorf("Expected %s to contain %s", receivedOutput, expectedOutput)
+		}
+	})
+
+	t.Run("some services", func(t *testing.T) {
+		stdout, _ := term.SetupTestTerm(t)
+		loader := cliClient.MockLoader{Project: &compose.Project{Name: "test"}}
+
+		err := GetServices(ctx, loader, &provider, false)
+		if err != nil {
+			t.Fatalf("GetServices() error = %v", err)
+		}
+		expectedOutput := `Name  Etag    PublicFqdn                 PrivateFqdn  Status
+foo   a1b2c3  test-foo.prod1.defang.dev               UNKNOWN
+`
+
+		receivedLines := strings.Split(stdout.String(), "\n")
+		expectedLines := strings.Split(expectedOutput, "\n")
+
+		if len(receivedLines) != len(expectedLines) {
+			t.Errorf("Expected %v lines, received %v", len(expectedLines), len(receivedLines))
+		}
+
+		for i, receivedLine := range receivedLines {
+			receivedLine = strings.TrimRight(receivedLine, " ")
+			if receivedLine != expectedLines[i] {
+				t.Errorf("\n-%v\n+%v", expectedLines[i], receivedLine)
+			}
+		}
+	})
+
+	t.Run("no services long", func(t *testing.T) {
+		stdout, _ := term.SetupTestTerm(t)
+		loader := cliClient.MockLoader{Project: &compose.Project{Name: "empty"}}
+		err := GetServices(ctx, loader, &provider, false)
+		if err == nil {
+			t.Fatalf("expected GetServices() error to not be nil")
+		}
+
+		receivedOutput := stdout.String()
+		expectedOutput := "no services found in project \"empty\""
+
+		if !strings.Contains(stdout.String(), expectedOutput) {
+			t.Errorf("Expected %s to contain %s", receivedOutput, expectedOutput)
+		}
+	})
+
+	t.Run("some services long", func(t *testing.T) {
+		stdout, _ := term.SetupTestTerm(t)
+		loader := cliClient.MockLoader{Project: &compose.Project{Name: "test"}}
+
+		err := GetServices(ctx, loader, &provider, true)
+		if err != nil {
+			t.Fatalf("GetServices() error = %v", err)
+		}
+		expectedOutput := "\x1b[95m * expiresAt: \"" + mockExpiresAt.AsTime().Format(time.RFC3339) + `"
+project: test
+services:
+    - createdAt: "` + mockCreatedAt.AsTime().Format(time.RFC3339) + `"
+      etag: a1b2c3
+      project: test
+      publicFqdn: test-foo.prod1.defang.dev
+      service:
+        name: foo
+      status: UNKNOWN
+
+` + "\x1b[0m"
+
+		receivedLines := stdout.String()
+		expectedLines := expectedOutput
+
+		if receivedLines != expectedLines {
+			t.Errorf("expected %q to equal %q", receivedLines, expectedLines)
 		}
 	})
 }

--- a/src/pkg/cli/getServices_test.go
+++ b/src/pkg/cli/getServices_test.go
@@ -134,7 +134,7 @@ foo   a1b2c3  test-foo.prod1.defang.dev               UNKNOWN
 		if err != nil {
 			t.Fatalf("GetServices() error = %v", err)
 		}
-		expectedOutput := "\x1b[0mexpiresAt: \"2021-09-02T12:34:56Z\"\n" +
+		expectedOutput := "expiresAt: \"2021-09-02T12:34:56Z\"\n" +
 			"project: test\n" +
 			"services:\n" +
 			"    - createdAt: \"2021-09-01T12:34:56Z\"\n" +

--- a/src/pkg/cli/getServices_test.go
+++ b/src/pkg/cli/getServices_test.go
@@ -134,7 +134,7 @@ foo   a1b2c3  test-foo.prod1.defang.dev               UNKNOWN
 		if err != nil {
 			t.Fatalf("GetServices() error = %v", err)
 		}
-		expectedOutput := "\x1b[95m * expiresAt: \"" + mockExpiresAt.AsTime().Format(time.RFC3339) + `"
+		expectedOutput := "expiresAt: \"" + mockExpiresAt.AsTime().Format(time.RFC3339) + `"
 project: test
 services:
     - createdAt: "` + mockCreatedAt.AsTime().Format(time.RFC3339) + `"
@@ -145,7 +145,7 @@ services:
         name: foo
       status: UNKNOWN
 
-` + "\x1b[0m"
+`
 
 		receivedLines := stdout.String()
 		expectedLines := expectedOutput

--- a/src/pkg/term/test_utils.go
+++ b/src/pkg/term/test_utils.go
@@ -1,0 +1,22 @@
+package term
+
+import (
+	"bytes"
+	"io"
+	"testing"
+)
+
+func SetupTestTerm(t *testing.T) (*bytes.Buffer, *bytes.Buffer) {
+	t.Helper()
+
+	var stdout, stderr bytes.Buffer
+	testTerm := NewTerm(&stdout, io.MultiWriter(&stderr))
+	testTerm.ForceColor(true)
+	defaultTerm := DefaultTerm
+	DefaultTerm = testTerm
+	t.Cleanup(func() {
+		DefaultTerm = defaultTerm
+	})
+
+	return &stdout, &stderr
+}


### PR DESCRIPTION
## Description

There are a few defang commands which print table responses: `defang (deployments|config ls|services)`. This PR updates them to print an "empty message" when there is no data to print instead of printing an empty table.

For example:

```diff
 defang services
+no services found in project "foo"
-Name  Etag          PublicFqdn                           PrivateFqdn  Status
```

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added appropriate tests
- [x] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

