### PR TITLE
Truncate debug query

### DIFF
--- a/src/pkg/clouds/aws/ecs/logs.go
+++ b/src/pkg/clouds/aws/ecs/logs.go
@@ -152,7 +152,7 @@ func TailLogGroup(ctx context.Context, input LogGroupInput) (EventStream, error)
 	})
 }
 
-func Query(ctx context.Context, input LogGroupInput, start, end time.Time, cb func([]LogEvent)) error {
+func Query(ctx context.Context, input LogGroupInput, start, end time.Time, cb func([]LogEvent) error) error {
 	region := region.FromArn(input.LogGroupARN)
 	cw, err := newCloudWatchLogsClient(ctx, region)
 	if err != nil {
@@ -161,7 +161,7 @@ func Query(ctx context.Context, input LogGroupInput, start, end time.Time, cb fu
 	return filterLogEvents(ctx, cw, input, start, end, cb)
 }
 
-func filterLogEvents(ctx context.Context, cw *cloudwatchlogs.Client, lgi LogGroupInput, start, end time.Time, cb func([]LogEvent)) error {
+func filterLogEvents(ctx context.Context, cw *cloudwatchlogs.Client, lgi LogGroupInput, start, end time.Time, cb func([]LogEvent) error) error {
 	logGroupIdentifier := getLogGroupIdentifier(lgi.LogGroupARN)
 	params := &cloudwatchlogs.FilterLogEventsInput{
 		StartTime:          ptr.Int64(start.UnixMilli()),
@@ -187,7 +187,9 @@ func filterLogEvents(ctx context.Context, cw *cloudwatchlogs.Client, lgi LogGrou
 				LogStreamName:      event.LogStreamName,
 			}
 		}
-		cb(events)
+		if err := cb(events); err != nil {
+			return err
+		}
 		if fleo.NextToken == nil {
 			return nil
 		}
@@ -347,10 +349,11 @@ func (c *collectionStream) addAndStart(s EventStream, since time.Time, lgi LogGr
 		defer c.wg.Done()
 		if pkg.IsValidTime(since) {
 			// Query the logs between the start time and now
-			if err := Query(c.ctx, lgi, since, time.Now(), func(events []LogEvent) {
+			if err := Query(c.ctx, lgi, since, time.Now(), func(events []LogEvent) error {
 				c.ch <- &types.StartLiveTailResponseStreamMemberSessionUpdate{
 					Value: types.LiveTailSessionUpdate{SessionResults: events},
 				}
+				return nil
 			}); err != nil {
 				c.errCh <- err // the caller will likely cancel the context
 			}


### PR DESCRIPTION
## Description

Customer was trying to use `defang debug` but got gRPC error that the payload was too large. We truncate the logs on the backend to fit in the LLM context, but the CLI needs to make sure it's within the gRPC limits.

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

