### PR TITLE
Do not add execution name query when there is none

### DIFF
--- a/src/pkg/cli/client/byoc/gcp/byoc.go
+++ b/src/pkg/cli/client/byoc/gcp/byoc.go
@@ -562,8 +562,8 @@ func (b *ByocGcp) Follow(ctx context.Context, req *defangv1.TailRequest) (client
 			etag = ""
 		}
 		if logs.LogType(req.LogType).Has(logs.LogTypeBuild) {
-			logStream.AddJobExecutionLog(execName)                      // CD log
-			logStream.AddJobLog(req.Project, etag, req.Services)        // Kaniko logs
+			logStream.AddJobExecutionLog(execName)                      // CD log when there is an execution name
+			logStream.AddJobLog(req.Project, etag, req.Services)        // Kaniko or CD logs when there is no execution name
 			logStream.AddCloudBuildLog(req.Project, etag, req.Services) // CloudBuild logs
 		}
 		if logs.LogType(req.LogType).Has(logs.LogTypeRun) {
@@ -686,7 +686,7 @@ func (b *ByocGcp) createDeploymentLogQuery(req *defangv1.DebugRequest) string {
 	}
 
 	// Logs
-	query.AddJobLogQuery(req.Project, req.Etag, req.Services)        // Kaniko logs
+	query.AddJobLogQuery(req.Project, req.Etag, req.Services)        // Kaniko OR CD logs
 	query.AddServiceLogQuery(req.Project, req.Etag, req.Services)    // Cloudrun service logs
 	query.AddCloudBuildLogQuery(req.Project, req.Etag, req.Services) // CloudBuild logs
 	query.AddSince(since)

--- a/src/pkg/cli/client/byoc/gcp/query.go
+++ b/src/pkg/cli/client/byoc/gcp/query.go
@@ -56,6 +56,9 @@ protoPayload.serviceName="compute.googleapis.com"
 }
 
 func (q *Query) AddJobExecutionQuery(executionName string) {
+	if executionName == "" {
+		return
+	}
 	query := `resource.type = "cloud_run_job"`
 
 	if executionName != "" {


### PR DESCRIPTION
## Description
Do not add execution name query when there is none, otherwise when we do defang tail, gcp log query would have a OR clause for cloudrun jobs without any other constraint, which could show cloudrun logs from other projects.

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [X] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

