### PR TITLE
fix: don't return ErrDeploymentFailed for clean CD exit

### DIFF
--- a/src/pkg/cli/client/byoc/aws/byoc.go
+++ b/src/pkg/cli/client/byoc/aws/byoc.go
@@ -753,7 +753,10 @@ func (b *ByocAws) Follow(ctx context.Context, req *defangv1.TailRequest) (client
 			if err := ecs.WaitForTask(ctx, taskArn, 2*time.Second); err != nil {
 				if stopWhenCDTaskDone || errors.As(err, &ecs.TaskFailure{}) {
 					time.Sleep(2 * time.Second) // make sure we got all the logs from the task/ecs before cancelling
-					cancel(pkg.ErrDeploymentFailed{Service: "Defang CD", Message: err.Error()})
+					if !errors.Is(err, io.EOF) {
+						err = pkg.ErrDeploymentFailed{Message: err.Error()}
+					}
+					cancel(err)
 				}
 			}
 		}()

--- a/src/pkg/cli/client/byoc/gcp/stream.go
+++ b/src/pkg/cli/client/byoc/gcp/stream.go
@@ -425,7 +425,7 @@ func getActivityParser() func(entry *loggingpb.LogEntry) ([]*defangv1.SubscribeR
 			executionName = executionName[:len(executionName)-6] // Remove the random suffix
 			if executionName == "defang-cd" {
 				if auditLog.GetStatus().GetCode() != 0 {
-					return nil, pkg.ErrDeploymentFailed{Service: "defang CD", Message: auditLog.GetStatus().GetMessage()}
+					return nil, pkg.ErrDeploymentFailed{Message: auditLog.GetStatus().GetMessage()}
 				}
 				cdSuccess = true
 				if len(readyServices) > 0 {

--- a/src/pkg/clouds/aws/ecs/logs.go
+++ b/src/pkg/clouds/aws/ecs/logs.go
@@ -218,6 +218,7 @@ func startLiveTail(ctx context.Context, slti *cloudwatchlogs.StartLiveTailInput)
 	return slto.GetStream(), nil
 }
 
+// GetTaskStatus returns nil if the task is still running, io.EOF if the task is stopped successfully, or an error if the task failed.
 func GetTaskStatus(ctx context.Context, taskArn TaskArn) error {
 	region := region.FromArn(*taskArn)
 	cluster, taskID := SplitClusterTask(taskArn)
@@ -234,6 +235,7 @@ func isTaskTerminalStatus(status string) bool {
 	}
 }
 
+// getTaskStatus returns nil if the task is still running, io.EOF if the task is stopped successfully, or an error if the task failed.
 func getTaskStatus(ctx context.Context, region aws.Region, cluster, taskId string) error {
 	cfg, err := aws.LoadDefaultConfig(ctx, region)
 	if err != nil {
@@ -416,6 +418,7 @@ func GetLogEvents(e types.StartLiveTailResponseStream) ([]LogEvent, error) {
 	}
 }
 
+// WaitForTask polls the ECS task status. It returns io.EOF if the task is stopped successfully, or an error if the task failed.
 func WaitForTask(ctx context.Context, taskArn TaskArn, poll time.Duration) error {
 	if taskArn == nil {
 		panic("taskArn is nil")

--- a/src/pkg/errors.go
+++ b/src/pkg/errors.go
@@ -3,10 +3,14 @@ package pkg
 import "fmt"
 
 type ErrDeploymentFailed struct {
-	Service string
 	Message string
+	Service string // optional
 }
 
 func (e ErrDeploymentFailed) Error() string {
-	return fmt.Sprintf("deployment failed for service %q", e.Service)
+	var service string
+	if e.Service != "" {
+		service = fmt.Sprintf(" for service %q", e.Service)
+	}
+	return fmt.Sprintf("deployment failed%s: %s", service, e.Message)
 }


### PR DESCRIPTION
## Description

This fixes a regression caused by #914 where "defang up" would always fail with `ErrDeploymentFailed` even when CD exited with 0, ie. success.

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

