### PR TITLE
Factor out TailUp

### DIFF
--- a/src/cmd/cli/command/compose.go
+++ b/src/cmd/cli/command/compose.go
@@ -23,28 +23,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func isManagedService(service compose.ServiceConfig) bool {
-	if service.Extensions == nil {
-		return false
-	}
-
-	return service.Extensions["x-defang-static-files"] != nil || service.Extensions["x-defang-redis"] != nil || service.Extensions["x-defang-postgres"] != nil
-}
-
-func splitManagedAndUnmanagedServices(serviceInfos compose.Services) ([]string, []string) {
-	var managedServices []string
-	var unmanagedServices []string
-	for _, service := range serviceInfos {
-		if isManagedService(service) {
-			managedServices = append(managedServices, service.Name)
-		} else {
-			unmanagedServices = append(unmanagedServices, service.Name)
-		}
-	}
-
-	return managedServices, unmanagedServices
-}
-
 func createProjectForDebug(loader *compose.Loader) (*compose.Project, error) {
 	projOpts, err := loader.NewProjectOptions()
 	if err != nil {
@@ -117,7 +95,7 @@ func makeComposeUpCmd() *cobra.Command {
 				return err
 			}
 
-			managedServices, unmanagedServices := splitManagedAndUnmanagedServices(project.Services)
+			managedServices, _ := cli.SplitManagedAndUnmanagedServices(project.Services)
 
 			if len(managedServices) > 0 {
 				term.Warnf("Defang cannot monitor status of the following managed service(s): %v.\n   To check if the managed service is up, check the status of the service which depends on it.", managedServices)

--- a/src/cmd/cli/command/compose_test.go
+++ b/src/cmd/cli/command/compose_test.go
@@ -1,10 +1,6 @@
 package command
 
-import (
-	"testing"
-
-	"github.com/compose-spec/compose-go/v2/types"
-)
+import "testing"
 
 func TestInitializeTailCmd(t *testing.T) {
 	t.Run("", func(t *testing.T) {
@@ -13,107 +9,6 @@ func TestInitializeTailCmd(t *testing.T) {
 				cmd.Execute()
 				return
 			}
-		}
-	})
-}
-
-func TestGetUnreferencedManagedResources(t *testing.T) {
-	t.Run("no services", func(t *testing.T) {
-		project := types.Services{}
-
-		managed, unmanaged := splitManagedAndUnmanagedServices(project)
-		if len(managed) != 0 {
-			t.Errorf("Expected 0 managed resources, got %d (%v)", len(managed), managed)
-		}
-
-		if len(unmanaged) != 0 {
-			t.Errorf("Expected 0 unmanaged resources, got %d (%v)", len(unmanaged), unmanaged)
-		}
-	})
-
-	t.Run("one service all managed", func(t *testing.T) {
-		project := types.Services{
-			"service1": types.ServiceConfig{
-				Extensions: map[string]any{"x-defang-postgres": true},
-			},
-		}
-
-		managed, unmanaged := splitManagedAndUnmanagedServices(project)
-		if len(managed) != 1 {
-			t.Errorf("Expected 1 managed resource, got %d (%v)", len(managed), managed)
-		}
-
-		if len(unmanaged) != 0 {
-			t.Errorf("Expected 0 unmanaged resource, got %d (%v)", len(unmanaged), unmanaged)
-		}
-	})
-
-	t.Run("one service unmanaged", func(t *testing.T) {
-		project := types.Services{
-			"service1": types.ServiceConfig{},
-		}
-
-		managed, unmanaged := splitManagedAndUnmanagedServices(project)
-		if len(managed) != 0 {
-			t.Errorf("Expected 0 managed resource, got %d (%v)", len(managed), managed)
-		}
-
-		if len(unmanaged) != 1 {
-			t.Errorf("Expected 1 unmanaged resource, got %d (%v)", len(unmanaged), unmanaged)
-		}
-	})
-
-	t.Run("one service unmanaged, one service managed", func(t *testing.T) {
-		project := types.Services{
-			"service1": types.ServiceConfig{},
-			"service2": types.ServiceConfig{
-				Extensions: map[string]any{"x-defang-postgres": true},
-			},
-		}
-
-		managed, unmanaged := splitManagedAndUnmanagedServices(project)
-		if len(managed) != 1 {
-			t.Errorf("Expected 1 managed resource, got %d (%v)", len(managed), managed)
-		}
-
-		if len(unmanaged) != 1 {
-			t.Errorf("Expected 1 unmanaged resource, got %d (%v)", len(unmanaged), unmanaged)
-		}
-	})
-
-	t.Run("two service two unmanaged", func(t *testing.T) {
-		project := types.Services{
-			"service1": types.ServiceConfig{},
-			"service2": types.ServiceConfig{},
-		}
-
-		managed, unmanaged := splitManagedAndUnmanagedServices(project)
-		if len(managed) != 0 {
-			t.Errorf("Expected 0 managed resource, got %d (%v)", len(managed), managed)
-		}
-
-		if len(unmanaged) != 2 {
-			t.Errorf("Expected 2 unmanaged resource, got %d (%v)", len(unmanaged), unmanaged)
-		}
-	})
-
-	t.Run("one service two managed", func(t *testing.T) {
-		project := types.Services{
-			"service1": types.ServiceConfig{},
-			"service2": types.ServiceConfig{
-				Extensions: map[string]any{"x-defang-postgres": true},
-			},
-			"service3": types.ServiceConfig{
-				Extensions: map[string]any{"x-defang-redis": true},
-			},
-		}
-
-		managed, unmanaged := splitManagedAndUnmanagedServices(project)
-		if len(managed) != 2 {
-			t.Errorf("Expected 2 managed resource, got %d (%v)", len(managed), managed)
-		}
-		if len(unmanaged) != 1 {
-			t.Errorf("Expected 1 unmanaged resource, got %d (%s)", len(unmanaged), unmanaged)
 		}
 	})
 }

--- a/src/cmd/cli/command/deploymentinfo.go
+++ b/src/cmd/cli/command/deploymentinfo.go
@@ -19,32 +19,3 @@ func printPlaygroundPortalServiceURLs(serviceInfos []*defangv1.ServiceInfo) {
 		}
 	}
 }
