### PR TITLE
Fix loading of selected provider, add more test cases for getProvider

### DIFF
--- a/src/cmd/cli/command/commands.go
+++ b/src/cmd/cli/command/commands.go
@@ -15,7 +15,6 @@ import (
 	"time"
 
 	"github.com/AlecAivazis/survey/v2"
-	"github.com/AlecAivazis/survey/v2/terminal"
 	"github.com/DefangLabs/defang/src/pkg"
 	"github.com/DefangLabs/defang/src/pkg/cli"
 	cliClient "github.com/DefangLabs/defang/src/pkg/cli/client"
@@ -470,12 +469,6 @@ var certGenerateCmd = &cobra.Command{
 	},
 }
 
-var SurveyStdio = &terminal.Stdio{
-	In:  os.Stdin,
-	Out: os.Stdout,
-	Err: os.Stderr,
-}
-
 var generateCmd = &cobra.Command{
 	Use:     "generate",
 	Args:    cobra.MaximumNArgs(1),
@@ -522,7 +515,7 @@ var generateCmd = &cobra.Command{
 					Description: func(value string, i int) string {
 						return sampleTitles[i]
 					},
-				}, &sample, survey.WithStdio(SurveyStdio.In, SurveyStdio.Out, SurveyStdio.Err)); err != nil {
+				}, &sample, survey.WithStdio(term.DefaultTerm.Stdio())); err != nil {
 					return err
 				}
 				if sample == generateWithAI {
@@ -530,7 +523,7 @@ var generateCmd = &cobra.Command{
 						Message: "Choose the language you'd like to use:",
 						Options: cli.SupportedLanguages,
 						Help:    "The project code will be in the language you choose here.",
-					}, &language, survey.WithStdio(SurveyStdio.In, SurveyStdio.Out, SurveyStdio.Err)); err != nil {
+					}, &language, survey.WithStdio(term.DefaultTerm.Stdio())); err != nil {
 						return err
 					}
 					sample = ""
@@ -581,7 +574,7 @@ var generateCmd = &cobra.Command{
 		}{}
 
 		// ask the remaining questions
-		err := survey.Ask(qs, &prompt, survey.WithStdio(SurveyStdio.In, SurveyStdio.Out, SurveyStdio.Err))
+		err := survey.Ask(qs, &prompt, survey.WithStdio(term.DefaultTerm.Stdio()))
 		if err != nil {
 			return err
 		}
@@ -763,7 +756,7 @@ var configSetCmd = &cobra.Command{
 				Help:    "The value will be stored securely and cannot be retrieved later.",
 			}
 
-			err := survey.AskOne(sensitivePrompt, &value, survey.WithStdio(SurveyStdio.In, SurveyStdio.Out, SurveyStdio.Err))
+			err := survey.AskOne(sensitivePrompt, &value, survey.WithStdio(term.DefaultTerm.Stdio()))
 			if err != nil {
 				return err
 			}
@@ -1151,7 +1144,7 @@ func configureLoader(cmd *cobra.Command) *compose.Loader {
 			var confirm bool
 			err := survey.AskOne(&survey.Confirm{
 				Message: "Continue with project: " + projectName + "?",
-			}, &nonInteractive, survey.WithStdio(SurveyStdio.In, SurveyStdio.Out, SurveyStdio.Err))
+			}, &nonInteractive, survey.WithStdio(term.DefaultTerm.Stdio()))
 			if err == nil && !confirm {
 				os.Exit(1)
 			}
