### PR TITLE
Check response status in PostForValues

### DIFF
--- a/src/cmd/cli/main.go
+++ b/src/cmd/cli/main.go
@@ -3,11 +3,14 @@ package main
 import (
 	"bytes"
 	"context"
+	"log/slog"
 	"os"
 	"os/signal"
 	"runtime/debug"
 
 	"github.com/DefangLabs/defang/src/cmd/cli/command"
+	"github.com/DefangLabs/defang/src/pkg/logs"
+	"github.com/DefangLabs/defang/src/pkg/term"
 	"github.com/DefangLabs/defang/src/pkg/track"
 )
 
@@ -32,6 +35,7 @@ func main() {
 		cancel()
 	}()
 
+	slog.SetDefault(logs.NewTermLogger(term.DefaultTerm))
 	command.SetupCommands(ctx, version)
 	err := command.Execute(ctx)
 	track.FlushAllTracking() // TODO: track errors/panics

--- a/src/pkg/http/client.go
+++ b/src/pkg/http/client.go
@@ -1,20 +1,22 @@
 package http
 
 import (
-	"github.com/DefangLabs/defang/src/pkg/term"
+	"fmt"
+	"log/slog"
+
 	"github.com/hashicorp/go-retryablehttp"
 )
 
 var DefaultClient = newClient().StandardClient()
 
-type termLogger struct{}
+type slogLogger struct{}
 
-func (termLogger) Printf(format string, args ...interface{}) {
-	term.Debugf(format, args...)
+func (slogLogger) Printf(format string, args ...interface{}) {
+	slog.Debug(fmt.Sprintf(format, args...))
 }
 
 func newClient() *retryablehttp.Client {
-	c := retryablehttp.NewClient() // default client retries 4 times: 1+2+4+8 = 15s max
-	c.Logger = termLogger{}
+	c := retryablehttp.NewClient() // default client retries 4 times: 0+1+2+4+8 = 15s max
+	c.Logger = slogLogger{}
 	return c
 }

--- a/src/pkg/http/post.go
+++ b/src/pkg/http/post.go
@@ -17,10 +17,14 @@ func PostForValues(_url, contentType string, body io.Reader) (url.Values, error)
 	if err != nil {
 		return nil, err
 	}
-	// FIXME: on error, the body might not be URL-encoded
 	values, err := url.ParseQuery(string(bytes))
+	// By default, HTTP status codes in the 2xx range are considered successful
+	// and the default client will have followed any redirects.
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return values, fmt.Errorf("unexpected status code: %s", resp.Status)
+	}
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse response body %s: %w", resp.Status, err)
+		return nil, fmt.Errorf("failed to parse response body: %w", err)
 	}
 	return values, nil
 }

--- a/src/pkg/http/post_test.go
+++ b/src/pkg/http/post_test.go
@@ -1,0 +1,54 @@
+package http
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestPostForValues(t *testing.T) {
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Return an error to test the error handling on /error
+		if r.URL.Path == "/error" {
+			http.Error(w, "error", http.StatusNotFound) // not retried
+			return
+		}
+		// Return a redirect to test the error handling on unexpected status codes
+		if r.URL.Path == "/redirect" {
+			http.Redirect(w, r, "/", http.StatusFound)
+			return
+		}
+		w.Write([]byte("foo=bar&baz=qux"))
+	}))
+	t.Cleanup(s.Close)
+
+	t.Run("success", func(t *testing.T) {
+		values, err := PostForValues(s.URL, "application/text", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got, want := values.Get("foo"), "bar"; got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("redirect", func(t *testing.T) {
+		values, err := PostForValues(s.URL+"/redirect", "application/text", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got, want := values.Get("foo"), "bar"; got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("error", func(t *testing.T) {
+		_, err := PostForValues(s.URL+"/error", "application/text", nil)
+		if err == nil {
+			t.Fatal("expected an error")
+		}
+		if got, want := err.Error(), "unexpected status code: 404 Not Found"; got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+}

--- a/src/pkg/logs/slog.go
+++ b/src/pkg/logs/slog.go
@@ -1,0 +1,74 @@
+package logs
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/DefangLabs/defang/src/pkg/term"
+)
+
+type termHandler struct {
+	t *term.Term
+}
+
+func newTermHandler(t *term.Term) *termHandler {
+	return &termHandler{t: t}
+}
+
+func NewTermLogger(t *term.Term) *slog.Logger {
+	return slog.New(newTermHandler(t))
+}
+
+func (h *termHandler) Handle(ctx context.Context, r slog.Record) error {
+	// Format attrs if any
+	var attrs string
+	if r.NumAttrs() > 0 {
+		r.Attrs(func(a slog.Attr) bool {
+			if attrs == "" {
+				attrs = " {"
+			} else {
+				attrs += ", "
+			}
+			attrs += a.String()
+			return true
+		})
+		attrs += "}"
+	}
+
+	msg := r.Message + attrs
+
+	switch r.Level {
+	case slog.LevelDebug:
+		_, err := h.t.Debug(msg)
+		return err
+	case slog.LevelInfo:
+		_, err := h.t.Info(msg)
+		return err
+	case slog.LevelWarn:
+		_, err := h.t.Warn(msg)
+		return err
+	case slog.LevelError:
+		_, err := h.t.Error(msg)
+		return err
+	default:
+		_, err := h.t.Println(msg)
+		return err
+	}
+}
+
+func (h *termHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	if level == slog.LevelDebug {
+		return h.t.DoDebug()
+	}
+	return true
+}
+
+func (h *termHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	// Since we format attributes in Handle(), we can just return self
+	return h
+}
+
+func (h *termHandler) WithGroup(name string) slog.Handler {
+	// Groups are not supported in this implementation
+	return h
+}


### PR DESCRIPTION
## Description

The `PostForValues` helper did not check the response status. The default HTTP client was also logging to `term`, even though its being used in the backend which shouldn't use the `term` package.

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