-
-func printEndpoints(serviceInfos []*defangv1.ServiceInfo) {
-	for _, serviceInfo := range serviceInfos {
-		andEndpoints := ""
-		if len(serviceInfo.Endpoints) > 0 {
-			andEndpoints = "and will be available at:"
-		}
-
-		serviceConditionText := "has status " + serviceInfo.Status
-		if serviceInfo.State != defangv1.ServiceState_NOT_SPECIFIED {
-			serviceConditionText = "is in state " + serviceInfo.State.String()
-		}
-
-		term.Info("Service", serviceInfo.Service.Name, serviceConditionText, andEndpoints)
-		for i, endpoint := range serviceInfo.Endpoints {
-			if serviceInfo.Service.Ports[i].Mode == defangv1.Mode_INGRESS {
-				endpoint = "https://" + endpoint
-			}
-			term.Println("   -", endpoint)
-		}
-		if serviceInfo.Domainname != "" {
-			if serviceInfo.ZoneId != "" {
-				term.Println("   -", "https://"+serviceInfo.Domainname)
-			} else {
-				term.Println("   -", "https://"+serviceInfo.Domainname+" (after `defang cert generate` to get a TLS certificate)")
-			}
-		}
-	}
-}

--- a/src/cmd/cli/command/deploymentinfo_test.go
+++ b/src/cmd/cli/command/deploymentinfo_test.go
@@ -33,36 +33,3 @@ func TestPrintPlaygroundPortalServiceURLs(t *testing.T) {
 		t.Errorf("got %q, want %q", got, want)
 	}
 }
-
-func TestPrintEndpoints(t *testing.T) {
-	defaultTerm := term.DefaultTerm
-	t.Cleanup(func() {
-		term.DefaultTerm = defaultTerm
-	})
-
-	var stdout, stderr bytes.Buffer
-	term.DefaultTerm = term.NewTerm(os.Stdin, &stdout, &stderr)
-
-	printEndpoints([]*defangv1.ServiceInfo{
-		{
-			Service: &defangv1.Service{
-				Name: "service1",
-				Ports: []*defangv1.Port{
-					{Mode: defangv1.Mode_INGRESS},
-					{Mode: defangv1.Mode_HOST},
-				},
-			},
-			Status: "UNKNOWN",
-			Endpoints: []string{
-				"example.com",
-				"service1.internal",
-			},
-		}})
-	const want = ` * Service service1 has status UNKNOWN and will be available at:
-   - https://example.com
-   - service1.internal
-`
-	if got := stdout.String(); got != want {
-		t.Errorf("got %q, want %q", got, want)
-	}
-}

