### PR TITLE
remove need to get execution name

### DIFF
--- a/src/pkg/cli/client/byoc/gcp/byoc.go
+++ b/src/pkg/cli/client/byoc/gcp/byoc.go
@@ -764,18 +764,6 @@ func (b *ByocGcp) query(ctx context.Context, query string) ([]*loggingpb.LogEntr
 }
 
 func (b *ByocGcp) Query(ctx context.Context, req *defangv1.DebugRequest) error {
-	// if there is no execution info then get from execution list
-	if req.Etag != "" && b.cdExecution == "" {
-		b.cdEtag = req.Etag
-
-		execution, err := b.driver.FindExecutionWithEtag(req.Etag)
-		if err != nil {
-			return fmt.Errorf("could not find job with etag %s: %v", req.Etag, annotateGcpError(err))
-		}
-		b.cdExecution = execution.Name
-		req.Since = execution.CreateTime
-	}
-
 	logEntries, err := b.query(ctx, b.createDeploymentLogQuery(req))
 	if err != nil {
 		return annotateGcpError(err)

--- a/src/pkg/clouds/gcp/cloudrun.go
+++ b/src/pkg/clouds/gcp/cloudrun.go
@@ -2,7 +2,6 @@ package gcp
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"math"
 	"os"
@@ -14,7 +13,6 @@ import (
 	"cloud.google.com/go/run/apiv2/runpb"
 	"github.com/DefangLabs/defang/src/pkg"
 	"github.com/DefangLabs/defang/src/pkg/types"
-	"google.golang.org/api/iterator"
 	"google.golang.org/protobuf/types/known/durationpb"
 )
 
@@ -95,49 +93,6 @@ func (gcp Gcp) SetupJob(ctx context.Context, jobId, serviceAccount string, conta
 		}
 		pkg.SleepWithContext(ctx, 1*time.Second)
 	}
-}
-
-func (gcp Gcp) FindExecutionWithEtag(etag string) (*runpb.Execution, error) {
-	ctx := context.Background()
-
-	// Create a Cloud Run Job Executions client
-	client, err := run.NewExecutionsClient(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create Cloud Run client: %v", err)
-	}
-	defer client.Close()
-
-	// List jobs in the region
-	req := &runpb.ListExecutionsRequest{
-		Parent: fmt.Sprintf("projects/%s/locations/%s/jobs/%s", gcp.ProjectId, gcp.Region, JobNameCD),
-	}
-
-	//FIXME: This may need refactoring or architecture changes as we have to scour all
-	//  executions to find the matching etag. For any job there may be a large number of
-	//  executions to look through which may not scale well.
-
-	// Iterate through executions and filter by environment variable
-	it := client.ListExecutions(ctx, req)
-	var execution *runpb.Execution
-	for {
-		execution, err = it.Next()
-		if err == iterator.Done {
-			break
-		}
-		if err != nil {
-			return nil, fmt.Errorf("error listing execution: %v", err)
-		}
-
-		// Check if the execution has the target environment variable
-		for _, container := range execution.Template.Containers {
-			for _, entry := range container.Env {
-				if entry.GetName() == "DEFANG_ETAG" && entry.GetValue() == etag {
-					return execution, nil
-				}
-			}
-		}
-	}
-	return nil, errors.New("no job found with matching etag")
 }
 
 func (gcp Gcp) Run(ctx context.Context, jobId string, env map[string]string, cmd ...string) (string, error) {


### PR DESCRIPTION
## Description

Removing need for GCP execution name when getting debug logs

## Linked Issues

[<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->
](https://github.com/DefangLabs/defang/issues/941)
## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

