### PR TITLE
Fix: skip quote in the case that "filter" is empty

### DIFF
--- a/src/pkg/cli/client/byoc/aws/byoc.go
+++ b/src/pkg/cli/client/byoc/aws/byoc.go
@@ -723,7 +723,10 @@ func (b *ByocAws) makeLogGroupARN(name string) string {
 func (b *ByocAws) getLogGroupInputs(etag types.ETag, projectName, service, filter string, logType logs.LogType) []ecs.LogGroupInput {
 	// Escape the filter pattern to avoid problems with the CloudWatch Logs pattern syntax
 	// See https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/FilterAndPatternSyntax.html
-	pattern := strconv.Quote(filter) // TODO: add etag to filter
+	var pattern string // TODO: add etag to filter
+	if filter != "" {
+		pattern = strconv.Quote(filter)
+	}
 
 	var groups []ecs.LogGroupInput
 	// Tail CD and kaniko


### PR DESCRIPTION
## Description
- The current main branch built command can't run `defang tail`.
```bash
 ./defang tail --since=2025-02-14T00:20:43.964Z --type=RUN --project-name=ecs-yuta-cluster

 * Showing logs since 2025-02-14T00:20:43.964Z ; press Ctrl+C to stop:
 * Using AWS provider from stored preference
Error: https response error StatusCode: 400, RequestID: 9e7ad05f-ae4d-4da2-8907-0d7c5566bc7d, InvalidParameterException: Invalid filter pattern: Invalid character(s) in term '""'
```
- If adding qoutes to filter with a empty string, `"\"\""` will be returned, which is invalid as cloudwatch filter pattern
<img width="476" alt="Image" src="https://github.com/user-attachments/assets/02761f95-5e5e-4b32-b755-cc4ce227bea9" />


## Linked Issues
#1008 

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