--- a/src/pkg/cli/composeUp.go
+++ b/src/pkg/cli/composeUp.go
@@ -6,10 +6,13 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/DefangLabs/defang/src/pkg"
 	"github.com/DefangLabs/defang/src/pkg/cli/client"
 	"github.com/DefangLabs/defang/src/pkg/cli/compose"
+	"github.com/DefangLabs/defang/src/pkg/logs"
 	"github.com/DefangLabs/defang/src/pkg/term"
 	defangv1 "github.com/DefangLabs/defang/src/protos/io/defang/v1"
+	"github.com/bufbuild/connect-go"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -139,6 +142,93 @@ func ComposeUp(ctx context.Context, project *compose.Project, c client.FabricCli
 		}
 	}
 	return resp, project, nil
+}
+
+func TailUp(ctx context.Context, provider client.Provider, project *compose.Project, deploy *defangv1.DeployResponse, tailOptions TailOptions) error {
+	ctx, cancelTail := context.WithCancelCause(ctx)
+	defer cancelTail(nil) // to cancel WaitServiceState and clean-up context
+
+	if tailOptions.WaitTimeout >= 0 {
+		var cancelTimeout context.CancelFunc
+		ctx, cancelTimeout = context.WithTimeout(ctx, time.Duration(tailOptions.WaitTimeout)*time.Second)
+		defer cancelTimeout()
+	}
+	errCompleted := errors.New("deployment succeeded") // tail canceled because of deployment completion
+	const targetState = defangv1.ServiceState_DEPLOYMENT_COMPLETED
+
+	_, unmanagedServices := SplitManagedAndUnmanagedServices(project.Services)
+
+	go func() {
+		if err := WaitServiceState(ctx, provider, targetState, project.Name, deploy.Etag, unmanagedServices); err != nil {
+			var errDeploymentFailed pkg.ErrDeploymentFailed
+			if errors.As(err, &errDeploymentFailed) {
+				cancelTail(err)
+			} else if !(errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)) {
+				term.Warnf("error waiting for deployment completion: %v", err) // TODO: don't print in Go-routine
+			}
+		} else {
+			cancelTail(errCompleted)
+		}
+	}()
+
+	// show users the current streaming logs
+	tailSource := "all services"
+	if deploy.Etag != "" {
+		tailSource = "deployment ID " + deploy.Etag
+	}
+
+	term.Info("Tailing logs for", tailSource, "; press Ctrl+C to detach:")
+
+	if tailOptions.Etag == "" {
+		tailOptions.Etag = deploy.Etag
+	}
+	if tailOptions.Since.IsZero() {
+		tailOptions.Since = time.Now()
+	}
+	if tailOptions.LogType == logs.LogTypeUnspecified {
+		tailOptions.LogType = logs.LogTypeAll
+	}
+
+	err := Tail(ctx, provider, project.Name, tailOptions)
+	if err != nil {
+		term.Debug("Tail stopped with", err)
+
+		if connect.CodeOf(err) == connect.CodePermissionDenied {
+			// If tail fails because of missing permission, we wait for the deployment to finish
+			term.Warn("Unable to tail logs. Waiting for the deployment to finish.")
+			<-ctx.Done()
+			// Get the actual error from the context so we won't print "Error: missing tail permission"
+			err = context.Cause(ctx)
+		} else if !(errors.Is(ctx.Err(), context.Canceled) || errors.Is(ctx.Err(), context.DeadlineExceeded)) {
+			return err // any error other than cancelation
+		}
+
+		// The tail was canceled; check if it was because of deployment failure or explicit cancelation or wait-timeout reached
+		if errors.Is(context.Cause(ctx), context.Canceled) {
+			// Tail was canceled by the user before deployment completion/failure; show a warning and exit with an error
+			term.Warn("Deployment is not finished. Service(s) might not be running.")
+			return err
+		} else if errors.Is(context.Cause(ctx), context.DeadlineExceeded) {
+			// Tail was canceled when wait-timeout is reached; show a warning and exit with an error
+			term.Warn("Wait-timeout exceeded, detaching from logs. Deployment still in progress.")
+			return err
+		}
+
+		return err
+	}
+
+	// Print the current service states of the deployment
+	if errors.Is(context.Cause(ctx), errCompleted) {
+		for _, service := range deploy.Services {
+			service.State = targetState
+		}
+
+		printEndpoints(deploy.Services)
+	}
+
+	term.Info("Done.")
+
+	return nil
 }
 
 func SplitManagedAndUnmanagedServices(serviceInfos compose.Services) ([]string, []string) {

--- a/src/pkg/cli/composeUp.go
+++ b/src/pkg/cli/composeUp.go
@@ -6,13 +6,10 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/DefangLabs/defang/src/pkg"
 	"github.com/DefangLabs/defang/src/pkg/cli/client"
 	"github.com/DefangLabs/defang/src/pkg/cli/compose"
-	"github.com/DefangLabs/defang/src/pkg/logs"
 	"github.com/DefangLabs/defang/src/pkg/term"
 	defangv1 "github.com/DefangLabs/defang/src/protos/io/defang/v1"
-	"github.com/bufbuild/connect-go"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -142,93 +139,6 @@ func ComposeUp(ctx context.Context, project *compose.Project, c client.FabricCli
 		}
 	}
 	return resp, project, nil
