### PR TITLE
Add Pulumi "NO_COLOR" env for BYOC

### DIFF
--- a/src/pkg/cli/client/byoc/aws/byoc.go
+++ b/src/pkg/cli/client/byoc/aws/byoc.go
@@ -470,7 +470,7 @@ func (b *ByocAws) environment(projectName string) map[string]string {
 	}
 
 	if !term.StdoutCanColor() {
-		env["NO_COLOR"] = "enabled no color mode"
+		env["NO_COLOR"] = "1"
 	}
 
 	return env

--- a/src/pkg/cli/client/byoc/aws/byoc.go
+++ b/src/pkg/cli/client/byoc/aws/byoc.go
@@ -455,7 +455,7 @@ func (b *ByocAws) bucketName() string {
 
 func (b *ByocAws) environment(projectName string) map[string]string {
 	region := b.driver.Region // TODO: this should be the destination region, not the CD region; make customizable
-	return map[string]string{
+	env := map[string]string{
 		// "AWS_REGION":               region.String(), should be set by ECS (because of CD task role)
 		"DEFANG_DEBUG":               os.Getenv("DEFANG_DEBUG"), // TODO: use the global DoDebug flag
 		"DEFANG_ORG":                 b.TenantName,
@@ -468,6 +468,12 @@ func (b *ByocAws) environment(projectName string) map[string]string {
 		"PULUMI_SKIP_UPDATE_CHECK":   "true",
 		"STACK":                      b.PulumiStack,
 	}
+
+	if !term.StdoutCanColor() {
+		env["NO_COLOR"] = "enabled no color mode"
+	}
+
+	return env
 }
 
 type cdCmd struct {

--- a/src/pkg/cli/client/byoc/do/byoc.go
+++ b/src/pkg/cli/client/byoc/do/byoc.go
@@ -615,7 +615,7 @@ func (b *ByocDo) environment(projectName, delegateDomain string) []*godo.AppVari
 		},
 	}
 	if !term.StdoutCanColor() {
-		env = append(env, &godo.AppVariableDefinition{Key: "NO_COLOR", Value: "enabled no color mode"})
+		env = append(env, &godo.AppVariableDefinition{Key: "NO_COLOR", Value: "1"})
 	}
 	return env
 }

--- a/src/pkg/cli/client/byoc/do/byoc.go
+++ b/src/pkg/cli/client/byoc/do/byoc.go
@@ -532,7 +532,7 @@ func (b *ByocDo) runCdCommand(ctx context.Context, projectName, delegateDomain s
 
 func (b *ByocDo) environment(projectName, delegateDomain string) []*godo.AppVariableDefinition {
 	region := b.driver.Region // TODO: this should be the destination region, not the CD region; make customizable
-	return []*godo.AppVariableDefinition{
+	env := []*godo.AppVariableDefinition{
 		{
 			Key:   "DEFANG_PREFIX",
 			Value: byoc.DefangPrefix,
@@ -614,6 +614,10 @@ func (b *ByocDo) environment(projectName, delegateDomain string) []*godo.AppVari
 			Type:  godo.AppVariableType_Secret,
 		},
 	}
+	if !term.StdoutCanColor() {
+		env = append(env, &godo.AppVariableDefinition{Key: "NO_COLOR", Value: "enabled no color mode"})
+	}
+	return env
 }
 
 func (b *ByocDo) update(service composeTypes.ServiceConfig, projectName string) *defangv1.ServiceInfo {

--- a/src/pkg/cli/client/byoc/gcp/byoc.go
+++ b/src/pkg/cli/client/byoc/gcp/byoc.go
@@ -320,7 +320,7 @@ func (b *ByocGcp) runCdCommand(ctx context.Context, cmd cdCommand) (string, erro
 	}
 
 	if !term.StdoutCanColor() {
-		env["NO_COLOR"] = "enabled no color mode"
+		env["NO_COLOR"] = "1"
 	}
 
 	if cmd.DelegateDomain != "" {

--- a/src/pkg/cli/client/byoc/gcp/byoc.go
+++ b/src/pkg/cli/client/byoc/gcp/byoc.go
@@ -319,6 +319,10 @@ func (b *ByocGcp) runCdCommand(ctx context.Context, cmd cdCommand) (string, erro
 		"DEFANG_MODE":              strings.ToLower(cmd.Mode.String()),
 	}
 
+	if !term.StdoutCanColor() {
+		env["NO_COLOR"] = "enabled no color mode"
+	}
+
 	if cmd.DelegateDomain != "" {
 		env["DOMAIN"] = b.GetProjectDomain(cmd.Project, cmd.DelegateDomain)
 	} else {


### PR DESCRIPTION
## Description

- Added an optional "NO_COLOR" key in the environment for the cloud providers
- This key will exist if `term.StdoutCanColor()` is false (i.e. if color is not enabled in the CLI)

## Linked Issues

Fixes #921 

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [x] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

