### PR TITLE
Increase the delay after cd exit to 3s for gcp

### DIFF
--- a/src/pkg/cli/client/byoc/gcp/byoc.go
+++ b/src/pkg/cli/client/byoc/gcp/byoc.go
@@ -529,12 +529,12 @@ func (b *ByocGcp) Follow(ctx context.Context, req *defangv1.TailRequest) (client
 			for subscribeStream.Receive() {
 				msg := subscribeStream.Msg()
 				if msg.State == defangv1.ServiceState_BUILD_FAILED || msg.State == defangv1.ServiceState_DEPLOYMENT_FAILED {
-					pkg.SleepWithContext(ctx, 1*time.Second) // Make sure the logs are flushed
+					pkg.SleepWithContext(ctx, 3*time.Second) // Make sure the logs are flushed, gcp logs has a longer delay, thus 3s
 					cancel(fmt.Errorf("CD job failed %s", msg.Status))
 					return
 				}
 				if msg.State == defangv1.ServiceState_DEPLOYMENT_COMPLETED {
-					pkg.SleepWithContext(ctx, 1*time.Second) // Make sure the logs are flushed
+					pkg.SleepWithContext(ctx, 3*time.Second) // Make sure the logs are flushed, gcp logs has a longer delay, thus 3s
 					cancel(io.EOF)
 					return
 				}


### PR DESCRIPTION
As CD logs often are incomplete due to the delayed availability of logs in the gcp logging tail API, probably due to aggregation.

## Description

Increase the delay after cd exit to 3s for gcp

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

