### PR TITLE
Better error message when GitHub REST API fails

### DIFF
--- a/src/cmd/cli/command/version.go
+++ b/src/cmd/cli/command/version.go
@@ -3,11 +3,12 @@ package command
 import (
 	"context"
 	"encoding/json"
-	"errors"
+	"fmt"
 	"os"
 	"strings"
 
 	"github.com/DefangLabs/defang/src/pkg/http"
+	"github.com/DefangLabs/defang/src/pkg/term"
 	"golang.org/x/mod/semver"
 )
 
@@ -36,6 +37,12 @@ func GetCurrentVersion() string {
 	return version
 }
 
+type githubError struct {
+	Message          string
+	Status           string
+	DocumentationUrl string
+}
+
 func GetLatestVersion(ctx context.Context) (string, error) {
 	// Anonymous API request to GitHub are rate limited to 60 requests per hour per IP.
 	// Check whether the user has set a GitHub token to increase the rate limit. (Copied from the install script.)
@@ -53,9 +60,14 @@ func GetLatestVersion(ctx context.Context) (string, error) {
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != 200 {
+		term.Debug(resp.Header)
 		// The primary rate limit for unauthenticated requests is 60 requests per hour, per IP.
 		// The API returns a 403 status code when the rate limit is exceeded.
-		return "", errors.New(resp.Status)
+		githubError := githubError{Message: resp.Status}
+		if err := json.NewDecoder(resp.Body).Decode(&githubError); err != nil {
+			term.Debugf("Failed to decode GitHub response: %v", err)
+		}
+		return "", fmt.Errorf("error fetching release info from GitHub: %s", githubError.Message)
 	}
 	var release struct {
 		TagName string `json:"tag_name"`


### PR DESCRIPTION
## Description

When GitHub API gets throttled the CLI just prints `Error: 403 Forbidden`, without much context. This PR prints the actual error message (if available) for better diagnosis.


## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