-}
-
-func TailUp(ctx context.Context, provider client.Provider, project *compose.Project, deploy *defangv1.DeployResponse, tailOptions TailOptions) error {
-	ctx, cancelTail := context.WithCancelCause(ctx)
-	defer cancelTail(nil) // to cancel WaitServiceState and clean-up context
-
-	if tailOptions.WaitTimeout >= 0 {
-		var cancelTimeout context.CancelFunc
-		ctx, cancelTimeout = context.WithTimeout(ctx, time.Duration(tailOptions.WaitTimeout)*time.Second)
-		defer cancelTimeout()
-	}
-	errCompleted := errors.New("deployment succeeded") // tail canceled because of deployment completion
-	const targetState = defangv1.ServiceState_DEPLOYMENT_COMPLETED
-
-	_, unmanagedServices := SplitManagedAndUnmanagedServices(project.Services)
-
-	go func() {
-		if err := WaitServiceState(ctx, provider, targetState, project.Name, deploy.Etag, unmanagedServices); err != nil {
-			var errDeploymentFailed pkg.ErrDeploymentFailed
-			if errors.As(err, &errDeploymentFailed) {
-				cancelTail(err)
-			} else if !(errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)) {
-				term.Warnf("error waiting for deployment completion: %v", err) // TODO: don't print in Go-routine
-			}
-		} else {
-			cancelTail(errCompleted)
-		}
-	}()
-
-	// show users the current streaming logs
-	tailSource := "all services"
-	if deploy.Etag != "" {
-		tailSource = "deployment ID " + deploy.Etag
-	}
-
-	term.Info("Tailing logs for", tailSource, "; press Ctrl+C to detach:")
-
-	if tailOptions.Etag == "" {
-		tailOptions.Etag = deploy.Etag
-	}
-	if tailOptions.Since.IsZero() {
-		tailOptions.Since = time.Now()
-	}
-	if tailOptions.LogType == logs.LogTypeUnspecified {
-		tailOptions.LogType = logs.LogTypeAll
-	}
-
-	err := Tail(ctx, provider, project.Name, tailOptions)
-	if err != nil {
-		term.Debug("Tail stopped with", err)
-
-		if connect.CodeOf(err) == connect.CodePermissionDenied {
-			// If tail fails because of missing permission, we wait for the deployment to finish
-			term.Warn("Unable to tail logs. Waiting for the deployment to finish.")
-			<-ctx.Done()
-			// Get the actual error from the context so we won't print "Error: missing tail permission"
-			err = context.Cause(ctx)
-		} else if !(errors.Is(ctx.Err(), context.Canceled) || errors.Is(ctx.Err(), context.DeadlineExceeded)) {
-			return err // any error other than cancelation
-		}
-
-		// The tail was canceled; check if it was because of deployment failure or explicit cancelation or wait-timeout reached
-		if errors.Is(context.Cause(ctx), context.Canceled) {
-			// Tail was canceled by the user before deployment completion/failure; show a warning and exit with an error
-			term.Warn("Deployment is not finished. Service(s) might not be running.")
-			return err
-		} else if errors.Is(context.Cause(ctx), context.DeadlineExceeded) {
-			// Tail was canceled when wait-timeout is reached; show a warning and exit with an error
-			term.Warn("Wait-timeout exceeded, detaching from logs. Deployment still in progress.")
-			return err
-		}
-
-		return err
-	}
-
-	// Print the current service states of the deployment
-	if errors.Is(context.Cause(ctx), errCompleted) {
-		for _, service := range deploy.Services {
-			service.State = targetState
-		}
-
-		printEndpoints(deploy.Services)
-	}
-
-	term.Info("Done.")
-
-	return nil
 }
 
 func SplitManagedAndUnmanagedServices(serviceInfos compose.Services) ([]string, []string) {

--- a/src/pkg/cli/composeUp.go
+++ b/src/pkg/cli/composeUp.go
@@ -6,10 +6,13 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/DefangLabs/defang/src/pkg"
 	"github.com/DefangLabs/defang/src/pkg/cli/client"
 	"github.com/DefangLabs/defang/src/pkg/cli/compose"
+	"github.com/DefangLabs/defang/src/pkg/logs"
 	"github.com/DefangLabs/defang/src/pkg/term"
 	defangv1 "github.com/DefangLabs/defang/src/protos/io/defang/v1"
+	"github.com/bufbuild/connect-go"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -139,4 +142,142 @@ func ComposeUp(ctx context.Context, project *compose.Project, c client.FabricCli
 		}
 	}
 	return resp, project, nil
