### PR TITLE
populate byoc client with task arn used by client to extract information

### DIFF
--- a/src/pkg/cli/client/byoc/aws/byoc.go
+++ b/src/pkg/cli/client/byoc/aws/byoc.go
@@ -613,6 +613,12 @@ func (b *ByocAws) Query(ctx context.Context, req *defangv1.DebugRequest) error {
 		since = time.Now().Add(-time.Hour)
 	}
 
+	// get stack information
+	err := b.driver.FillOutputs(ctx)
+	if err != nil {
+		return AnnotateAwsError(err)
+	}
+
 	// Gather logs from the CD task, kaniko, ECS events, and all services
 	sb := strings.Builder{}
 	for _, lgi := range b.getLogGroupInputs(req.Etag, req.Project, service, logs.LogTypeAll) {


### PR DESCRIPTION
## Description

fixes #968  
Fix panic when using debug command

## Linked Issues

https://github.com/DefangLabs/defang/issues/968

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