@@ -1304,7 +1297,7 @@ func determineProviderID(ctx context.Context, loader cliClient.Loader) (string, 
 		Description: func(value string, i int) string {
 			return providerDescription[cliClient.ProviderID(value)]
 		},
-	}, &optionValue, survey.WithStdio(SurveyStdio.In, SurveyStdio.Out, SurveyStdio.Err)); err != nil {
+	}, &optionValue, survey.WithStdio(term.DefaultTerm.Stdio())); err != nil {
 		return "", err
 	}
 	if err := providerID.Set(optionValue); err != nil {

--- a/src/cmd/cli/command/commands_test.go
+++ b/src/cmd/cli/command/commands_test.go
@@ -9,13 +9,13 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/AlecAivazis/survey/v2/terminal"
 	cliClient "github.com/DefangLabs/defang/src/pkg/cli/client"
 	"github.com/DefangLabs/defang/src/pkg/cli/client/byoc/aws"
 	"github.com/DefangLabs/defang/src/pkg/cli/client/byoc/gcp"
 	"github.com/DefangLabs/defang/src/pkg/cli/compose"
 	pkg "github.com/DefangLabs/defang/src/pkg/clouds/aws"
 	gcpdriver "github.com/DefangLabs/defang/src/pkg/clouds/gcp"
+	"github.com/DefangLabs/defang/src/pkg/term"
 	defangv1 "github.com/DefangLabs/defang/src/protos/io/defang/v1"
 	"github.com/DefangLabs/defang/src/protos/io/defang/v1/defangv1connect"
 	awssdk "github.com/aws/aws-sdk-go-v2/aws"
@@ -340,17 +340,17 @@ func TestGetProvider(t *testing.T) {
 		sts := aws.StsClient
 		aws.StsClient = &mockStsProviderAPI{}
 		nonInteractive = false
-		oldSurveyStdio := SurveyStdio
-		SurveyStdio = &terminal.Stdio{
-			In:  &FakeStdin{bytes.NewReader([]byte("aws\n"))},
-			Out: &FakeStdout{new(bytes.Buffer)},
-			Err: new(bytes.Buffer),
-		}
+		oldTerm := term.DefaultTerm
+		term.DefaultTerm = term.NewTerm(
+			&FakeStdin{bytes.NewReader([]byte("aws\n"))},
+			&FakeStdout{new(bytes.Buffer)},
+			new(bytes.Buffer),
+		)
 		t.Cleanup(func() {
 			nonInteractive = ni
 			aws.StsClient = sts
 			mockCtrl.savedProvider = nil
-			SurveyStdio = oldSurveyStdio
+			term.DefaultTerm = oldTerm
 		})
 
 		p, err := getProvider(ctx, loader)
@@ -378,17 +378,17 @@ func TestGetProvider(t *testing.T) {
 		sts := aws.StsClient
 		aws.StsClient = &mockStsProviderAPI{}
 		nonInteractive = false
-		oldSurveyStdio := SurveyStdio
-		SurveyStdio = &terminal.Stdio{
-			In:  &FakeStdin{bytes.NewReader([]byte("\n"))}, // Use default option, which should be DO from env var
-			Out: &FakeStdout{new(bytes.Buffer)},
-			Err: new(bytes.Buffer),
-		}
+		oldTerm := term.DefaultTerm
+		term.DefaultTerm = term.NewTerm(
+			&FakeStdin{bytes.NewReader([]byte("\n"))}, // Use default option, which should be DO from env var
+			&FakeStdout{new(bytes.Buffer)},
+			new(bytes.Buffer),
+		)
 		t.Cleanup(func() {
 			nonInteractive = ni
 			aws.StsClient = sts
 			mockCtrl.savedProvider = nil
-			SurveyStdio = oldSurveyStdio
+			term.DefaultTerm = oldTerm
 		})
 
 		_, err := getProvider(ctx, loader)
@@ -412,17 +412,17 @@ func TestGetProvider(t *testing.T) {
 		sts := aws.StsClient
 		aws.StsClient = &mockStsProviderAPI{}
 		nonInteractive = false
-		oldSurveyStdio := SurveyStdio
-		SurveyStdio = &terminal.Stdio{
-			In:  &FakeStdin{bytes.NewReader([]byte("gcp\n"))},
-			Out: &FakeStdout{new(bytes.Buffer)},
-			Err: new(bytes.Buffer),
-		}
+		oldTerm := term.DefaultTerm
+		term.DefaultTerm = term.NewTerm(
+			&FakeStdin{bytes.NewReader([]byte("gcp\n"))},
+			&FakeStdout{new(bytes.Buffer)},
+			new(bytes.Buffer),
+		)
 		t.Cleanup(func() {
 			nonInteractive = ni
 			aws.StsClient = sts
 			mockCtrl.savedProvider = nil
-			SurveyStdio = oldSurveyStdio
+			term.DefaultTerm = oldTerm
 		})
 
 		_, err := getProvider(ctx, loader)

--- a/src/cmd/cli/command/commands_test.go
+++ b/src/cmd/cli/command/commands_test.go
@@ -1,6 +1,7 @@
 package command
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"net/http/httptest"
@@ -8,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/AlecAivazis/survey/v2/terminal"
 	cliClient "github.com/DefangLabs/defang/src/pkg/cli/client"
 	"github.com/DefangLabs/defang/src/pkg/cli/client/byoc/aws"
 	"github.com/DefangLabs/defang/src/pkg/cli/client/byoc/gcp"
@@ -21,6 +23,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/bufbuild/connect-go"
 	connect_go "github.com/bufbuild/connect-go"
+	"github.com/spf13/cobra"
 	"golang.org/x/oauth2/google"
 	"google.golang.org/protobuf/types/known/emptypb"
 )
@@ -223,7 +226,7 @@ func TestCommandGates(t *testing.T) {
 type MockFabricControllerClient struct {
 	defangv1connect.FabricControllerClient
 	canIUseResponse defangv1.CanIUseResponse
-	savedProvider   defangv1.Provider
+	savedProvider   map[string]defangv1.Provider
 }
 
 func (m *MockFabricControllerClient) CanIUse(context.Context, *connect_go.Request[defangv1.CanIUseRequest]) (*connect_go.Response[defangv1.CanIUseResponse], error) {
@@ -234,10 +237,31 @@ func (m *MockFabricControllerClient) GetServices(context.Context, *connect_go.Re
 	return connect.NewResponse(&defangv1.GetServicesResponse{}), nil
 }
 
-func (m *MockFabricControllerClient) GetSelectedProvider(context.Context, *connect_go.Request[defangv1.GetSelectedProviderRequest]) (*connect_go.Response[defangv1.GetSelectedProviderResponse], error) {
+func (m *MockFabricControllerClient) GetSelectedProvider(ctx context.Context, req *connect_go.Request[defangv1.GetSelectedProviderRequest]) (*connect_go.Response[defangv1.GetSelectedProviderResponse], error) {
 	return connect.NewResponse(&defangv1.GetSelectedProviderResponse{
-		Provider: m.savedProvider,
+		Provider: m.savedProvider[req.Msg.Project],
 	}), nil
+}
+
+func (m *MockFabricControllerClient) SetSelectedProvider(ctx context.Context, req *connect_go.Request[defangv1.SetSelectedProviderRequest]) (*connect_go.Response[emptypb.Empty], error) {
+	m.savedProvider[req.Msg.Project] = req.Msg.Provider
+	return connect.NewResponse(&emptypb.Empty{}), nil
+}
+
+type FakeStdin struct {
+	*bytes.Reader
+}
+
+func (f *FakeStdin) Fd() uintptr {
+	return os.Stdin.Fd()
+}
+
+type FakeStdout struct {
+	*bytes.Buffer
+}
+
+func (f *FakeStdout) Fd() uintptr {
+	return os.Stdout.Fd()
 }
 
 func TestGetProvider(t *testing.T) {
@@ -248,11 +272,24 @@ func TestGetProvider(t *testing.T) {
 	mockClient.SetClient(mockCtrl)
 	client = mockClient
 	loader := cliClient.MockLoader{Project: &compose.Project{Name: "empty"}}
+	oldRootCmd := RootCmd
+	t.Cleanup(func() {
+		RootCmd = oldRootCmd
+	})
+	FakeRootWithProviderParam := func(provider string) *cobra.Command {
+		cmd := &cobra.Command{}
+		cmd.PersistentFlags().VarP(&providerID, "provider", "P", "fake provider flag")
+		if provider != "" {
+			cmd.ParseFlags([]string{"--provider", provider})
+		}
+		return cmd
+	}
 
 	t.Run("Nil loader auto provider non-interactive should load playground provider", func(t *testing.T) {
 		ctx := context.Background()
 		providerID = "auto"
 		os.Unsetenv("DEFANG_PROVIDER")
+		RootCmd = FakeRootWithProviderParam("")
 
 		p, err := getProvider(ctx, nil)
 		if err != nil {
@@ -268,8 +305,9 @@ func TestGetProvider(t *testing.T) {
 		providerID = "auto"
 		os.Unsetenv("DEFANG_PROVIDER")
 		t.Setenv("AWS_REGION", "us-west-2")
-		mockCtrl.savedProvider = defangv1.Provider_AWS
-		RootCmd.ResetFlags() // TODO: This should not be needed, but seems other tests messes up RootCmd.PersistentFlags()
+		RootCmd = FakeRootWithProviderParam("")
+
+		mockCtrl.savedProvider = map[string]defangv1.Provider{"empty": defangv1.Provider_AWS}
 
 		ni := nonInteractive
 		sts := aws.StsClient
@@ -278,7 +316,7 @@ func TestGetProvider(t *testing.T) {
 		t.Cleanup(func() {
 			nonInteractive = ni
 			aws.StsClient = sts
-			mockCtrl.savedProvider = defangv1.Provider_PROVIDER_UNSPECIFIED
+			mockCtrl.savedProvider = nil
 		})
 
 		p, err := getProvider(ctx, loader)
@@ -290,10 +328,139 @@ func TestGetProvider(t *testing.T) {
 		}
 	})
 
+	t.Run("Auto provider with no saved provider should go interactive and save", func(t *testing.T) {
+		ctx := context.Background()
+		providerID = "auto"
+		os.Unsetenv("DEFANG_PROVIDER")
+		t.Setenv("AWS_REGION", "us-west-2")
+		mockCtrl.savedProvider = map[string]defangv1.Provider{"someotherproj": defangv1.Provider_AWS}
+		RootCmd = FakeRootWithProviderParam("")
+
+		ni := nonInteractive
+		sts := aws.StsClient
+		aws.StsClient = &mockStsProviderAPI{}
+		nonInteractive = false
+		oldSurveyStdio := SurveyStdio
+		SurveyStdio = &terminal.Stdio{
+			In:  &FakeStdin{bytes.NewReader([]byte("aws\n"))},
+			Out: &FakeStdout{new(bytes.Buffer)},
+			Err: new(bytes.Buffer),
+		}
+		t.Cleanup(func() {
+			nonInteractive = ni
+			aws.StsClient = sts
+			mockCtrl.savedProvider = nil
+			SurveyStdio = oldSurveyStdio
+		})
+
+		p, err := getProvider(ctx, loader)
+		if err != nil {
+			t.Fatalf("getProvider() failed: %v", err)
+		}
+		if _, ok := p.(*aws.ByocAws); !ok {
+			t.Errorf("Expected provider to be of type *aws.ByocAws, got %T", p)
+		}
+		if mockCtrl.savedProvider["empty"] != defangv1.Provider_AWS {
+			t.Errorf("Expected provider to be saved as AWS, got %v", mockCtrl.savedProvider["empty"])
+		}
+	})
+
+	t.Run("Interactive provider prompt infer default provider from environment variable", func(t *testing.T) {
+		ctx := context.Background()
+		providerID = "auto"
+		os.Unsetenv("DEFANG_PROVIDER")
+		t.Setenv("AWS_REGION", "us-west-2")
+		t.Setenv("DIGITALOCEAN_TOKEN", "test-token")
+		mockCtrl.savedProvider = map[string]defangv1.Provider{"someotherproj": defangv1.Provider_AWS}
+		RootCmd = FakeRootWithProviderParam("")
+
+		ni := nonInteractive
+		sts := aws.StsClient
+		aws.StsClient = &mockStsProviderAPI{}
+		nonInteractive = false
+		oldSurveyStdio := SurveyStdio
+		SurveyStdio = &terminal.Stdio{
+			In:  &FakeStdin{bytes.NewReader([]byte("\n"))}, // Use default option, which should be DO from env var
+			Out: &FakeStdout{new(bytes.Buffer)},
+			Err: new(bytes.Buffer),
+		}
+		t.Cleanup(func() {
+			nonInteractive = ni
+			aws.StsClient = sts
+			mockCtrl.savedProvider = nil
+			SurveyStdio = oldSurveyStdio
+		})
+
+		_, err := getProvider(ctx, loader)
+		if err != nil && !strings.HasPrefix(err.Error(), "GET https://api.digitalocean.com/v2/account: 401") {
+			t.Fatalf("getProvider() failed: %v", err)
+		}
+		if mockCtrl.savedProvider["empty"] != defangv1.Provider_DIGITALOCEAN {
+			t.Errorf("Expected provider to be saved as DIGITALOCEAN, got %v", mockCtrl.savedProvider["empty"])
+		}
+	})
+
+	t.Run("Auto provider from param with saved provider should go interactive and save", func(t *testing.T) {
+		ctx := context.Background()
+		os.Unsetenv("GCP_PROJECT_ID") // To trigger error
+		os.Unsetenv("DEFANG_PROVIDER")
+		providerID = "auto"
+		mockCtrl.savedProvider = map[string]defangv1.Provider{"empty": defangv1.Provider_AWS}
+		RootCmd = FakeRootWithProviderParam("auto")
+
+		ni := nonInteractive
+		sts := aws.StsClient
+		aws.StsClient = &mockStsProviderAPI{}
+		nonInteractive = false
+		oldSurveyStdio := SurveyStdio
+		SurveyStdio = &terminal.Stdio{
+			In:  &FakeStdin{bytes.NewReader([]byte("gcp\n"))},
+			Out: &FakeStdout{new(bytes.Buffer)},
+			Err: new(bytes.Buffer),
+		}
+		t.Cleanup(func() {
+			nonInteractive = ni
+			aws.StsClient = sts
+			mockCtrl.savedProvider = nil
+			SurveyStdio = oldSurveyStdio
+		})
+
+		_, err := getProvider(ctx, loader)
+		if err != nil && err.Error() != "GCP_PROJECT_ID must be set for GCP projects" {
+			t.Fatalf("getProvider() failed: %v", err)
+		}
+		if mockCtrl.savedProvider["empty"] != defangv1.Provider_GCP {
+			t.Errorf("Expected provider to be saved as GCP, got %v", mockCtrl.savedProvider["empty"])
+		}
+	})
+
+	t.Run("Should take provider from param without updating saved provider", func(t *testing.T) {
+		ctx := context.Background()
+		os.Unsetenv("DIGITALOCEAN_TOKEN")
+		os.Unsetenv("DEFANG_PROVIDER")
+		mockCtrl.savedProvider = map[string]defangv1.Provider{"empty": defangv1.Provider_AWS}
+		RootCmd = FakeRootWithProviderParam("digitalocean")
+		ni := nonInteractive
+		nonInteractive = false
+		t.Cleanup(func() {
+			nonInteractive = ni
+			mockCtrl.savedProvider = nil
+		})
+
+		_, err := getProvider(ctx, loader)
+		if err != nil && !strings.HasPrefix(err.Error(), "DIGITALOCEAN_TOKEN must be set") {
+			t.Fatalf("getProvider() failed: %v", err)
+		}
+		if mockCtrl.savedProvider["empty"] != defangv1.Provider_AWS {
+			t.Errorf("Expected provider to stay as AWS, but got %v", mockCtrl.savedProvider["empty"])
+		}
+	})
+
 	t.Run("Should take provider from env aws", func(t *testing.T) {
 		ctx := context.Background()
 		t.Setenv("DEFANG_PROVIDER", "aws")
 		t.Setenv("AWS_REGION", "us-west-2")
+		RootCmd = FakeRootWithProviderParam("")
 		sts := aws.StsClient
 		aws.StsClient = &mockStsProviderAPI{}
 		t.Cleanup(func() {
@@ -313,6 +480,7 @@ func TestGetProvider(t *testing.T) {
 		ctx := context.Background()
 		t.Setenv("DEFANG_PROVIDER", "gcp")
 		t.Setenv("GCP_PROJECT_ID", "test_proj_id")
+		RootCmd = FakeRootWithProviderParam("")
 		gcpdriver.FindGoogleDefaultCredentials = func(ctx context.Context, scopes ...string) (*google.Credentials, error) {
 			return &google.Credentials{
 				JSON: []byte(`{"client_email":"test@email.com"}`),

--- a/src/cmd/cli/command/deploymentinfo_test.go
+++ b/src/cmd/cli/command/deploymentinfo_test.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"bytes"
+	"os"
 	"testing"
 
 	"github.com/DefangLabs/defang/src/pkg/cli"
@@ -17,7 +18,7 @@ func TestPrintPlaygroundPortalServiceURLs(t *testing.T) {
 	})
 
 	var stdout, stderr bytes.Buffer
-	term.DefaultTerm = term.NewTerm(&stdout, &stderr)
+	term.DefaultTerm = term.NewTerm(os.Stdin, &stdout, &stderr)
 
 	providerID = cliClient.ProviderDefang
 	cluster = cli.DefaultCluster
@@ -40,7 +41,7 @@ func TestPrintEndpoints(t *testing.T) {
 	})
 
 	var stdout, stderr bytes.Buffer
-	term.DefaultTerm = term.NewTerm(&stdout, &stderr)
+	term.DefaultTerm = term.NewTerm(os.Stdin, &stdout, &stderr)
 
 	printEndpoints([]*defangv1.ServiceInfo{
 		{

--- a/src/pkg/cli/compose/compose_test.go
+++ b/src/pkg/cli/compose/compose_test.go
@@ -199,7 +199,7 @@ func TestComposeGoNoDoubleWarningLog(t *testing.T) {
 	})
 
 	var warnings bytes.Buffer
-	term.DefaultTerm = term.NewTerm(&warnings, &warnings)
+	term.DefaultTerm = term.NewTerm(os.Stdin, &warnings, &warnings)
 
 	loader := NewLoader(WithPath("../../../tests/compose-go-warn/compose.yaml"))
 	_, err := loader.LoadProject(context.Background())

--- a/src/pkg/cli/compose/validation_test.go
+++ b/src/pkg/cli/compose/validation_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"os"
 	"slices"
 	"strings"
 	"testing"
@@ -37,7 +38,7 @@ func TestValidationAndConvert(t *testing.T) {
 
 	testRunCompose(t, func(t *testing.T, path string) {
 		logs := new(bytes.Buffer)
-		term.DefaultTerm = term.NewTerm(logs, logs)
+		term.DefaultTerm = term.NewTerm(os.Stdin, logs, logs)
 
 		options := LoaderOptions{ConfigPaths: []string{path}}
 		loader := Loader{options: options}

--- a/src/pkg/cli/tail_test.go
+++ b/src/pkg/cli/tail_test.go
@@ -3,7 +3,7 @@ package cli
 import (
 	"bytes"
 	"context"
-	"io"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -70,7 +70,7 @@ func TestParseTimeOrDuration(t *testing.T) {
 
 func TestTail(t *testing.T) {
 	var stdout, stderr bytes.Buffer
-	testTerm := term.NewTerm(&stdout, io.MultiWriter(&stderr))
+	testTerm := term.NewTerm(os.Stdin, &stdout, &stderr)
 	testTerm.ForceColor(true)
 	defaultTerm := term.DefaultTerm
 	term.DefaultTerm = testTerm

--- a/src/pkg/logs/logrus_test.go
+++ b/src/pkg/logs/logrus_test.go
@@ -3,6 +3,7 @@ package logs
 import (
 	"bytes"
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 
@@ -49,7 +50,7 @@ func TestTermLogFormatter(t *testing.T) {
 	})
 
 	var out, termout, termerr bytes.Buffer
-	term.DefaultTerm = term.NewTerm(&termout, &termerr)
+	term.DefaultTerm = term.NewTerm(os.Stdin, &termout, &termerr)
 	f := TermLogFormatter{Term: term.DefaultTerm}
 	logrus.SetOutput(&out)
 	logrus.SetFormatter(f)
@@ -95,7 +96,7 @@ func TestDiscardFormatter(t *testing.T) {
 	var out, termout, termerr bytes.Buffer
 	logrus.SetOutput(&out)
 	logrus.SetFormatter(DiscardFormatter{})
-	term.DefaultTerm = term.NewTerm(&termout, &termerr)
+	term.DefaultTerm = term.NewTerm(os.Stdin, &termout, &termerr)
 
 	logrus.Debug("debug message")
 	logrus.Info("info message")

--- a/src/pkg/term/colorizer_test.go
+++ b/src/pkg/term/colorizer_test.go
@@ -3,6 +3,7 @@ package term
 import (
 	"bytes"
 	"errors"
+	"os"
 	"strconv"
 	"strings"
 	"testing"
@@ -74,7 +75,7 @@ func TestAddingPrefix(t *testing.T) {
 		DefaultTerm = defaultTerm
 	})
 	var stdout, stderr bytes.Buffer
-	DefaultTerm = NewTerm(&stdout, &stderr)
+	DefaultTerm = NewTerm(os.Stdin, &stdout, &stderr)
 	DefaultTerm.SetDebug(true)
 
 	Debug("Hello, World!")
@@ -124,7 +125,7 @@ func TestInfoAddSpaceBetweenStrings(t *testing.T) {
 		DefaultTerm = defaultTerm
 	})
 	var stdout, stderr bytes.Buffer
-	DefaultTerm = NewTerm(&stdout, &stderr)
+	DefaultTerm = NewTerm(os.Stdin, &stdout, &stderr)
 	DefaultTerm.SetDebug(true)
 
 	Info("Hello", "World!")

--- a/src/pkg/term/table.go
+++ b/src/pkg/term/table.go
@@ -15,7 +15,7 @@ func Table(slice interface{}, attributes []string) error {
 	}
 
 	// Create a tabwriter
-	w := tabwriter.NewWriter(DefaultTerm.outw, 0, 0, 2, ' ', 0)
+	w := tabwriter.NewWriter(DefaultTerm.stdout, 0, 0, 2, ' ', 0)
 
 	var err error
 

--- a/src/pkg/term/test_utils.go
+++ b/src/pkg/term/test_utils.go
@@ -2,7 +2,7 @@ package term
 
 import (
 	"bytes"
-	"io"
+	"os"
 	"testing"
 )
 
@@ -10,7 +10,7 @@ func SetupTestTerm(t *testing.T) (*bytes.Buffer, *bytes.Buffer) {
 	t.Helper()
 
 	var stdout, stderr bytes.Buffer
-	testTerm := NewTerm(&stdout, io.MultiWriter(&stderr))
+	testTerm := NewTerm(os.Stdin, &stdout, &stderr)
 	testTerm.ForceColor(true)
 	defaultTerm := DefaultTerm
 	DefaultTerm = testTerm


### PR DESCRIPTION
## Description
In previous bug fix, a new bug was introduced, the API call to load saved provider was supplied with an empty string as project name and results loading a wrong value, and use have to repeatedly select provider.

Fixed the issue and:
 - Add new tests to improve coverage of different cases for getProvider and determineProvider
 - Create facility to allow testing of survey interactive workflow
 - Create fake RootCmd to prevent tests affecting each other due to manipulation of the flags.

## Checklist

- [X] I have performed a self-review of my code
- [X] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary


### Current test coverage of getProvider and determineProvider

![Screenshot from 2024-12-07 20-12-41](https://github.com/user-attachments/assets/4f81a6e1-22b5-4425-a2d3-42dce666effb)
![Screenshot from 2024-12-07 20-13-12](https://github.com/user-attachments/assets/7c2776e7-84c8-4749-bde1-a855c69dc67b)
![Screenshot from 2024-12-07 20-13-30](https://github.com/user-attachments/assets/bc76774c-4df9-448b-9112-7d6aed2d1848)
