### PR TITLE
Fix debug panic

### DIFF
--- a/src/pkg/cli/debug_test.go
+++ b/src/pkg/cli/debug_test.go
@@ -89,22 +89,11 @@ func TestDebugProject(t *testing.T) {
 	}
 
 	loadErr := errors.New("load error")
-	provider := MustHaveProjectNameQueryProvider{}
 	fabricClient := MockDebugFabricClient{}
 
 	t.Run("with load error", func(t *testing.T) {
-		if err := DebugComposeFileLoadError(context.Background(), fabricClient, provider, project, loadErr); err != nil {
+		if err := debugComposeFileLoadError(context.Background(), fabricClient, project, loadErr); err != nil {
 			t.Errorf("expected no error, got %v", err)
-		}
-	})
-
-	t.Run("without load error", func(t *testing.T) {
-		err := DebugDeployment(context.Background(), fabricClient, provider, "", project, []string{"service"})
-		if err == nil {
-			t.Fatal("expected error, got none")
-		}
-		if err.Error() != "no information to use for debugger" {
-			t.Error("expected: no information to use for debugger")
 		}
 	})
 }


### PR DESCRIPTION
## Description

Fixes panic when replying `N` to debug prompt:

```
$ defang compose up
 ! Unable to load project: yaml: line 2: could not find expected ':'
? Choose a cloud provider: defang
 * Using Defang Playground provider from interactive prompt
 ! yaml: line 2: could not find expected ':'
? Would you like to debug the deployment with AI? No
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x10214868c]

goroutine 1 [running]:
main.main.func1()
	/Users/llunesu/dev/defang/src/cmd/cli/main.go:19 +0x144
panic({0x102aae920?, 0x104b27f10?})
	/nix/store/rfcwglhhspqx5v5h0sl4b3py14i6vpxa-go-1.22.7/share/go/src/runtime/panic.go:770 +0x124
github.com/DefangLabs/defang/src/cmd/cli/command.makeComposeUpCmd.func1(0x14000740008, {0x104c3d940?, 0x0?, 0x0?})
	/Users/llunesu/dev/defang/src/cmd/cli/command/compose.go:118 +0x2ec
github.com/spf13/cobra.(*Command).execute(0x14000740008, {0x104c3d940, 0x0, 0x0})
	/Users/llunesu/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:983 +0x840
github.com/spf13/cobra.(*Command).ExecuteC(0x104bb9cc0)
	/Users/llunesu/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:1115 +0x344
github.com/spf13/cobra.(*Command).Execute(...)
	/Users/llunesu/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:1039
github.com/spf13/cobra.(*Command).ExecuteContext(...)
	/Users/llunesu/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:1032
github.com/DefangLabs/defang/src/cmd/cli/command.Execute({0x1033fba70, 0x140000fcfa0})
	/Users/llunesu/dev/defang/src/cmd/cli/command/commands.go:86 +0xac
main.main()
	/Users/llunesu/dev/defang/src/cmd/cli/main.go:36 +0x10c
```

Further avoids prompting the user for the cloud provider when we already know the project failed to load (it would show a load warning first).

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

