### PR TITLE
Ignore Dockerfile/Compose files by default

### DIFF
--- a/src/pkg/cli/compose/context.go
+++ b/src/pkg/cli/compose/context.go
@@ -42,19 +42,23 @@ const (
 	sourceDateEpoch = 315532800 // 1980-01-01, same as nix-shell
 	// The default .dockerignore for projects that don't have one. Keep in sync with upload.ts in pulumi-defang repo.
 	defaultDockerIgnore = `# Default .dockerignore file for Defang
-**/.DS_Store
+**/__pycache__
 **/.direnv
+**/.DS_Store
 **/.envrc
 **/.git
 **/.github
 **/.idea
 **/.next
 **/.vscode
-**/__pycache__
+**/compose.*.yaml
+**/compose.*.yml
 **/compose.yaml
 **/compose.yml
-**/docker-compose.yml
+**/docker-compose.*.yaml
+**/docker-compose.*.yml
 **/docker-compose.yaml
+**/docker-compose.yml
 **/node_modules
 **/Thumbs.db
 Dockerfile

--- a/src/pkg/cli/compose/context.go
+++ b/src/pkg/cli/compose/context.go
@@ -39,7 +39,8 @@ const (
 	ContextSizeSoftLimit        = 10 * MiB
 	DefaultContextSizeHardLimit = 100 * MiB
 
-	sourceDateEpoch     = 315532800 // 1980-01-01, same as nix-shell
+	sourceDateEpoch = 315532800 // 1980-01-01, same as nix-shell
+	// The default .dockerignore for projects that don't have one. Keep in sync with upload.ts in pulumi-defang repo.
 	defaultDockerIgnore = `# Default .dockerignore file for Defang
 **/.DS_Store
 **/.direnv
@@ -52,13 +53,15 @@ const (
 **/__pycache__
 **/compose.yaml
 **/compose.yml
-**/defang.exe
 **/docker-compose.yml
 **/docker-compose.yaml
 **/node_modules
 **/Thumbs.db
+Dockerfile
+*.Dockerfile
 # Ignore our own binary, but only in the root to avoid ignoring subfolders
 defang
+defang.exe
 # Ignore our project-level state
 .defang`
 )

--- a/src/pkg/cli/compose/context_test.go
+++ b/src/pkg/cli/compose/context_test.go
@@ -109,6 +109,25 @@ func TestWalkContextFolder(t *testing.T) {
 			t.Fatal("WalkContextFolder() should have failed")
 		}
 	})
+
+	t.Run("Default .dockerignore", func(t *testing.T) {
+		var files []string
+		err := WalkContextFolder("../../../testdata/alttestproj", "", func(path string, de os.DirEntry, slashPath string) error {
+			if strings.Contains(slashPath, "alttestproj") {
+				t.Errorf("Path is not relative: %v", slashPath)
+			}
+			files = append(files, slashPath)
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("WalkContextFolder() failed: %v", err)
+		}
+
+		expected := []string{"Dockerfile", "altcomp.yaml", "compose.yaml.fixup", "compose.yaml.golden", "compose.yaml.warnings"}
+		if !reflect.DeepEqual(files, expected) {
+			t.Errorf("Expected files: %v, got %v", expected, files)
+		}
+	})
 }
 
 func TestCreateTarballReader(t *testing.T) {

--- a/src/testdata/alttestproj/ignored.Dockerfile
+++ b/src/testdata/alttestproj/ignored.Dockerfile
@@ -1,0 +1,2 @@
+# This file should not be included in the build context
+FROM scratch


### PR DESCRIPTION
## Description

Keep default `.dockerignore` in sync with https://github.com/DefangLabs/pulumi-defang/pull/51

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

