### PR TITLE
Retry Tail on SessionStreamingException

### DIFF
--- a/src/cmd/cli/command/compose.go
+++ b/src/cmd/cli/command/compose.go
@@ -439,7 +439,7 @@ func makeComposeLogsCmd() *cobra.Command {
 
 			ts = ts.UTC()
 			sinceStr := ""
-			if ts.Year() > 1970 {
+			if pkg.IsValidTime(ts) {
 				sinceStr = " since " + ts.Format(time.RFC3339Nano) + " "
 			}
 			term.Infof("Showing logs%s; press Ctrl+C to stop:", sinceStr)

--- a/src/pkg/cli/client/byoc/aws/byoc.go
+++ b/src/pkg/cli/client/byoc/aws/byoc.go
@@ -30,6 +30,7 @@ import (
 	defangv1 "github.com/DefangLabs/defang/src/protos/io/defang/v1"
 	awssdk "github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
+	cwTypes "github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
 	"github.com/aws/aws-sdk-go-v2/service/route53"
 	r53types "github.com/aws/aws-sdk-go-v2/service/route53/types"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
@@ -107,6 +108,9 @@ func AnnotateAwsError(err error) error {
 	}
 	if cerr := new(smithy.OperationError); errors.As(err, &cerr) {
 		return ErrMissingAwsCreds{err}
+	}
+	if cerr := new(cwTypes.SessionStreamingException); errors.As(err, &cerr) {
+		return connect.NewError(connect.CodeInternal, err)
 	}
 	return err
 }

--- a/src/pkg/cli/tail.go
+++ b/src/pkg/cli/tail.go
@@ -298,7 +298,7 @@ func tail(ctx context.Context, provider client.Provider, projectName string, opt
 					spaces, _ = term.Warnf("Reconnecting...\r") // overwritten below
 				}
 				pkg.SleepWithContext(ctx, 1*time.Second)
-				serverStream, err = provider.Follow(ctx, &defangv1.TailRequest{Services: options.Services, Etag: options.Etag, Since: timestamppb.New(options.Since)})
+				serverStream, err = provider.Follow(ctx, &defangv1.TailRequest{Project: projectName, Services: options.Services, Etag: options.Etag, Since: timestamppb.New(options.Since), LogType: uint32(options.LogType)})
 				if err != nil {
 					term.Debug("Reconnect failed:", err)
 					return err
@@ -324,7 +324,7 @@ func tail(ctx context.Context, provider client.Provider, projectName string, opt
 			etag := valueOrDefault(e.Etag, msg.Etag)
 
 			// HACK: skip noisy CI/CD logs (except errors)
-			isInternal := service == "cd" || service == "ci" || service == "kaniko" || service == "fabric" || host == "kaniko" || host == "fabric"
+			isInternal := service == "cd" || service == "ci" || service == "kaniko" || service == "fabric" || host == "kaniko" || host == "fabric" || host == "ecs"
 			onlyErrors := !options.Verbose && isInternal
 			if onlyErrors && !e.Stderr {
 				if options.EndEventDetectFunc != nil && options.EndEventDetectFunc([]string{service}, host, e.Message) {

--- a/src/pkg/cli/tail.go
+++ b/src/pkg/cli/tail.go
@@ -207,19 +207,20 @@ func isTransientError(err error) bool {
 
 func tail(ctx context.Context, provider client.Provider, projectName string, options TailOptions) error {
 	var since *timestamppb.Timestamp
-	if options.Since.Year() <= 1970 {
-		options.Since = time.Now() // this is used to continue from the last timestamp
-	} else {
+	if pkg.IsValidTime(options.Since) {
 		since = timestamppb.New(options.Since)
+	} else {
+		options.Since = time.Now() // this is used to continue from the last timestamp
 	}
 
-	serverStream, err := provider.Follow(ctx, &defangv1.TailRequest{
+	tailRequest := &defangv1.TailRequest{
 		Project:  projectName,
 		Services: options.Services,
 		Etag:     options.Etag,
 		Since:    since,
 		LogType:  uint32(options.LogType),
-	})
+	}
+	serverStream, err := provider.Follow(ctx, tailRequest)
 	if err != nil {
 		return err
 	}
@@ -298,7 +299,8 @@ func tail(ctx context.Context, provider client.Provider, projectName string, opt
 					spaces, _ = term.Warnf("Reconnecting...\r") // overwritten below
 				}
 				pkg.SleepWithContext(ctx, 1*time.Second)
-				serverStream, err = provider.Follow(ctx, &defangv1.TailRequest{Project: projectName, Services: options.Services, Etag: options.Etag, Since: timestamppb.New(options.Since), LogType: uint32(options.LogType)})
+				tailRequest.Since = timestamppb.New(options.Since)
+				serverStream, err = provider.Follow(ctx, tailRequest)
 				if err != nil {
 					term.Debug("Reconnect failed:", err)
 					return err
@@ -335,6 +337,7 @@ func tail(ctx context.Context, provider client.Provider, projectName string, opt
 			}
 
 			ts := e.Timestamp.AsTime()
+			// Skip duplicate logs (e.g. after reconnecting we might get the same log once more)
 			if skipDuplicate && ts.Equal(options.Since) {
 				skipDuplicate = false
 				continue

--- a/src/pkg/cli/tail_test.go
+++ b/src/pkg/cli/tail_test.go
@@ -15,6 +15,7 @@ import (
 	defangv1 "github.com/DefangLabs/defang/src/protos/io/defang/v1"
 	cwTypes "github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
 	"github.com/bufbuild/connect-go"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -78,7 +79,8 @@ type mockTailProvider struct {
 }
 
 func (m *mockTailProvider) Follow(ctx context.Context, req *defangv1.TailRequest) (client.ServerStream[defangv1.TailResponse], error) {
-	m.Reqs = append(m.Reqs, req)
+	dup, _ := proto.Clone(req).(*defangv1.TailRequest)
+	m.Reqs = append(m.Reqs, dup)
 	if len(m.ServerStreams) == 0 {
 		return nil, errors.New("no server stream provided")
 	}

--- a/src/pkg/clouds/aws/ecs/event.go
+++ b/src/pkg/clouds/aws/ecs/event.go
@@ -146,7 +146,7 @@ func (e *TaskStateChangeEvent) Etag() string {
 	return etag
 }
 func (e *TaskStateChangeEvent) Host() string {
-	return "fabric"
+	return "ecs"
 }
 
 func (e *TaskStateChangeEvent) Status() string {
@@ -275,7 +275,7 @@ func (e *ServiceActionEvent) Etag() string {
 	return ""
 }
 func (e *ServiceActionEvent) Host() string {
-	return "fabric"
+	return "ecs"
 }
 func (e *ServiceActionEvent) Status() string {
 	return e.Detail.EventName
@@ -291,7 +291,7 @@ func (e *DeploymentStateChangeEvent) Etag() string {
 	return DeploymentEtags.Get(e.Detail.DeploymentId)
 }
 func (e *DeploymentStateChangeEvent) Host() string {
-	return "fabric"
+	return "ecs"
 }
 func (e *DeploymentStateChangeEvent) Status() string {
 	return e.Detail.EventName

--- a/src/pkg/clouds/aws/ecs/logs.go
+++ b/src/pkg/clouds/aws/ecs/logs.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/DefangLabs/defang/src/pkg"
 	"github.com/DefangLabs/defang/src/pkg/clouds/aws"
 	"github.com/DefangLabs/defang/src/pkg/clouds/aws/region"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
@@ -73,7 +74,7 @@ func TailLogGroups(ctx context.Context, since time.Time, logGroups ...LogGroupIn
 	var pendingGroups []LogGroupInput
 
 	sincePending := since
-	if sincePending.Year() <= 1970 {
+	if !pkg.IsValidTime(since) {
 		sincePending = time.Now()
 	}
 	for _, lgi := range logGroups {
@@ -342,7 +343,7 @@ func (c *collectionStream) addAndStart(s EventStream, since time.Time, lgi LogGr
 	c.wg.Add(1)
 	go func() {
 		defer c.wg.Done()
-		if since.Year() > 1970 {
+		if pkg.IsValidTime(since) {
 			// Query the logs between the start time and now
 			if err := Query(c.ctx, lgi, since, time.Now(), func(events []LogEvent) {
 				c.ch <- &types.StartLiveTailResponseStreamMemberSessionUpdate{

--- a/src/pkg/utils.go
+++ b/src/pkg/utils.go
@@ -133,3 +133,7 @@ func SubscriptionTierToString(tier defangv1.SubscriptionTier) string {
 		return "Unknown"
 	}
 }
+
+func IsValidTime(t time.Time) bool {
+	return t.Year() > 1970
+}

--- a/src/pkg/utils_test.go
+++ b/src/pkg/utils_test.go
@@ -4,6 +4,9 @@ import (
 	"encoding/json"
 	"reflect"
 	"testing"
+	"time"
+
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 func TestGetenvBool(t *testing.T) {
@@ -152,6 +155,27 @@ func TestContains(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := Contains(tt.slice, tt.value); got != tt.expected {
 				t.Errorf("Contains() returned %v, expected %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestIsValidTime(t *testing.T) {
+	tests := []struct {
+		name     string
+		time     time.Time
+		expected bool
+	}{
+		{"Valid time", time.Now(), true},
+		{"Zero time", time.Time{}, false},
+		{"From zero Timestamppb", timestamppb.New(time.Time{}).AsTime(), false},
+		{"From now Timestamppb", timestamppb.Now().AsTime(), true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsValidTime(tt.time); got != tt.expected {
+				t.Errorf("IsValidTime() returned %v, expected %v", got, tt.expected)
 			}
 		})
 	}


### PR DESCRIPTION
## Description

Sometimes AWS CW Tail API returns `SessionStreamingException`. This PR ensures we automatically retry the Tail in that case.

```
Error: SessionStreamingException: Internal Streaming Error Encountered in Live Tail Session: [f364f055-47b8-41ee-a298-88dfae6e802f] for Account: [861988606655]
```

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

