### PR TITLE
Fix cd cancel and cd refresh

### DIFF
--- a/src/cmd/cli/command/cd.go
+++ b/src/cmd/cli/command/cd.go
@@ -18,8 +18,8 @@ var cdCmd = &cobra.Command{
 
 var cdDestroyCmd = &cobra.Command{
 	Use:         "destroy",
-	Annotations: authNeededAnnotation,
-	Args:        cobra.NoArgs, // TODO: set MaximumNArgs(1),
+	Annotations: authNeededAnnotation, // need subscription
+	Args:        cobra.NoArgs,         // TODO: set MaximumNArgs(1),
 	Short:       "Destroy the service stack",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		loader := configureLoader(cmd)
@@ -44,8 +44,8 @@ var cdDestroyCmd = &cobra.Command{
 
 var cdDownCmd = &cobra.Command{
 	Use:         "down",
-	Annotations: authNeededAnnotation,
-	Args:        cobra.NoArgs, // TODO: set MaximumNArgs(1),
+	Annotations: authNeededAnnotation, // need subscription
+	Args:        cobra.NoArgs,         // TODO: set MaximumNArgs(1),
 	Short:       "Refresh and then destroy the service stack",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		loader := configureLoader(cmd)
@@ -69,9 +69,10 @@ var cdDownCmd = &cobra.Command{
 }
 
 var cdRefreshCmd = &cobra.Command{
-	Use:   "refresh",
-	Args:  cobra.NoArgs, // TODO: set MaximumNArgs(1),
-	Short: "Refresh the service stack",
+	Use:         "refresh",
+	Annotations: authNeededAnnotation, // need subscription
+	Args:        cobra.NoArgs,         // TODO: set MaximumNArgs(1),
+	Short:       "Refresh the service stack",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		loader := configureLoader(cmd)
 		provider, err := getProvider(cmd.Context(), loader)
@@ -83,14 +84,21 @@ var cdRefreshCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
+
+		err = canIUseProvider(cmd.Context(), provider, projectName)
+		if err != nil {
+			return err
+		}
+
 		return cli.BootstrapCommand(cmd.Context(), projectName, client, provider, "refresh")
 	},
 }
 
 var cdCancelCmd = &cobra.Command{
-	Use:   "cancel",
-	Args:  cobra.NoArgs, // TODO: set MaximumNArgs(1),
-	Short: "Cancel the current CD operation",
+	Use:         "cancel",
+	Annotations: authNeededAnnotation, // need subscription
+	Args:        cobra.NoArgs,         // TODO: set MaximumNArgs(1),
+	Short:       "Cancel the current CD operation",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		loader := configureLoader(cmd)
 		provider, err := getProvider(cmd.Context(), loader)
@@ -102,6 +110,12 @@ var cdCancelCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
+
+		err = canIUseProvider(cmd.Context(), provider, projectName)
+		if err != nil {
+			return err
+		}
+
 		return cli.BootstrapCommand(cmd.Context(), projectName, client, provider, "cancel")
 	},
 }

--- a/src/pkg/cli/client/byoc/aws/byoc.go
+++ b/src/pkg/cli/client/byoc/aws/byoc.go
@@ -137,6 +137,8 @@ func (b *ByocAws) setUpCD(ctx context.Context) error {
 		return nil
 	}
 
+	term.Debugf("Using CD image: %q", b.CDImage)
+
 	cdTaskName := byoc.CdTaskPrefix
 	containers := []types.Container{
 		{

--- a/src/pkg/cli/client/byoc/gcp/byoc.go
+++ b/src/pkg/cli/client/byoc/gcp/byoc.go
@@ -188,6 +188,8 @@ func (b *ByocGcp) setUpCD(ctx context.Context) error {
 	}
 
 	// 5. Setup Cloud Run Job
+	term.Debugf("Using CD image: %q", b.CDImage)
+
 	serviceAccount := path.Base(b.cdServiceAccount)
 	if err := b.driver.SetupJob(ctx, "defang-cd", serviceAccount, []types.Container{
 		{

--- a/src/pkg/clouds/do/appPlatform/setup.go
+++ b/src/pkg/clouds/do/appPlatform/setup.go
@@ -98,7 +98,7 @@ func shellQuote(args ...string) string {
 }
 
 func getImageSourceSpec(cdImagePath string) (*godo.ImageSourceSpec, error) {
-	term.Debugf("Using CD image: %s", cdImagePath)
+	term.Debugf("Using CD image: %q", cdImagePath)
 	image, err := ParseImage(cdImagePath)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Description

Failures in CLI:
```
$ defang cd cancel --project-name nextjs -Pdigitalocean
 * Using DigitalOcean provider from command line flag
 * Running CD command "cancel" in project "nextjs"
Error: invalid image:
```
AWS:
```
$ AWS_PROFILE=defang-lab defang cd cancel --project-name nextjs -Paws
 * Using AWS provider from command line flag
 * Running CD command "cancel" in project "nextjs"
Waiting for CloudFormation stack defang-cd to be updated...
Error: waiter state transitioned to Failure
```
Getting empty image URL even though I’m pro. Seems that cancel and refresh didn't check `canIUse`. 

## Linked Issues

Missed these two commands in #929 

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

