### PR TITLE
expose FabricClient interface

### DIFF
--- a/src/pkg/cli/client/client.go
+++ b/src/pkg/cli/client/client.go
@@ -3,7 +3,9 @@ package client
 import (
 	"context"
 
+	"github.com/DefangLabs/defang/src/pkg/types"
 	defangv1 "github.com/DefangLabs/defang/src/protos/io/defang/v1"
+	"github.com/DefangLabs/defang/src/protos/io/defang/v1/defangv1connect"
 	composeTypes "github.com/compose-spec/compose-go/v2/types"
 )
 
@@ -27,7 +29,9 @@ type FabricClient interface {
 	DelegateSubdomainZone(context.Context, *defangv1.DelegateSubdomainZoneRequest) (*defangv1.DelegateSubdomainZoneResponse, error)
 	DeleteSubdomainZone(context.Context) error
 	GenerateFiles(context.Context, *defangv1.GenerateFilesRequest) (*defangv1.GenerateFilesResponse, error)
+	GetController() defangv1connect.FabricControllerClient
 	GetDelegateSubdomainZone(context.Context) (*defangv1.DelegateSubdomainZoneResponse, error)
+	GetTenantName() types.TenantName
 	GetSelectedProvider(context.Context, *defangv1.GetSelectedProviderRequest) (*defangv1.GetSelectedProviderResponse, error)
 	GetVersions(context.Context) (*defangv1.Version, error)
 	Publish(context.Context, *defangv1.PublishRequest) error

--- a/src/pkg/cli/client/grpc.go
+++ b/src/pkg/cli/client/grpc.go
@@ -51,6 +51,14 @@ func getMsg[T any](resp *connect.Response[T], err error) (*T, error) {
 	return resp.Msg, nil
 }
 
+func (g GrpcClient) GetController() defangv1connect.FabricControllerClient {
+	return g.client
+}
+
+func (g GrpcClient) GetTenantName() types.TenantName {
+	return g.TenantName
+}
+
 func (g *GrpcClient) SetClient(client defangv1connect.FabricControllerClient) {
 	g.client = client
 }

--- a/src/pkg/cli/client/playground.go
+++ b/src/pkg/cli/client/playground.go
@@ -11,14 +11,14 @@ import (
 )
 
 type PlaygroundProvider struct {
-	GrpcClient
+	FabricClient
 	RetryDelayer
 }
 
 var _ Provider = (*PlaygroundProvider)(nil)
 
 func (g *PlaygroundProvider) Deploy(ctx context.Context, req *defangv1.DeployRequest) (*defangv1.DeployResponse, error) {
-	return getMsg(g.client.Deploy(ctx, connect.NewRequest(req)))
+	return getMsg(g.GetController().Deploy(ctx, connect.NewRequest(req)))
 }
 
 func (g *PlaygroundProvider) Preview(ctx context.Context, req *defangv1.DeployRequest) (*defangv1.DeployResponse, error) {
@@ -26,41 +26,41 @@ func (g *PlaygroundProvider) Preview(ctx context.Context, req *defangv1.DeployRe
 }
 
 func (g *PlaygroundProvider) GetService(ctx context.Context, req *defangv1.GetRequest) (*defangv1.ServiceInfo, error) {
-	return getMsg(g.client.Get(ctx, connect.NewRequest(req)))
+	return getMsg(g.GetController().Get(ctx, connect.NewRequest(req)))
 }
 
 func (g *PlaygroundProvider) Delete(ctx context.Context, req *defangv1.DeleteRequest) (*defangv1.DeleteResponse, error) {
-	return getMsg(g.client.Delete(ctx, connect.NewRequest(req)))
+	return getMsg(g.GetController().Delete(ctx, connect.NewRequest(req)))
 }
 
 func (g *PlaygroundProvider) GetServices(ctx context.Context, req *defangv1.GetServicesRequest) (*defangv1.GetServicesResponse, error) {
-	return getMsg(g.client.GetServices(ctx, connect.NewRequest(req)))
+	return getMsg(g.GetController().GetServices(ctx, connect.NewRequest(req)))
 }
 
 func (g *PlaygroundProvider) PutConfig(ctx context.Context, req *defangv1.PutConfigRequest) error {
-	_, err := g.client.PutSecret(ctx, connect.NewRequest(req))
+	_, err := g.GetController().PutSecret(ctx, connect.NewRequest(req))
 	return err
 }
 
 func (g *PlaygroundProvider) DeleteConfig(ctx context.Context, req *defangv1.Secrets) error {
-	_, err := g.client.DeleteSecrets(ctx, connect.NewRequest(&defangv1.Secrets{Names: req.Names}))
+	_, err := g.GetController().DeleteSecrets(ctx, connect.NewRequest(&defangv1.Secrets{Names: req.Names}))
 	return err
 }
 
 func (g *PlaygroundProvider) ListConfig(ctx context.Context, req *defangv1.ListConfigsRequest) (*defangv1.Secrets, error) {
-	return getMsg(g.client.ListSecrets(ctx, connect.NewRequest(req)))
+	return getMsg(g.GetController().ListSecrets(ctx, connect.NewRequest(req)))
 }
 
 func (g *PlaygroundProvider) CreateUploadURL(ctx context.Context, req *defangv1.UploadURLRequest) (*defangv1.UploadURLResponse, error) {
-	return getMsg(g.client.CreateUploadURL(ctx, connect.NewRequest(req)))
+	return getMsg(g.GetController().CreateUploadURL(ctx, connect.NewRequest(req)))
 }
 
 func (g *PlaygroundProvider) Subscribe(ctx context.Context, req *defangv1.SubscribeRequest) (ServerStream[defangv1.SubscribeResponse], error) {
-	return g.client.Subscribe(ctx, connect.NewRequest(req))
+	return g.GetController().Subscribe(ctx, connect.NewRequest(req))
 }
 
 func (g *PlaygroundProvider) Follow(ctx context.Context, req *defangv1.TailRequest) (ServerStream[defangv1.TailResponse], error) {
-	return g.client.Tail(ctx, connect.NewRequest(req))
+	return g.GetController().Tail(ctx, connect.NewRequest(req))
 }
 
 func (g *PlaygroundProvider) BootstrapCommand(ctx context.Context, req BootstrapCommandRequest) (types.ETag, error) {
@@ -97,7 +97,7 @@ func (g *PlaygroundProvider) BootstrapList(context.Context) ([]string, error) {
 }
 
 func (g PlaygroundProvider) ServiceDNS(name string) string {
-	return string(g.TenantName) + "-" + name
+	return string(g.GetTenantName()) + "-" + name
 }
 
 func (g PlaygroundProvider) RemoteProjectName(ctx context.Context) (string, error) {

--- a/src/pkg/cli/client/playground_test.go
+++ b/src/pkg/cli/client/playground_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestServiceDNS(t *testing.T) {
-	p := PlaygroundProvider{GrpcClient: GrpcClient{TenantName: "proj1"}}
+	p := PlaygroundProvider{FabricClient: GrpcClient{TenantName: "proj1"}}
 
 	const expected = "proj1-service1"
 	if got := p.ServiceDNS("service1"); got != expected {

--- a/src/pkg/cli/configList_test.go
+++ b/src/pkg/cli/configList_test.go
@@ -45,7 +45,7 @@ func TestConfigList(t *testing.T) {
 
 	url := strings.TrimPrefix(server.URL, "http://")
 	grpcClient := NewGrpcClient(ctx, url)
-	provider := cliClient.PlaygroundProvider{GrpcClient: grpcClient}
+	provider := cliClient.PlaygroundProvider{FabricClient: grpcClient}
 
 	t.Run("no configs", func(t *testing.T) {
 		stdout, _ := term.SetupTestTerm(t)

--- a/src/pkg/cli/connect.go
+++ b/src/pkg/cli/connect.go
@@ -57,18 +57,18 @@ func NewGrpcClient(ctx context.Context, cluster string) client.GrpcClient {
 	return grpcClient
 }
 
-func NewProvider(ctx context.Context, providerID client.ProviderID, grpcClient client.GrpcClient) (client.Provider, error) {
+func NewProvider(ctx context.Context, providerID client.ProviderID, fabricClient client.FabricClient) (client.Provider, error) {
 	var provider client.Provider
 	term.Debugf("Creating %s provider", providerID)
 	switch providerID {
 	case client.ProviderAWS:
-		provider = aws.NewByocProvider(ctx, grpcClient.TenantName)
+		provider = aws.NewByocProvider(ctx, fabricClient.GetTenantName())
 	case client.ProviderDO:
-		provider = do.NewByocProvider(ctx, grpcClient.TenantName)
+		provider = do.NewByocProvider(ctx, fabricClient.GetTenantName())
 	case client.ProviderGCP:
-		provider = gcp.NewByocProvider(ctx, grpcClient.TenantName)
+		provider = gcp.NewByocProvider(ctx, fabricClient.GetTenantName())
 	default:
-		provider = &client.PlaygroundProvider{GrpcClient: grpcClient}
+		provider = &client.PlaygroundProvider{FabricClient: fabricClient}
 	}
 	_, err := provider.AccountInfo(ctx)
 	return provider, err

--- a/src/pkg/cli/destroy_test.go
+++ b/src/pkg/cli/destroy_test.go
@@ -43,7 +43,7 @@ func TestDestroy(t *testing.T) {
 	ctx := context.Background()
 	url := strings.TrimPrefix(server.URL, "http://")
 	grpcClient := NewGrpcClient(ctx, url)
-	client := cliClient.PlaygroundProvider{GrpcClient: grpcClient}
+	client := cliClient.PlaygroundProvider{FabricClient: grpcClient}
 
 	etag, err := client.Destroy(ctx, &defangv1.DestroyRequest{Project: "test-project"})
 	if err != nil {

--- a/src/pkg/cli/getServices_test.go
+++ b/src/pkg/cli/getServices_test.go
@@ -65,7 +65,7 @@ func TestGetServices(t *testing.T) {
 
 	url := strings.TrimPrefix(server.URL, "http://")
 	grpcClient := NewGrpcClient(ctx, url)
-	provider := cliClient.PlaygroundProvider{GrpcClient: grpcClient}
+	provider := cliClient.PlaygroundProvider{FabricClient: grpcClient}
 
 	t.Run("no services", func(t *testing.T) {
 		err := GetServices(ctx, "empty", &provider, false)

--- a/src/pkg/cli/whoami_test.go
+++ b/src/pkg/cli/whoami_test.go
@@ -36,7 +36,7 @@ func TestWhoami(t *testing.T) {
 	ctx := context.Background()
 	url := strings.TrimPrefix(server.URL, "http://")
 	grpcClient := NewGrpcClient(ctx, url)
-	client := cliClient.PlaygroundProvider{GrpcClient: grpcClient}
+	client := cliClient.PlaygroundProvider{FabricClient: grpcClient}
 
 	got, err := Whoami(ctx, grpcClient, &client)
 	if err != nil {


### PR DESCRIPTION
## Description

This PR extracts a mockable `FabricClient` interface to support unit testing in the V1 Defang Pulumi Provider: https://github.com/DefangLabs/pulumi-defang/pull/54

In order to do this, I needed to avoid accessing data attributes directly, so I implemented `GetTenantName` and `GetController`.

## Linked Issues

https://github.com/DefangLabs/pulumi-defang/pull/54

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

