### PR TITLE
HACK: do not return ErrDeploymentFailed returned from tail

### DIFF
--- a/src/cmd/cli/command/compose.go
+++ b/src/cmd/cli/command/compose.go
@@ -216,13 +216,14 @@ func makeComposeUpCmd() *cobra.Command {
 			if err := cli.Tail(tailCtx, provider, project.Name, tailOptions); err != nil {
 				term.Debug("Tail stopped with", err)
 
+				// FIXME: This code needs to be refactored
 				if connect.CodeOf(err) == connect.CodePermissionDenied {
 					// If tail fails because of missing permission, we wait for the deployment to finish
 					term.Warn("Unable to tail logs. Waiting for the deployment to finish.")
 					<-tailCtx.Done()
 					// Get the actual error from the context so we won't print "Error: missing tail permission"
 					err = context.Cause(tailCtx)
-				} else if !(errors.Is(tailCtx.Err(), context.Canceled) || errors.Is(tailCtx.Err(), context.DeadlineExceeded)) {
+				} else if !(errors.Is(tailCtx.Err(), context.Canceled) || errors.Is(tailCtx.Err(), context.DeadlineExceeded) || errors.As(err, &pkg.ErrDeploymentFailed{})) {
 					return err // any error other than cancelation
 				}
 


### PR DESCRIPTION
to make sure AI debugger is triggered when cd exit abnormally

## Description

When cd exit abnormally an ErrDeploymentFailed is returned, but the current code will only handle context cancelled with ErrDeploymentFailed error, preventing the AI debugger from starting.

This code should be refactored:
- Current logic is convoluted, difficult to read
- Logic of handling no permission to read log should not be in compose.go 
## Linked Issues

## Checklist

- [X] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

