### PR TITLE
Create tests for configSet and configDelete

### DIFF
--- a/src/pkg/cli/configDelete_test.go
+++ b/src/pkg/cli/configDelete_test.go
@@ -1,0 +1,37 @@
+package cli
+
+import (
+	"context"
+	"testing"
+
+	"github.com/DefangLabs/defang/src/pkg/cli/client"
+	defangv1 "github.com/DefangLabs/defang/src/protos/io/defang/v1"
+)
+
+func TestConfigDelete(t *testing.T) {
+	ctx := context.Background()
+	provider := MockConfigDeleteProvider{}
+
+	t.Run("expect no error", func(t *testing.T) {
+		if err := ConfigDelete(ctx, "test", provider, "test_name"); err != nil {
+			t.Fatalf("ConfigDelete() error = %v", err)
+		}
+	})
+
+	t.Run("expect error on DryRun", func(t *testing.T) {
+		DoDryRun = true
+		defer func() { DoDryRun = false }()
+
+		if err := ConfigDelete(ctx, "test", provider, "test_name"); err != ErrDryRun {
+			t.Fatalf("Expected ErrDryRun, got %v", err)
+		}
+	})
+}
+
+type MockConfigDeleteProvider struct {
+	client.Provider
+}
+
+func (MockConfigDeleteProvider) DeleteConfig(ctx context.Context, req *defangv1.Secrets) error {
+	return nil
+}

--- a/src/pkg/cli/configDelete_test.go
+++ b/src/pkg/cli/configDelete_test.go
@@ -20,7 +20,7 @@ func TestConfigDelete(t *testing.T) {
 
 	t.Run("expect error on DryRun", func(t *testing.T) {
 		DoDryRun = true
-		defer func() { DoDryRun = false }()
+		t.Cleanup(func() { DoDryRun = false })
 
 		if err := ConfigDelete(ctx, "test", provider, "test_name"); err != ErrDryRun {
 			t.Fatalf("Expected ErrDryRun, got %v", err)

--- a/src/pkg/cli/configSet_test.go
+++ b/src/pkg/cli/configSet_test.go
@@ -12,10 +12,22 @@ import (
 func TestConfigSet(t *testing.T) {
 	ctx := context.Background()
 	provider := MustHaveProjectNamePutConfigProvider{}
-	err := ConfigSet(ctx, "test", provider, "test_name", "test_value")
-	if err != nil {
-		t.Fatalf("ConfigSet() error = %v", err)
-	}
+
+	t.Run("expect no error", func(t *testing.T) {
+		err := ConfigSet(ctx, "test", provider, "test_name", "test_value")
+		if err != nil {
+			t.Fatalf("ConfigSet() error = %v", err)
+		}
+	})
+
+	t.Run("expect error on DryRun", func(t *testing.T) {
+		DoDryRun = true
+		defer func() { DoDryRun = false }()
+		err := ConfigSet(ctx, "test", provider, "test_name", "test_value")
+		if err != ErrDryRun {
+			t.Fatalf("Expected ErrDryRun, got %v", err)
+		}
+	})
 }
 
 type MustHaveProjectNamePutConfigProvider struct {

--- a/src/pkg/cli/configSet_test.go
+++ b/src/pkg/cli/configSet_test.go
@@ -22,7 +22,7 @@ func TestConfigSet(t *testing.T) {
 
 	t.Run("expect error on DryRun", func(t *testing.T) {
 		DoDryRun = true
-		defer func() { DoDryRun = false }()
+		t.Cleanup(func() { DoDryRun = false })
 		err := ConfigSet(ctx, "test", provider, "test_name", "test_value")
 		if err != ErrDryRun {
 			t.Fatalf("Expected ErrDryRun, got %v", err)


### PR DESCRIPTION
## Description
<!-- Concise description of what this PR is tackling. -->
- Create tests for
  - [configDelete](https://github.com/DefangLabs/defang/blob/main/src/pkg/cli/configDelete.go)
- Add test cases for
  - [configSet](https://github.com/DefangLabs/defang/blob/main/src/pkg/cli/configSet.go)

## Linked Issues
<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->
https://github.com/DefangLabs/defang/issues/988

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

