### PR TITLE
fix panic if delegate domain is not returned

### DIFF
--- a/src/pkg/cli/composeDown.go
+++ b/src/pkg/cli/composeDown.go
@@ -53,10 +53,8 @@ func ComposeDown(ctx context.Context, projectName string, c client.FabricClient,
 
 	delegateDomain, err := c.GetDelegateSubdomainZone(ctx)
 	if err != nil {
-		term.Debug("Failed to get delegate domain:", err)
-		delegateDomain = &defangv1.DelegateSubdomainZoneResponse{
-			Zone: "",
-		}
+		term.Debug("GetDelegateSubdomainZone failed:", err)
+		return "", errors.New("failed to get delegate domain")
 	}
 
 	resp, err := provider.Delete(ctx, &defangv1.DeleteRequest{Project: projectName, Names: names, DelegateDomain: delegateDomain.Zone})

--- a/src/pkg/cli/composeDown.go
+++ b/src/pkg/cli/composeDown.go
@@ -54,6 +54,9 @@ func ComposeDown(ctx context.Context, projectName string, c client.FabricClient,
 	delegateDomain, err := c.GetDelegateSubdomainZone(ctx)
 	if err != nil {
 		term.Debug("Failed to get delegate domain:", err)
+		delegateDomain = &defangv1.DelegateSubdomainZoneResponse{
+			Zone: "",
+		}
 	}
 
 	resp, err := provider.Delete(ctx, &defangv1.DeleteRequest{Project: projectName, Names: names, DelegateDomain: delegateDomain.Zone})

--- a/src/pkg/cli/composeUp.go
+++ b/src/pkg/cli/composeUp.go
@@ -68,6 +68,9 @@ func ComposeUp(ctx context.Context, project *compose.Project, c client.FabricCli
 	delegateDomain, err := c.GetDelegateSubdomainZone(ctx)
 	if err != nil {
 		term.Debug("Failed to get delegate domain:", err)
+		delegateDomain = &defangv1.DelegateSubdomainZoneResponse{
+			Zone: "",
+		}
 	}
 
 	deployRequest := &defangv1.DeployRequest{

--- a/src/pkg/cli/composeUp.go
+++ b/src/pkg/cli/composeUp.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -67,10 +68,8 @@ func ComposeUp(ctx context.Context, project *compose.Project, c client.FabricCli
 
 	delegateDomain, err := c.GetDelegateSubdomainZone(ctx)
 	if err != nil {
-		term.Debug("Failed to get delegate domain:", err)
-		delegateDomain = &defangv1.DelegateSubdomainZoneResponse{
-			Zone: "",
-		}
+		term.Debug("GetDelegateSubdomainZone failed:", err)
+		return nil, project, errors.New("failed to get delegate domain")
 	}
 
 	deployRequest := &defangv1.DeployRequest{

--- a/src/pkg/cli/delete.go
+++ b/src/pkg/cli/delete.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"errors"
 
 	"github.com/DefangLabs/defang/src/pkg/cli/client"
 	"github.com/DefangLabs/defang/src/pkg/term"
@@ -18,10 +19,8 @@ func Delete(ctx context.Context, projectName string, c client.FabricClient, prov
 
 	delegateDomain, err := c.GetDelegateSubdomainZone(ctx)
 	if err != nil {
-		term.Debug("Failed to get delegate domain:", err)
-		delegateDomain = &defangv1.DelegateSubdomainZoneResponse{
-			Zone: "",
-		}
+		term.Debug("GetDelegateSubdomainZone failed:", err)
+		return "", errors.New("failed to get delegate domain")
 	}
 
 	resp, err := provider.Delete(ctx, &defangv1.DeleteRequest{Project: projectName, Names: names, DelegateDomain: delegateDomain.Zone})

--- a/src/pkg/cli/delete.go
+++ b/src/pkg/cli/delete.go
@@ -19,6 +19,9 @@ func Delete(ctx context.Context, projectName string, c client.FabricClient, prov
 	delegateDomain, err := c.GetDelegateSubdomainZone(ctx)
 	if err != nil {
 		term.Debug("Failed to get delegate domain:", err)
+		delegateDomain = &defangv1.DelegateSubdomainZoneResponse{
+			Zone: "",
+		}
 	}
 
 	resp, err := provider.Delete(ctx, &defangv1.DeleteRequest{Project: projectName, Names: names, DelegateDomain: delegateDomain.Zone})


### PR DESCRIPTION
## Description

#fixes 970 
panic occurs in CLI when GetDelegateSubdomainZone() returns error, but we still try to reference as if it there was no error. Fix to exit command if error is found.

## Linked Issues

#970 

## Checklist

- [X] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