+}
+
+func TailUp(ctx context.Context, provider client.Provider, project *compose.Project, deploy *defangv1.DeployResponse, tailOptions TailOptions) error {
+	ctx, cancelTail := context.WithCancelCause(ctx)
+	defer cancelTail(nil) // to cancel WaitServiceState and clean-up context
+
+	if tailOptions.WaitTimeout >= 0 {
+		var cancelTimeout context.CancelFunc
+		ctx, cancelTimeout = context.WithTimeout(ctx, time.Duration(tailOptions.WaitTimeout)*time.Second)
+		defer cancelTimeout()
+	}
+	errCompleted := errors.New("deployment succeeded") // tail canceled because of deployment completion
+	const targetState = defangv1.ServiceState_DEPLOYMENT_COMPLETED
+
+	_, unmanagedServices := SplitManagedAndUnmanagedServices(project.Services)
+
+	go func() {
+		if err := WaitServiceState(ctx, provider, targetState, project.Name, deploy.Etag, unmanagedServices); err != nil {
+			var errDeploymentFailed pkg.ErrDeploymentFailed
+			if errors.As(err, &errDeploymentFailed) {
+				cancelTail(err)
+			} else if !(errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)) {
+				term.Warnf("error waiting for deployment completion: %v", err) // TODO: don't print in Go-routine
+			}
+		} else {
+			cancelTail(errCompleted)
+		}
+	}()
+
+	// show users the current streaming logs
+	tailSource := "all services"
+	if deploy.Etag != "" {
+		tailSource = "deployment ID " + deploy.Etag
+	}
+
+	term.Info("Tailing logs for", tailSource, "; press Ctrl+C to detach:")
+
+	if tailOptions.Etag == "" {
+		tailOptions.Etag = deploy.Etag
+	}
+	if tailOptions.Since.IsZero() {
+		tailOptions.Since = time.Now()
+	}
+	if tailOptions.LogType == logs.LogTypeUnspecified {
+		tailOptions.LogType = logs.LogTypeAll
+	}
+
+	err := Tail(ctx, provider, project.Name, tailOptions)
+	if err != nil {
+		term.Debug("Tail stopped with", err)
+
+		if connect.CodeOf(err) == connect.CodePermissionDenied {
+			// If tail fails because of missing permission, we wait for the deployment to finish
+			term.Warn("Unable to tail logs. Waiting for the deployment to finish.")
+			<-ctx.Done()
+			// Get the actual error from the context so we won't print "Error: missing tail permission"
+			err = context.Cause(ctx)
+		} else if !(errors.Is(ctx.Err(), context.Canceled) || errors.Is(ctx.Err(), context.DeadlineExceeded)) {
+			return err // any error other than cancelation
+		}
+
+		// The tail was canceled; check if it was because of deployment failure or explicit cancelation or wait-timeout reached
+		if errors.Is(context.Cause(ctx), context.Canceled) {
+			// Tail was canceled by the user before deployment completion/failure; show a warning and exit with an error
+			term.Warn("Deployment is not finished. Service(s) might not be running.")
+			return err
+		} else if errors.Is(context.Cause(ctx), context.DeadlineExceeded) {
+			// Tail was canceled when wait-timeout is reached; show a warning and exit with an error
+			term.Warn("Wait-timeout exceeded, detaching from logs. Deployment still in progress.")
+			return err
+		}
+
+		return err
+	}
+
+	// Print the current service states of the deployment
+	if errors.Is(context.Cause(ctx), errCompleted) {
+		for _, service := range deploy.Services {
+			service.State = targetState
+		}
+
+		printEndpoints(deploy.Services)
+	}
+
+	term.Info("Done.")
+
+	return nil
+}
+
+func SplitManagedAndUnmanagedServices(serviceInfos compose.Services) ([]string, []string) {
+	var managedServices []string
+	var unmanagedServices []string
+	for _, service := range serviceInfos {
+		if isManagedService(service) {
+			managedServices = append(managedServices, service.Name)
+		} else {
+			unmanagedServices = append(unmanagedServices, service.Name)
+		}
+	}
+
+	return managedServices, unmanagedServices
+}
+
+func isManagedService(service compose.ServiceConfig) bool {
+	if service.Extensions == nil {
+		return false
+	}
+
+	return service.Extensions["x-defang-static-files"] != nil || service.Extensions["x-defang-redis"] != nil || service.Extensions["x-defang-postgres"] != nil
+}
+
+func printEndpoints(serviceInfos []*defangv1.ServiceInfo) {
+	for _, serviceInfo := range serviceInfos {
+		andEndpoints := ""
+		if len(serviceInfo.Endpoints) > 0 {
+			andEndpoints = "and will be available at:"
+		}
+
+		serviceConditionText := "has status " + serviceInfo.Status
+		if serviceInfo.State != defangv1.ServiceState_NOT_SPECIFIED {
+			serviceConditionText = "is in state " + serviceInfo.State.String()
+		}
+
+		term.Info("Service", serviceInfo.Service.Name, serviceConditionText, andEndpoints)
+		for i, endpoint := range serviceInfo.Endpoints {
+			if serviceInfo.Service.Ports[i].Mode == defangv1.Mode_INGRESS {
+				endpoint = "https://" + endpoint
+			}
+			term.Println("   -", endpoint)
+		}
+		if serviceInfo.Domainname != "" {
+			if serviceInfo.ZoneId != "" {
+				term.Println("   -", "https://"+serviceInfo.Domainname)
+			} else {
+				term.Println("   -", "https://"+serviceInfo.Domainname+" (after `defang cert generate` to get a TLS certificate)")
+			}
+		}
+	}
 }

--- a/src/pkg/cli/tail.go
+++ b/src/pkg/cli/tail.go
@@ -76,6 +76,7 @@ type TailOptions struct {
 	Verbose            bool
 	LogType            logs.LogType
 	Filter             string
+	WaitTimeout        int
 }
 
 func (to TailOptions) String() string {


### PR DESCRIPTION
## Description

This PR does the following:
1. factor out `cli.TailUp` to encapsulate the logic for setting up a Tail stream for monitoring a deployment. That way, the new V1 Defang Pulumi Provider in https://github.com/DefangLabs/pulumi-defang/pull/54 can tail logs after initiating a deployment.
2. add `WaitTimeout` to `TailOptions`
3. move the following helpers (and their tests) from the `command` package, to the `cli` package. This way, they are co-located with `cli.TailUp`:
  * `isManagedService`
  * `splitManagedAndUnmanagedServices`
  * `printEndpoints`

## Linked Issues

https://github.com/DefangLabs/pulumi-defang/pull/54

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

