### PR TITLE
Update flake.lock

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,2 +1,4 @@
-{ pkgs ? import <nixpkgs> {} }:
-pkgs.callPackage ./pkgs/defang/cli.nix {}
+{
+  pkgs ? import <nixpkgs> { },
+}:
+pkgs.callPackage ./pkgs/defang/cli.nix { }

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1726560853,
-        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -19,11 +19,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1728538411,
-        "narHash": "sha256-f0SBJz1eZ2yOuKUr5CA9BHULGXVSn6miBuUWdTyhUhU=",
+        "lastModified": 1739019272,
+        "narHash": "sha256-7Fu7oazPoYCbDzb9k8D/DdbKrC3aU1zlnc39Y8jy/s8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b69de56fac8c2b6f8fd27f2eca01dcda8e0a4221",
+        "rev": "fa35a3c8e17a3de613240fea68f876e5b4896aec",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,33 +1,42 @@
 {
-  outputs = { self, nixpkgs, flake-utils }:
-    flake-utils.lib.eachDefaultSystem
-      (system:
-        let
-          pkgs = import nixpkgs {
-            inherit system;
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+        };
+      in
+      {
+        devShell =
+          with pkgs;
+          mkShell {
+            buildInputs =
+              [
+                buf
+                crane
+                git
+                gnumake
+                gnused # force Linux `sed` everywhere
+                go_1_22
+                golangci-lint
+                goreleaser
+                nixfmt-rfc-style
+                nodejs_20 # for Pulumi, must match values in package.json
+                pulumi-bin
+                google-cloud-sdk
+              ]
+              ++ lib.optionals stdenv.isDarwin [
+                darwin.apple_sdk.frameworks.CoreServices
+              ];
           };
-        in
-        {
-          devShell = with pkgs; mkShell {
-            buildInputs = [
-              buf
-              crane
-              git
-              gnumake
-              gnused # force Linux `sed` everywhere
-              go_1_22
-              golangci-lint
-              goreleaser
-              nixfmt
-              nodejs_20 # for Pulumi, must match values in package.json
-              pulumi-bin
-              google-cloud-sdk
-            ] ++ lib.optionals stdenv.isDarwin [
-              darwin.apple_sdk.frameworks.CoreServices
-            ];
-          };
-          packages.defang-cli = pkgs.callPackage ./pkgs/defang/cli.nix { };
-          packages.defang-bin = pkgs.callPackage ./pkgs/defang { };
-        }
-      );
+        packages.defang-cli = pkgs.callPackage ./pkgs/defang/cli.nix { };
+        packages.defang-bin = pkgs.callPackage ./pkgs/defang { };
+      }
+    );
 }

--- a/pkgs/defang/cli.nix
+++ b/pkgs/defang/cli.nix
@@ -1,6 +1,7 @@
-{ buildGoModule
-, installShellFiles
-, lib
+{
+  buildGoModule,
+  installShellFiles,
+  lib,
 }:
 buildGoModule {
   pname = "defang-cli";
@@ -15,7 +16,10 @@ buildGoModule {
   ];
 
   CGO_ENABLED = 0;
-  ldflags = [ "-s" "-w" ];
+  ldflags = [
+    "-s"
+    "-w"
+  ];
   doCheck = false; # some unit tests need internet access
 
   postInstall = ''

--- a/src/go.mod
+++ b/src/go.mod
@@ -1,6 +1,6 @@
 module github.com/DefangLabs/defang/src
 
-go 1.22.7
+go 1.22.12
 
 require (
 	cloud.google.com/go/artifactregistry v1.16.0


### PR DESCRIPTION
## Description

Keep in sync with MVP repo.

- `nix update flake`
- Bump Go version in `go.mod` to match the Go from Nix
- `trace: evaluation warning: nixfmt was renamed to nixfmt-classic. The nixfmt attribute may be used for the new RFC 166-style formatter in the future, which is currently available as nixfmt-rfc-style`
  - Use new Nix formatter and reformat Nix files (except the generated one from Goreleaser)

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

