### PR TITLE
Log fabric grpc requests in debug mode

### DIFF
--- a/src/pkg/cli/client/grpc.go
+++ b/src/pkg/cli/client/grpc.go
@@ -35,7 +35,7 @@ func NewGrpcClient(host, accessToken string, tenantName types.TenantName) GrpcCl
 		baseUrl,
 		connect.WithGRPC(),
 		connect.WithInterceptors(
-			grpcLogger{},
+			grpcLogger{"fabricClient"},
 			auth.NewAuthInterceptor(accessToken),
 			Retrier{},
 		),

--- a/src/pkg/cli/client/grpc.go
+++ b/src/pkg/cli/client/grpc.go
@@ -30,7 +30,16 @@ func NewGrpcClient(host, accessToken string, tenantName types.TenantName) GrpcCl
 	}
 	baseUrl += host
 	// Debug(" - Connecting to", baseUrl)
-	fabricClient := defangv1connect.NewFabricControllerClient(http.DefaultClient, baseUrl, connect.WithGRPC(), connect.WithInterceptors(auth.NewAuthInterceptor(accessToken), Retrier{}))
+	fabricClient := defangv1connect.NewFabricControllerClient(
+		http.DefaultClient,
+		baseUrl,
+		connect.WithGRPC(),
+		connect.WithInterceptors(
+			grpcLogger{},
+			auth.NewAuthInterceptor(accessToken),
+			Retrier{},
+		),
+	)
 
 	return GrpcClient{client: fabricClient, anonID: GetAnonID(), TenantName: tenantName}
 }

--- a/src/pkg/cli/client/grpc_logger.go
+++ b/src/pkg/cli/client/grpc_logger.go
@@ -3,19 +3,19 @@ package client
 import (
 	"context"
 	"encoding/json"
-	"reflect"
 
 	"github.com/DefangLabs/defang/src/pkg/term"
 	"github.com/bufbuild/connect-go"
 )
 
 type grpcLogger struct {
+	prefix string
 }
 
-func (a grpcLogger) WrapUnary(next connect.UnaryFunc) connect.UnaryFunc {
+func (g grpcLogger) WrapUnary(next connect.UnaryFunc) connect.UnaryFunc {
 	return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
 		// Get the request type name
-		reqType := reflect.TypeOf(req.Any()).String()
+		reqType := req.Spec().Procedure
 
 		// Convert request payload to JSON for logging
 		payload, err := json.Marshal(req.Any())
@@ -23,13 +23,13 @@ func (a grpcLogger) WrapUnary(next connect.UnaryFunc) connect.UnaryFunc {
 			payload = []byte("Error marshaling request payload")
 		}
 
-		term.Debug("fabric", reqType, string(payload))
+		term.Debug(g.prefix, reqType, string(payload))
 
 		return next(ctx, req)
 	}
 }
 
-func (a grpcLogger) WrapStreamingClient(next connect.StreamingClientFunc) connect.StreamingClientFunc {
+func (grpcLogger) WrapStreamingClient(next connect.StreamingClientFunc) connect.StreamingClientFunc {
 	return next
 }
 

--- a/src/pkg/cli/client/grpc_logger.go
+++ b/src/pkg/cli/client/grpc_logger.go
@@ -1,0 +1,38 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"reflect"
+
+	"github.com/DefangLabs/defang/src/pkg/term"
+	"github.com/bufbuild/connect-go"
+)
+
+type grpcLogger struct {
+}
+
+func (a grpcLogger) WrapUnary(next connect.UnaryFunc) connect.UnaryFunc {
+	return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+		// Get the request type name
+		reqType := reflect.TypeOf(req.Any()).String()
+
+		// Convert request payload to JSON for logging
+		payload, err := json.Marshal(req.Any())
+		if err != nil {
+			payload = []byte("Error marshaling request payload")
+		}
+
+		term.Debug("fabric", reqType, string(payload))
+
+		return next(ctx, req)
+	}
+}
+
+func (a grpcLogger) WrapStreamingClient(next connect.StreamingClientFunc) connect.StreamingClientFunc {
+	return next
+}
+
+func (grpcLogger) WrapStreamingHandler(next connect.StreamingHandlerFunc) connect.StreamingHandlerFunc {
+	return next
+}


### PR DESCRIPTION
## Description

If you get a network error when invoking a CLI command, it can be difficult to understand which request caused it. This PR introduces a grpc client "interceptor" (like a middleware), which logs outgoing requests. We print the type of the request as well as a json marshalled string of the payload to stdout when `--debug` mode is enabled.

Here's an example session:

```
defang whoami --debug
 - Reading access token from file /Users/llunesu/.local/state/defang/fabric-prod1.defang.dev
 - Using tenant default for cluster fabric-prod1.defang.dev:443
 - fabricClient /io.defang.v1.FabricController/WhoAmI null
 - fabricClient /io.defang.v1.FabricController/GetVersion null
 - Fabric: v0.6.0-296-g4237cb43 CLI: development CLI-Min: v1.0.0
 - tracking event "WHOAMI INVOKED": [{args []} {err <nil>} {non-interactive false} {provider auto} {CalledAs  whoami} {version development} {debug true}]
 ! Using Defang playground, but DIGITALOCEAN_TOKEN environment variable was detected; did you forget --provider=digitalocean or DEFANG_PROVIDER=digitalocean?
 * Using Defang Playground provider from default project
 - Creating defang provider
 - fabricClient /io.defang.v1.FabricController/WhoAmI null
 - fabricClient /io.defang.v1.FabricController/Track {"anon_id":"4dd035a1-64dc-4047-828b-6a958bf363b4","event":"WHOAMI INVOKED","properties":{"CalledAs":" whoami","args":"[]","debug":"true","err":"\u003cnil\u003e","non-interactive":"false","provider":"auto","version":"development"},"os":"darwin","arch":"arm64"}
 * WhoAmI - 
        Provider: Defang Playground
        Tenant: lionello
        Subscription Tier: Pro
        Region: us-west-2
```

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

