### PR TITLE
Fix auth error after interactive login

### DIFF
--- a/src/cmd/cli/command/commands.go
+++ b/src/cmd/cli/command/commands.go
@@ -40,15 +40,6 @@ func P(name string, value interface{}) cliClient.Property {
 	return cliClient.Property{Name: name, Value: value}
 }
 
-type GrpcClientApi interface {
-	CanIUse(ctx context.Context, canUseReq *defangv1.CanIUseRequest) (*defangv1.CanIUseResponse, error)
-	GetVersions(ctx context.Context) (*defangv1.Version, error)
-	CheckLoginAndToS(context.Context) error
-	WhoAmI(context.Context) (*defangv1.WhoAmIResponse, error)
-	GetSelectedProvider(context.Context, *defangv1.GetSelectedProviderRequest) (*defangv1.GetSelectedProviderResponse, error)
-	SetSelectedProvider(context.Context, *defangv1.SetSelectedProviderRequest) error
-}
-
 // GLOBALS
 var (
 	client         cliClient.GrpcClient
@@ -57,7 +48,6 @@ var (
 	doDebug        = false
 	gitHubClientId = pkg.Getenv("DEFANG_CLIENT_ID", "7b41848ca116eac4b125") // GitHub OAuth app
 	hasTty         = term.IsTerminal() && !pkg.GetenvBool("CI")
-	localClient    GrpcClientApi
 	nonInteractive = !hasTty
 	providerID     = cliClient.ProviderID(pkg.Getenv("DEFANG_PROVIDER", "auto"))
 	verbose        = false
@@ -79,7 +69,7 @@ func allowToUseProvider(ctx context.Context, providerID cliClient.ProviderID, pr
 		Provider: providerID.EnumValue(),
 	}
 
-	resp, err := localClient.CanIUse(ctx, &canUseReq)
+	resp, err := client.CanIUse(ctx, &canUseReq)
 	if err != nil {
 		return gating.ErrNoPermission(fmt.Sprintf("no access to use %s provider", providerID))
 	}
@@ -344,11 +334,8 @@ var RootCmd = &cobra.Command{
 		}
 
 		client = cli.NewGrpcClient(cmd.Context(), cluster)
-		if localClient == nil {
-			localClient = client
-		}
 
-		if v, err := localClient.GetVersions(cmd.Context()); err == nil {
+		if v, err := client.GetVersions(cmd.Context()); err == nil {
 			version := cmd.Root().Version // HACK to avoid circular dependency with RootCmd
 			term.Debug("Fabric:", v.Fabric, "CLI:", version, "CLI-Min:", v.CliMin)
 			if hasTty && isNewer(version, v.CliMin) {
@@ -362,7 +349,7 @@ var RootCmd = &cobra.Command{
 			return nil
 		}
 
-		if err = localClient.CheckLoginAndToS(cmd.Context()); err != nil {
+		if err = client.CheckLoginAndToS(cmd.Context()); err != nil {
 			if nonInteractive {
 				return err
 			}
@@ -377,11 +364,8 @@ var RootCmd = &cobra.Command{
 				}
 
 				client = cli.NewGrpcClient(cmd.Context(), cluster) // reconnect with the new token
-				if localClient == nil {
-					localClient = client
-				}
 
-				if err = localClient.CheckLoginAndToS(cmd.Context()); err == nil { // recheck (new token = new user)
+				if err = client.CheckLoginAndToS(cmd.Context()); err == nil { // recheck (new token = new user)
 					return nil // success
 				}
 			}
@@ -579,7 +563,7 @@ var generateCmd = &cobra.Command{
 			return err
 		}
 
-		if localClient.CheckLoginAndToS(cmd.Context()) != nil {
+		if client.CheckLoginAndToS(cmd.Context()) != nil {
 			// The user is either not logged in or has not agreed to the terms of service; ask for agreement to the terms now
 			if err := cli.InteractiveAgreeToS(cmd.Context(), client); err != nil {
 				// This might fail because the user did not log in. This is fine: server won't save the terms agreement, but can proceed with the generation
@@ -1096,7 +1080,7 @@ var tosCmd = &cobra.Command{
 	Short:   "Read and/or agree the Defang terms of service",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Check if we are correctly logged in
-		if _, err := localClient.WhoAmI(cmd.Context()); err != nil {
+		if _, err := client.WhoAmI(cmd.Context()); err != nil {
 			return err
 		}
 
@@ -1244,7 +1228,7 @@ func determineProviderID(ctx context.Context, loader *compose.Loader) (string, e
 	if err != nil {
 		term.Warn("Unable to load project:", err)
 	} else if !RootCmd.PersistentFlags().Changed("provider") { // If user manually selected auto provider, do not load from remote
-		resp, err := localClient.GetSelectedProvider(ctx, &defangv1.GetSelectedProviderRequest{Project: projName})
+		resp, err := client.GetSelectedProvider(ctx, &defangv1.GetSelectedProviderRequest{Project: projName})
 		if err != nil {
 			term.Warn("Unable to get selected provider:", err)
 		} else if resp.Provider != defangv1.Provider_PROVIDER_UNSPECIFIED {
@@ -1283,7 +1267,7 @@ func determineProviderID(ctx context.Context, loader *compose.Loader) (string, e
 
 	// Save the selected provider to the fabric
 	if projName != "" {
-		if err := localClient.SetSelectedProvider(ctx, &defangv1.SetSelectedProviderRequest{Project: projName, Provider: providerID.EnumValue()}); err != nil {
+		if err := client.SetSelectedProvider(ctx, &defangv1.SetSelectedProviderRequest{Project: projName, Provider: providerID.EnumValue()}); err != nil {
 			term.Warn("Unable to save selected provider to defang server:", err)
 		} else {
 			term.Printf("%v is now the default provider for project %v and will auto-select next time if no other provider is specified. Use --provider=auto to reselect.", providerID, projName)

--- a/src/cmd/cli/command/commands_test.go
+++ b/src/cmd/cli/command/commands_test.go
@@ -3,25 +3,24 @@ package command
 import (
 	"context"
 	"errors"
+	"net/http/httptest"
 	"strings"
 	"testing"
-
-	defangv1 "github.com/DefangLabs/defang/src/protos/io/defang/v1"
-	awssdk "github.com/aws/aws-sdk-go-v2/aws"
 
 	"github.com/DefangLabs/defang/src/pkg/cli/client/byoc/aws"
 	"github.com/DefangLabs/defang/src/pkg/cli/gating"
 	pkg "github.com/DefangLabs/defang/src/pkg/clouds/aws"
+	defangv1 "github.com/DefangLabs/defang/src/protos/io/defang/v1"
+	"github.com/DefangLabs/defang/src/protos/io/defang/v1/defangv1connect"
+	awssdk "github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
+	connect_go "github.com/bufbuild/connect-go"
+	"google.golang.org/protobuf/types/known/emptypb"
 )
 
 type MockSsmClient struct {
 	pkg.SsmParametersAPI
-}
-
-type MockGrpcClientApi struct {
-	GrpcClientApi
 }
 
 func (m *MockSsmClient) PutParameter(ctx context.Context, params *ssm.PutParameterInput, optFns ...func(*ssm.Options)) (*ssm.PutParameterOutput, error) {
@@ -34,49 +33,50 @@ func (m *MockSsmClient) DeleteParameters(ctx context.Context, params *ssm.Delete
 	}, nil
 }
 
-var mockCanIUseResponse = defangv1.CanIUseResponse{
-	Gates: map[string]bool{},
+type mockFabricService struct {
+	defangv1connect.UnimplementedFabricControllerHandler
+	canIUseResponse defangv1.CanIUseResponse
 }
 
-var mockWhoAmIResponse = &defangv1.WhoAmIResponse{
-	Tenant:  "default",
-	Account: "default",
-	Region:  "us-west-2",
-	Tier:    defangv1.SubscriptionTier_HOBBY,
+func (m *mockFabricService) CanIUse(ctx context.Context, canUseReq *connect_go.Request[defangv1.CanIUseRequest]) (*connect_go.Response[defangv1.CanIUseResponse], error) {
+	if !m.canIUseResponse.Gates["provider"] {
+		return nil, connect_go.NewError(connect_go.CodePermissionDenied, errors.New("no access to use aws provider"))
+	}
+	return connect_go.NewResponse(&m.canIUseResponse), nil
 }
 
-func (m *MockGrpcClientApi) CanIUse(ctx context.Context, canUseReq *defangv1.CanIUseRequest) (*defangv1.CanIUseResponse, error) {
-	return &mockCanIUseResponse, nil
+func (m *mockFabricService) GetVersion(context.Context, *connect_go.Request[emptypb.Empty]) (*connect_go.Response[defangv1.Version], error) {
+	return connect_go.NewResponse(&defangv1.Version{
+		Fabric: "1.0.0-test",
+		CliMin: "1.0.0-test",
+	}), nil
 }
 
-func (m *MockGrpcClientApi) GetVersions(ctx context.Context) (*defangv1.Version, error) {
-	return &defangv1.Version{
-		Fabric: "1.0.0",
-		CliMin: "1.0.0",
-	}, nil
-}
-func (m *MockGrpcClientApi) CheckLoginAndToS(context.Context) error {
-	return nil
+func (m *mockFabricService) CheckToS(context.Context, *connect_go.Request[emptypb.Empty]) (*connect_go.Response[emptypb.Empty], error) {
+	return connect_go.NewResponse(&emptypb.Empty{}), nil
 }
 
-func (m *MockGrpcClientApi) WhoAmI(context.Context) (*defangv1.WhoAmIResponse, error) {
-	return mockWhoAmIResponse, nil
+func (m *mockFabricService) WhoAmI(context.Context, *connect_go.Request[emptypb.Empty]) (*connect_go.Response[defangv1.WhoAmIResponse], error) {
+	return connect_go.NewResponse(&defangv1.WhoAmIResponse{
+		Tenant:  "default",
+		Account: "default",
+		Region:  "us-west-2",
+		Tier:    defangv1.SubscriptionTier_HOBBY,
+	}), nil
 }
 
-func (m *MockGrpcClientApi) GetSelectedProvider(context.Context, *defangv1.GetSelectedProviderRequest) (*defangv1.GetSelectedProviderResponse, error) {
-	return &defangv1.GetSelectedProviderResponse{
+func (m *mockFabricService) GetSelectedProvider(context.Context, *connect_go.Request[defangv1.GetSelectedProviderRequest]) (*connect_go.Response[defangv1.GetSelectedProviderResponse], error) {
+	return connect_go.NewResponse(&defangv1.GetSelectedProviderResponse{
 		Provider: defangv1.Provider_AWS,
-	}, nil
+	}), nil
 }
 
-func (m *MockGrpcClientApi) SetSelectedProvider(context.Context, *defangv1.SetSelectedProviderRequest) error {
-	return nil
+func (m *mockFabricService) SetSelectedProvider(context.Context, *connect_go.Request[defangv1.SetSelectedProviderRequest]) (*connect_go.Response[emptypb.Empty], error) {
+	return connect_go.NewResponse(&emptypb.Empty{}), nil
 }
-
-var ctx = context.Background()
 
 func init() {
-	SetupCommands(ctx, "version")
+	SetupCommands(context.Background(), "0.0.0-test")
 }
 
 type mockStsProviderAPI struct{}
@@ -94,28 +94,45 @@ func (s *mockStsProviderAPI) AssumeRole(ctx context.Context, params *sts.AssumeR
 	return &aro, nil
 }
 
-var stsProviderApi aws.StsProviderAPI = &mockStsProviderAPI{}
-var ssmClient = &MockSsmClient{}
-
-func testCommand(args []string) error {
+func testCommand(args []string, cluster string) error {
+	if cluster != "" {
+		args = append(args, "--cluster", strings.TrimPrefix(cluster, "http://"))
+	}
 	RootCmd.SetArgs(args)
-	return RootCmd.ExecuteContext(ctx)
+	return RootCmd.ExecuteContext(context.Background())
 }
 
 func TestVersion(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping test in short mode.")
-	}
-	err := testCommand([]string{"version"})
-	if err != nil {
-		t.Fatalf("Version() failed: %v", err)
-	}
+	t.Run("live", func(t *testing.T) {
+		if testing.Short() {
+			t.Skip("skipping live test in short mode.")
+		}
+		err := testCommand([]string{"version"}, "")
+		if err != nil {
+			t.Fatalf("Version() failed: %v", err)
+		}
+	})
+
+	t.Run("mock", func(t *testing.T) {
+		mockService := &mockFabricService{}
+		_, handler := defangv1connect.NewFabricControllerHandler(mockService)
+
+		server := httptest.NewServer(handler)
+		t.Cleanup(server.Close)
+
+		err := testCommand([]string{"version"}, server.URL)
+		if err != nil {
+			t.Fatalf("Version() failed: %v", err)
+		}
+	})
 }
 
 func TestCommandGates(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping test in short mode.")
-	}
+	mockService := &mockFabricService{canIUseResponse: defangv1.CanIUseResponse{Gates: make(map[string]bool)}}
+	_, handler := defangv1connect.NewFabricControllerHandler(mockService)
+
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
 
 	type cmdPermTest struct {
 		name          string
@@ -125,14 +142,14 @@ func TestCommandGates(t *testing.T) {
 	}
 	type cmdPermTests []cmdPermTest
 
-	localClient = &MockGrpcClientApi{}
+	t.Setenv("AWS_REGION", "us-test-2")
 
 	testData := cmdPermTests{
 		{
 			name:          "compose up - aws - no access",
 			command:       []string{"compose", "up", "--project-name=app", "--provider=aws", "--dry-run"},
 			accessAllowed: false,
-			wantError:     gating.TIER_ERROR_MESSAGE + "no access to use aws provider",
+			wantError:     "current subscription tier does not allow this action: no access to use aws provider",
 		},
 		{
 			name:          "compose up - defang - has access",
@@ -144,19 +161,19 @@ func TestCommandGates(t *testing.T) {
 			name:          "compose down - aws - no access",
 			command:       []string{"compose", "down", "--provider=aws", "--dry-run"},
 			accessAllowed: false,
-			wantError:     gating.TIER_ERROR_MESSAGE + "no access to use aws provider",
+			wantError:     "current subscription tier does not allow this action: no access to use aws provider",
 		},
 		{
 			name:          "config set - aws - no access",
 			command:       []string{"config", "set", "var", "--project-name=app", "--provider=aws", "--dry-run"},
 			accessAllowed: false,
-			wantError:     gating.TIER_ERROR_MESSAGE + "no access to use aws provider",
+			wantError:     "current subscription tier does not allow this action: no access to use aws provider",
 		},
 		{
 			name:          "config rm - aws - no access",
 			command:       []string{"config", "rm", "var", "--project-name=app", "--provider=aws", "--dry-run"},
 			accessAllowed: false,
-			wantError:     gating.TIER_ERROR_MESSAGE + "no access to use aws provider",
+			wantError:     "current subscription tier does not allow this action: no access to use aws provider",
 		},
 		{
 			name:          "config rm - defang - has access",
@@ -168,35 +185,33 @@ func TestCommandGates(t *testing.T) {
 			name:          "delete service - aws - no access",
 			command:       []string{"delete", "abc", "--provider=aws", "--dry-run"},
 			accessAllowed: false,
-			wantError:     gating.TIER_ERROR_MESSAGE + "no access to use aws provider",
+			wantError:     "current subscription tier does not allow this action: no access to use aws provider",
 		},
 	}
 
-	for _, testGroup := range []cmdPermTests{testData} {
-		for _, tt := range testGroup {
-			t.Run(tt.name, func(t *testing.T) {
-				aws.StsClient = stsProviderApi
-				pkg.SsmClientOverride = ssmClient
-				mockCanIUseResponse.Gates[string(gating.ResourceProvider)] = tt.accessAllowed
-				mockCanIUseResponse.Gates[string(gating.ResourceGPU)] = tt.accessAllowed
-				mockCanIUseResponse.Gates[string(gating.ResourcePostgres)] = tt.accessAllowed
-				mockCanIUseResponse.Gates[string(gating.ResourceRedis)] = tt.accessAllowed
+	for _, tt := range testData {
+		t.Run(tt.name, func(t *testing.T) {
+			aws.StsClient = &mockStsProviderAPI{}
+			pkg.SsmClientOverride = &MockSsmClient{}
+			mockService.canIUseResponse.Gates[string(gating.ResourceProvider)] = tt.accessAllowed
+			mockService.canIUseResponse.Gates[string(gating.ResourceGPU)] = tt.accessAllowed
+			mockService.canIUseResponse.Gates[string(gating.ResourcePostgres)] = tt.accessAllowed
+			mockService.canIUseResponse.Gates[string(gating.ResourceRedis)] = tt.accessAllowed
 
-				err := testCommand(tt.command)
+			err := testCommand(tt.command, server.URL)
 
-				if err != nil && tt.wantError == "" {
-					if !strings.Contains(err.Error(), "dry run") && !strings.Contains(err.Error(), "no compose.yaml file found") {
-						t.Fatalf("Unexpected error: %v", err)
-					}
+			if err != nil && tt.wantError == "" {
+				if !strings.Contains(err.Error(), "dry run") && !strings.Contains(err.Error(), "no compose.yaml file found") {
+					t.Fatalf("Unexpected error: %v", err)
 				}
+			}
 
-				if tt.wantError != "" {
-					var errNoPermission = gating.ErrNoPermission(tt.wantError)
-					if !errors.As(err, &errNoPermission) || !strings.Contains(err.Error(), tt.wantError) {
-						t.Fatalf("Expected errNoPermission, got: %v", err)
-					}
+			if tt.wantError != "" {
+				var errNoPermission = gating.ErrNoPermission(tt.wantError)
+				if !errors.As(err, &errNoPermission) || !strings.Contains(err.Error(), tt.wantError) {
+					t.Fatalf("Expected errNoPermission, got: %v", err)
 				}
-			})
-		}
+			}
+		})
 	}
 }

--- a/src/cmd/cli/command/compose_test.go
+++ b/src/cmd/cli/command/compose_test.go
@@ -6,14 +6,6 @@ import (
 	"github.com/compose-spec/compose-go/v2/types"
 )
 
-func getTotalManagedServices(managed map[string]int) int {
-	var total = 0
-	for _, value := range managed {
-		total += value
-	}
-
-	return total
-}
 func TestInitializeTailCmd(t *testing.T) {
 	t.Run("", func(t *testing.T) {
 		for _, cmd := range RootCmd.Commands() {
@@ -30,9 +22,8 @@ func TestGetUnreferencedManagedResources(t *testing.T) {
 		project := types.Services{}
 
 		managed, unmanaged := splitManagedAndUnmanagedServices(project)
-		var totalManaged = getTotalManagedServices(managed)
-		if totalManaged != 0 {
-			t.Errorf("Expected 0 managed resources, got %d (%v)", totalManaged, managed)
+		if len(managed) != 0 {
+			t.Errorf("Expected 0 managed resources, got %d (%v)", len(managed), managed)
 		}
 
 		if len(unmanaged) != 0 {
@@ -48,10 +39,8 @@ func TestGetUnreferencedManagedResources(t *testing.T) {
 		}
 
 		managed, unmanaged := splitManagedAndUnmanagedServices(project)
-		var totalManaged = getTotalManagedServices(managed)
-
-		if totalManaged != 1 {
-			t.Errorf("Expected 1 managed resource, got %d (%v)", totalManaged, managed)
+		if len(managed) != 1 {
+			t.Errorf("Expected 1 managed resource, got %d (%v)", len(managed), managed)
 		}
 
 		if len(unmanaged) != 0 {
@@ -65,9 +54,8 @@ func TestGetUnreferencedManagedResources(t *testing.T) {
 		}
 
 		managed, unmanaged := splitManagedAndUnmanagedServices(project)
-		var totalManaged = getTotalManagedServices(managed)
-		if totalManaged != 0 {
-			t.Errorf("Expected 0 managed resource, got %d (%v)", totalManaged, managed)
+		if len(managed) != 0 {
+			t.Errorf("Expected 0 managed resource, got %d (%v)", len(managed), managed)
 		}
 
 		if len(unmanaged) != 1 {
@@ -84,9 +72,8 @@ func TestGetUnreferencedManagedResources(t *testing.T) {
 		}
 
 		managed, unmanaged := splitManagedAndUnmanagedServices(project)
-		var totalManaged = getTotalManagedServices(managed)
-		if totalManaged != 1 {
-			t.Errorf("Expected 1 managed resource, got %d (%v)", totalManaged, managed)
+		if len(managed) != 1 {
+			t.Errorf("Expected 1 managed resource, got %d (%v)", len(managed), managed)
 		}
 
 		if len(unmanaged) != 1 {
@@ -101,9 +88,8 @@ func TestGetUnreferencedManagedResources(t *testing.T) {
 		}
 
 		managed, unmanaged := splitManagedAndUnmanagedServices(project)
-		var totalManaged = getTotalManagedServices(managed)
-		if totalManaged != 0 {
-			t.Errorf("Expected 0 managed resource, got %d (%v)", totalManaged, managed)
+		if len(managed) != 0 {
+			t.Errorf("Expected 0 managed resource, got %d (%v)", len(managed), managed)
 		}
 
 		if len(unmanaged) != 2 {
@@ -123,9 +109,8 @@ func TestGetUnreferencedManagedResources(t *testing.T) {
 		}
 
 		managed, unmanaged := splitManagedAndUnmanagedServices(project)
-		var totalManaged = getTotalManagedServices(managed)
-		if totalManaged != 2 {
-			t.Errorf("Expected 2 managed resource, got %d (%v)", totalManaged, managed)
+		if len(managed) != 2 {
+			t.Errorf("Expected 2 managed resource, got %d (%v)", len(managed), managed)
 		}
 		if len(unmanaged) != 1 {
 			t.Errorf("Expected 1 unmanaged resource, got %d (%s)", len(unmanaged), unmanaged)

--- a/src/pkg/cli/compose/GPUcounter.go
+++ b/src/pkg/cli/compose/GPUcounter.go
@@ -7,17 +7,30 @@ import (
 	composeTypes "github.com/compose-spec/compose-go/v2/types"
 )
 
+func fixupDeviceCount(count composeTypes.DeviceCount) int {
+	if count == -1 {
+		return 1
+	}
+	return int(count)
+}
+
+func gpuDeviceCount(service *composeTypes.ServiceConfig) int {
+	count := 0
+	if service.Deploy != nil &&
+		service.Deploy.Resources.Reservations != nil {
+		for _, device := range service.Deploy.Resources.Reservations.Devices {
+			if slices.Contains(device.Capabilities, "gpu") {
+				count += fixupDeviceCount(device.Count)
+			}
+		}
+	}
+	return count
+}
+
 func GetNumOfGPUs(ctx context.Context, project *composeTypes.Project) int {
 	numGPUs := 0
 	for _, service := range project.Services {
-		if service.Deploy != nil &&
-			service.Deploy.Resources.Reservations != nil {
-			for _, device := range service.Deploy.Resources.Reservations.Devices {
-				if slices.Contains(device.Capabilities, "gpu") {
-					numGPUs += int(device.Count)
-				}
-			}
-		}
+		numGPUs += gpuDeviceCount(&service)
 	}
 	return numGPUs
 }

--- a/src/pkg/cli/whoami_test.go
+++ b/src/pkg/cli/whoami_test.go
@@ -27,11 +27,11 @@ func (g *grpcWhoamiMockHandler) WhoAmI(context.Context, *connect.Request[emptypb
 }
 
 func TestWhoami(t *testing.T) {
-	fabricServer := &grpcWhoamiMockHandler{}
-	_, handler := defangv1connect.NewFabricControllerHandler(fabricServer)
+	mockService := &grpcWhoamiMockHandler{}
+	_, handler := defangv1connect.NewFabricControllerHandler(mockService)
 
 	server := httptest.NewServer(handler)
-	defer server.Close()
+	t.Cleanup(server.Close)
 
 	ctx := context.Background()
 	url := strings.TrimPrefix(server.URL, "http://")


### PR DESCRIPTION
## Description

Because of the two clients `client` and `localClient`, the CLI would crap out with an auth error even after interactive login. This is because only one of the client vars got updated.

Fixing this also uncovered a testing error in the gating tests.

Regression from #882

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

