### PR TITLE
Hide mirrored cmds from top-level menu

### DIFF
--- a/src/cmd/cli/command/commands.go
+++ b/src/cmd/cli/command/commands.go
@@ -261,8 +261,12 @@ func SetupCommands(ctx context.Context, version string) {
 
 	RootCmd.AddCommand(setupComposeCommand())
 	// Add up/down commands to the root as well
-	RootCmd.AddCommand(makeComposeDownCmd())
-	RootCmd.AddCommand(makeComposeUpCmd())
+	down := makeComposeDownCmd()
+	down.Hidden = true // hidden from top-level menu
+	RootCmd.AddCommand(down)
+	up := makeComposeUpCmd()
+	up.Hidden = true // hidden from top-level menu
+	RootCmd.AddCommand(up)
 
 	// Debug Command
 	debugCmd.Flags().String("etag", "", "deployment ID (ETag) of the service")
@@ -901,6 +905,7 @@ var deploymentsListCmd = &cobra.Command{
 
 var restartCmd = &cobra.Command{
 	Use:         "restart SERVICE...",
+	Hidden:      true,
 	Annotations: authNeededAnnotation,
 	Args:        cobra.MinimumNArgs(1),
 	Short:       "Restart one or more services",

--- a/src/cmd/cli/command/commands.go
+++ b/src/cmd/cli/command/commands.go
@@ -257,7 +257,6 @@ func SetupCommands(ctx context.Context, version string) {
 	configCmd.AddCommand(configListCmd)
 
 	RootCmd.AddCommand(configCmd)
-	RootCmd.AddCommand(restartCmd)
 
 	RootCmd.AddCommand(setupComposeCommand())
 	// Add up/down commands to the root as well
@@ -267,6 +266,9 @@ func SetupCommands(ctx context.Context, version string) {
 	up := makeComposeUpCmd()
 	up.Hidden = true // hidden from top-level menu
 	RootCmd.AddCommand(up)
+	restart := makeComposeRestartCmd()
+	restart.Hidden = true // hidden from top-level menu
+	RootCmd.AddCommand(restart)
 
 	// Debug Command
 	debugCmd.Flags().String("etag", "", "deployment ID (ETag) of the service")
@@ -900,17 +902,6 @@ var deploymentsListCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		loader := configureLoader(cmd)
 		return cli.DeploymentsList(cmd.Context(), loader, client)
-	},
-}
-
-var restartCmd = &cobra.Command{
-	Use:         "restart SERVICE...",
-	Hidden:      true,
-	Annotations: authNeededAnnotation,
-	Args:        cobra.MinimumNArgs(1),
-	Short:       "Restart one or more services",
-	RunE: func(cmd *cobra.Command, args []string) error {
-		return errors.New("command 'restart' is deprecated, use 'up' instead")
 	},
 }
 


### PR DESCRIPTION
## Description

Hides mirrored commands (`up`, `down`, `restart`) from the top-level root menu, as per linked issue.

Details:
- the commands still work as they did before, just hidden
- `up`, `down`, and `restart` still show up in the `defang compose` menu
- `RestartCmd` at top-level is replaced with `makeComposeRestartCmd()` 

## Linked Issues

Fixes #912 

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [x] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

