### PR TITLE
Make ports optional for managed redis/postgres

### DIFF
--- a/src/pkg/cli/compose/constants.go
+++ b/src/pkg/cli/compose/constants.go
@@ -5,4 +5,3 @@ const Mode_HOST = "host"
 
 const Protocol_TCP = "tcp"
 const Protocol_UDP = "udp"
-const Protocol_HTTP = "http"

--- a/src/pkg/cli/compose/convert.go
+++ b/src/pkg/cli/compose/convert.go
@@ -22,11 +22,11 @@ func fixupPort(port *composeTypes.ServicePortConfig) {
 		fallthrough
 	case Mode_INGRESS:
 		// This code is unnecessarily complex because compose-go silently converts short `ports:` syntax to ingress+tcp
-		if port.Protocol != "udp" {
+		if port.Protocol != Protocol_UDP {
 			if port.Published != "" {
 				term.Debugf("port %d: ignoring 'published: %s' in 'ingress' mode", port.Target, port.Published)
 			}
-			if (port.Protocol == "tcp" || port.Protocol == "udp") && port.AppProtocol != "http" {
+			if (port.Protocol == Protocol_TCP || port.Protocol == Protocol_UDP) && port.AppProtocol != "http" {
 				// term.Warnf("TCP ingress is not supported; assuming HTTP (remove 'protocol' to silence)")
 				port.AppProtocol = "http"
 			}

--- a/src/pkg/cli/compose/fixup.go
+++ b/src/pkg/cli/compose/fixup.go
@@ -102,6 +102,9 @@ func FixupServices(ctx context.Context, provider client.Provider, project *types
 			if _, ok := provider.(*client.PlaygroundProvider); ok {
 				term.Warnf("service %q: Managed redis is not supported in the Playground; consider using BYOC (https://s.defang.io/byoc)", svccfg.Name)
 				delete(svccfg.Extensions, "x-defang-redis")
+			} else if len(svccfg.Ports) == 0 {
+				term.Debugf("service %q: adding default redis port", svccfg.Name)
+				svccfg.Ports = []types.ServicePortConfig{{Target: 6379, Published: "6379", Mode: Mode_HOST}}
 			}
 		}
 
@@ -110,6 +113,9 @@ func FixupServices(ctx context.Context, provider client.Provider, project *types
 			if _, ok := provider.(*client.PlaygroundProvider); ok {
 				term.Warnf("service %q: managed postgres is not supported in the Playground; consider using BYOC (https://s.defang.io/byoc)", svccfg.Name)
 				delete(svccfg.Extensions, "x-defang-postgres")
+			} else if len(svccfg.Ports) == 0 {
+				term.Debugf("service %q: adding default postgres port", svccfg.Name)
+				svccfg.Ports = []types.ServicePortConfig{{Target: 5432, Published: "5432", Mode: Mode_HOST}}
 			}
 		}
 

--- a/src/pkg/cli/compose/fixup.go
+++ b/src/pkg/cli/compose/fixup.go
@@ -104,7 +104,7 @@ func FixupServices(ctx context.Context, provider client.Provider, project *types
 				term.Warnf("service %q: Managed redis is not supported in the Playground; consider using BYOC (https://s.defang.io/byoc)", svccfg.Name)
 				delete(svccfg.Extensions, "x-defang-redis")
 			} else if len(svccfg.Ports) == 0 {
-				// HACK: we must have at least one host port to get a CNAME for the service
+				// HACK: we must have at least one host port to get a CNAME for the service https://redis.io/docs/latest/operate/oss_and_stack/management/config/
 				var port uint32 = 6379
 				// Check entrypoint or command for --port argument
 				args := append(svccfg.Entrypoint, svccfg.Command...)
@@ -131,7 +131,7 @@ func FixupServices(ctx context.Context, provider client.Provider, project *types
 			} else if len(svccfg.Ports) == 0 {
 				// HACK: we must have at least one host port to get a CNAME for the service
 				var port uint32 = 5432
-				// Check PGPORT environment variable for port number
+				// Check PGPORT environment variable for port number https://www.postgresql.org/docs/current/libpq-envars.html
 				if pgport := svccfg.Environment["PGPORT"]; pgport != nil {
 					if p, err := strconv.ParseUint(*pgport, 10, 16); err != nil {
 						return err

--- a/src/pkg/cli/compose/validate_test.go
+++ b/src/pkg/cli/compose/validate_test.go
@@ -39,7 +39,7 @@ func TestValidateService(t *testing.T) {
 		},
 		{
 			name:    "ingress with UDP",
-			service: &types.ServiceConfig{Name: "test", Image: "asdf", Ports: []types.ServicePortConfig{{Target: 53, Mode: "ingress", Protocol: Protocol_UDP}}},
+			service: &types.ServiceConfig{Name: "test", Image: "asdf", Ports: []types.ServicePortConfig{{Target: 53, Mode: "ingress", Protocol: "udp"}}},
 			wantErr: "`mode: ingress` is not supported by `protocol: udp`",
 		},
 		{
@@ -60,7 +60,7 @@ func TestValidateService(t *testing.T) {
 			service: &types.ServiceConfig{
 				Name:  "test",
 				Image: "asdf",
-				Ports: []types.ServicePortConfig{{Target: 80, Mode: "ingress", Protocol: Protocol_HTTP}},
+				Ports: []types.ServicePortConfig{{Target: 80, Mode: "ingress", Protocol: "http"}},
 				HealthCheck: &types.HealthCheckConfig{
 					Test: []string{"CMD", "echo 1"},
 				},
@@ -72,7 +72,7 @@ func TestValidateService(t *testing.T) {
 			service: &types.ServiceConfig{
 				Name:  "test",
 				Image: "asdf",
-				Ports: []types.ServicePortConfig{{Target: 80, Mode: "ingress", Protocol: Protocol_HTTP}},
+				Ports: []types.ServicePortConfig{{Target: 80, Mode: "ingress", Protocol: "http"}},
 				HealthCheck: &types.HealthCheckConfig{
 					Test: []string{"CMD", "echo", "1"},
 				},
@@ -84,7 +84,7 @@ func TestValidateService(t *testing.T) {
 			service: &types.ServiceConfig{
 				Name:  "test",
 				Image: "asdf",
-				Ports: []types.ServicePortConfig{{Target: 80, Mode: "ingress", Protocol: Protocol_HTTP}},
+				Ports: []types.ServicePortConfig{{Target: 80, Mode: "ingress", Protocol: "http"}},
 				HealthCheck: &types.HealthCheckConfig{
 					Test: []string{"CMD", "curl", "1"},
 				},
@@ -107,7 +107,7 @@ func TestValidateService(t *testing.T) {
 			service: &types.ServiceConfig{
 				Name:  "test",
 				Image: "asdf",
-				Ports: []types.ServicePortConfig{{Target: 80, Mode: "ingress", Protocol: Protocol_HTTP}},
+				Ports: []types.ServicePortConfig{{Target: 80, Mode: "ingress", Protocol: "http"}},
 				HealthCheck: &types.HealthCheckConfig{
 					Test: []string{"CMD-SHELL", "echo 1"},
 				},
@@ -119,7 +119,7 @@ func TestValidateService(t *testing.T) {
 			service: &types.ServiceConfig{
 				Name:  "test",
 				Image: "asdf",
-				Ports: []types.ServicePortConfig{{Target: 80, Mode: "ingress", Protocol: Protocol_HTTP}},
+				Ports: []types.ServicePortConfig{{Target: 80, Mode: "ingress", Protocol: "http"}},
 				HealthCheck: &types.HealthCheckConfig{
 					Test: []string{"NONE"},
 				},
@@ -142,7 +142,7 @@ func TestValidateService(t *testing.T) {
 			service: &types.ServiceConfig{
 				Name:  "test",
 				Image: "asdf",
-				Ports: []types.ServicePortConfig{{Target: 80, Mode: "ingress", Protocol: Protocol_HTTP}},
+				Ports: []types.ServicePortConfig{{Target: 80, Mode: "ingress", Protocol: "http"}},
 				HealthCheck: &types.HealthCheckConfig{
 					Test: []string{"CMD", "curl", "http://localhost"},
 				},

--- a/src/pkg/cli/compose/validation.go
+++ b/src/pkg/cli/compose/validation.go
@@ -296,10 +296,6 @@ func validateService(svccfg *composeTypes.ServiceConfig, project *composeTypes.P
 		if !strings.HasSuffix(repo, "redis") {
 			term.Warnf("service %q: managed Redis service should use a redis image", svccfg.Name)
 		}
-		// Ensure the service has a valid host port
-		if !slices.ContainsFunc(svccfg.Ports, isHostPort) {
-			return fmt.Errorf("service %q: managed Redis service should expose a host port", svccfg.Name)
-		}
 	}
 
 	if _, ok := svccfg.Extensions["x-defang-postgres"]; ok {
@@ -307,10 +303,6 @@ func validateService(svccfg *composeTypes.ServiceConfig, project *composeTypes.P
 		repo := strings.SplitN(svccfg.Image, ":", 2)[0]
 		if !strings.HasSuffix(repo, "postgres") {
 			term.Warnf("service %q: managed Postgres service should use a postgres image", svccfg.Name)
-		}
-		// Ensure the service has a valid host port
-		if !slices.ContainsFunc(svccfg.Ports, isHostPort) {
-			return fmt.Errorf("service %q: managed Postgres service should expose a host port", svccfg.Name)
 		}
 	}
 

--- a/src/pkg/quota/service_test.go
+++ b/src/pkg/quota/service_test.go
@@ -146,7 +146,7 @@ func TestValidateQuotas(t *testing.T) {
 			service: &types.ServiceConfig{
 				Name:  "test",
 				Image: "asdf",
-				Ports: []types.ServicePortConfig{{Target: 80, Mode: "ingress", Protocol: compose.Protocol_HTTP}},
+				Ports: []types.ServicePortConfig{{Target: 80, Mode: "ingress", Protocol: "http"}},
 				HealthCheck: &types.HealthCheckConfig{
 					Test: []string{"CMD", "curl", "http://localhost"},
 				},

--- a/src/tests/postgres/compose.yaml
+++ b/src/tests/postgres/compose.yaml
@@ -22,3 +22,9 @@ services:
   no-ports:
     image: postgres
     x-defang-postgres:
+
+  no-ports-override:
+    image: postgres
+    x-defang-postgres:
+    environment:
+      - PGPORT=5433

--- a/src/tests/postgres/compose.yaml.fixup
+++ b/src/tests/postgres/compose.yaml.fixup
@@ -20,7 +20,14 @@
     "image": "postgres",
     "networks": {
       "default": null
-    }
+    },
+    "ports": [
+      {
+        "mode": "host",
+        "target": 5432,
+        "published": "5432"
+      }
+    ]
   },
   "with-ext": {
     "command": null,

--- a/src/tests/postgres/compose.yaml.fixup
+++ b/src/tests/postgres/compose.yaml.fixup
@@ -25,7 +25,25 @@
       {
         "mode": "host",
         "target": 5432,
-        "published": "5432"
+        "protocol": "tcp"
+      }
+    ]
+  },
+  "no-ports-override": {
+    "command": null,
+    "entrypoint": null,
+    "environment": {
+      "PGPORT": "5433"
+    },
+    "image": "postgres",
+    "networks": {
+      "default": null
+    },
+    "ports": [
+      {
+        "mode": "host",
+        "target": 5433,
+        "protocol": "tcp"
       }
     ]
   },

--- a/src/tests/postgres/compose.yaml.golden
+++ b/src/tests/postgres/compose.yaml.golden
@@ -13,6 +13,13 @@ services:
     networks:
       default: null
     x-defang-postgres: null
+  no-ports-override:
+    environment:
+      PGPORT: "5433"
+    image: postgres
+    networks:
+      default: null
+    x-defang-postgres: null
   with-ext:
     image: postgres
     networks:

--- a/src/tests/postgres/compose.yaml.warnings
+++ b/src/tests/postgres/compose.yaml.warnings
@@ -4,4 +4,3 @@
  ! service "with-ext": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors
  ! service "wrong-image": managed Postgres service should use a postgres image
  ! service "wrong-image": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors
-service "no-ports": managed Postgres service should expose a host port

--- a/src/tests/postgres/compose.yaml.warnings
+++ b/src/tests/postgres/compose.yaml.warnings
@@ -1,6 +1,7 @@
  ! service "no-ext": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors
  ! service "no-ext": stateful service will lose data on restart; use a managed service instead
  ! service "no-ports": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors
+ ! service "no-ports-override": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors
  ! service "with-ext": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors
  ! service "wrong-image": managed Postgres service should use a postgres image
  ! service "wrong-image": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors

--- a/src/tests/redis/compose.yaml
+++ b/src/tests/redis/compose.yaml
@@ -22,3 +22,8 @@ services:
   no-ports:
     image: redis
     x-defang-redis:
+
+  no-ports-override:
+    image: redis
+    x-defang-redis:
+    command: ["--port", "6380"]

--- a/src/tests/redis/compose.yaml.fixup
+++ b/src/tests/redis/compose.yaml.fixup
@@ -20,7 +20,14 @@
     "image": "redis",
     "networks": {
       "default": null
-    }
+    },
+    "ports": [
+      {
+        "mode": "host",
+        "target": 6379,
+        "published": "6379"
+      }
+    ]
   },
   "with-ext": {
     "command": null,

--- a/src/tests/redis/compose.yaml.fixup
+++ b/src/tests/redis/compose.yaml.fixup
@@ -25,7 +25,25 @@
       {
         "mode": "host",
         "target": 6379,
-        "published": "6379"
+        "protocol": "tcp"
+      }
+    ]
+  },
+  "no-ports-override": {
+    "command": [
+      "--port",
+      "6380"
+    ],
+    "entrypoint": null,
+    "image": "redis",
+    "networks": {
+      "default": null
+    },
+    "ports": [
+      {
+        "mode": "host",
+        "target": 6380,
+        "protocol": "tcp"
       }
     ]
   },

--- a/src/tests/redis/compose.yaml.golden
+++ b/src/tests/redis/compose.yaml.golden
@@ -13,6 +13,14 @@ services:
     networks:
       default: null
     x-defang-redis: null
+  no-ports-override:
+    command:
+      - --port
+      - "6380"
+    image: redis
+    networks:
+      default: null
+    x-defang-redis: null
   with-ext:
     image: redis
     networks:

--- a/src/tests/redis/compose.yaml.warnings
+++ b/src/tests/redis/compose.yaml.warnings
@@ -4,4 +4,3 @@
  ! service "with-ext": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors
  ! service "wrong-image": managed Redis service should use a redis image
  ! service "wrong-image": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors
-service "no-ports": managed Redis service should expose a host port

--- a/src/tests/redis/compose.yaml.warnings
+++ b/src/tests/redis/compose.yaml.warnings
@@ -1,6 +1,7 @@
  ! service "no-ext": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors
  ! service "no-ext": stateful service will lose data on restart; use a managed service instead
  ! service "no-ports": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors
+ ! service "no-ports-override": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors
  ! service "with-ext": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors
  ! service "wrong-image": managed Redis service should use a redis image
  ! service "wrong-image": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors


### PR DESCRIPTION
## Description

Replace #918: make ports optional for managed services.

Ideally we'd do this "fixup" in the Pulumi deployment code.

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

