### PR TITLE
remove "last" prefix from byoc client attrs

### DIFF
--- a/src/pkg/cli/client/byoc/gcp/byoc.go
+++ b/src/pkg/cli/client/byoc/gcp/byoc.go
@@ -81,8 +81,8 @@ type ByocGcp struct {
 	uploadServiceAccount string
 	delegateDomainZone   string
 
-	lastCdExecution string
-	lastCdEtag      string
+	cdExecution string
+	cdEtag      string
 }
 
 func NewByocProvider(ctx context.Context, tenantName types.TenantName) *ByocGcp {
@@ -337,7 +337,7 @@ func (b *ByocGcp) runCdCommand(ctx context.Context, cmd cdCommand) (string, erro
 	if err != nil {
 		return "", err
 	}
-	b.lastCdExecution = execution
+	b.cdExecution = execution
 	// fmt.Printf("CD Execution: %s\n", execution)
 	return execution, nil
 }
@@ -433,7 +433,7 @@ func (b *ByocGcp) deploy(ctx context.Context, req *defangv1.DeployRequest, comma
 		return nil, err
 	}
 
-	b.lastCdEtag = etag
+	b.cdEtag = etag
 	if command == "preview" {
 		etag = execution // Only wait for the preview command cd job to finish
 	}
@@ -477,8 +477,8 @@ func (b *ByocGcp) Subscribe(ctx context.Context, req *defangv1.SubscribeRequest)
 	if err != nil {
 		return nil, err
 	}
-	if req.Etag == b.lastCdEtag {
-		ss.AddJobExecutionUpdate(path.Base(b.lastCdExecution))
+	if req.Etag == b.cdEtag {
+		ss.AddJobExecutionUpdate(path.Base(b.cdExecution))
 	}
 	ss.AddJobStatusUpdate(req.Project, req.Etag, req.Services)
 	ss.AddServiceStatusUpdate(req.Project, req.Etag, req.Services)
@@ -489,12 +489,12 @@ func (b *ByocGcp) Subscribe(ctx context.Context, req *defangv1.SubscribeRequest)
 }
 
 func (b *ByocGcp) Follow(ctx context.Context, req *defangv1.TailRequest) (client.ServerStream[defangv1.TailResponse], error) {
-	if req.Etag == b.lastCdExecution { // Only follow CD log, we need to subscribe to cd activities to detect when the job is done
+	if req.Etag == b.cdExecution { // Only follow CD log, we need to subscribe to cd activities to detect when the job is done
 		ss, err := NewSubscribeStream(ctx, b.driver)
 		if err != nil {
 			return nil, err
 		}
-		ss.AddJobExecutionUpdate(path.Base(b.lastCdExecution))
+		ss.AddJobExecutionUpdate(path.Base(b.cdExecution))
 		if err := ss.Start(); err != nil {
 			return nil, err
 		}
@@ -524,11 +524,11 @@ func (b *ByocGcp) Follow(ctx context.Context, req *defangv1.TailRequest) (client
 	if err != nil {
 		return nil, err
 	}
-	if req.Etag == b.lastCdEtag || req.Etag == b.lastCdExecution {
-		ls.AddJobExecutionLog(path.Base(b.lastCdExecution), req.Since.AsTime()) // CD log
+	if req.Etag == b.cdEtag || req.Etag == b.cdExecution {
+		ls.AddJobExecutionLog(path.Base(b.cdExecution), req.Since.AsTime()) // CD log
 	}
 
-	if req.Etag != b.lastCdExecution { // No need to tail kaniko and service log if there is only cd running
+	if req.Etag != b.cdExecution { // No need to tail kaniko and service log if there is only cd running
 		ls.AddJobLog(req.Project, req.Etag, req.Services, req.Since.AsTime())     // Kaniko logs
 		ls.AddServiceLog(req.Project, req.Etag, req.Services, req.Since.AsTime()) // Service logs
 	}


### PR DESCRIPTION
## Description

at a glance, I thought these vars referred to values from a previous defang invocation, but it turns out they are for the _current_ invocation, so I think removing the "last" prefix will help a future reader to avoid that confusion.

## Linked Issues

https://github.com/DefangLabs/defang/pull/923#discussion_r1890983036

## Checklist

- [x] I have performed a self-review of my code
