### PR TITLE
Expose cli.ErrDeploymentCompleted

### DIFF
--- a/src/cmd/cli/command/compose.go
+++ b/src/cmd/cli/command/compose.go
@@ -181,7 +181,6 @@ func makeComposeUpCmd() *cobra.Command {
 				defer cancelTimeout()
 			}
 
-			errCompleted := errors.New("deployment succeeded") // tail canceled because of deployment completion
 			const targetState = defangv1.ServiceState_DEPLOYMENT_COMPLETED
 
 			go func() {
@@ -193,7 +192,7 @@ func makeComposeUpCmd() *cobra.Command {
 						term.Warnf("error waiting for deployment completion: %v", err) // TODO: don't print in Go-routine
 					}
 				} else {
-					cancelTail(errCompleted)
+					cancelTail(cli.ErrDeploymentCompleted)
 				}
 			}()
 
@@ -268,7 +267,7 @@ func makeComposeUpCmd() *cobra.Command {
 			}
 
 			// Print the current service states of the deployment
-			if errors.Is(context.Cause(tailCtx), errCompleted) {
+			if errors.Is(context.Cause(tailCtx), cli.ErrDeploymentCompleted) {
 				for _, service := range deploy.Services {
 					service.State = targetState
 				}

--- a/src/pkg/cli/tail.go
+++ b/src/pkg/cli/tail.go
@@ -32,7 +32,8 @@ const (
 )
 
 var (
-	colorKeyRegex = regexp.MustCompile(`"(?:\\["\\/bfnrt]|[^\x00-\x1f"\\]|\\u[0-9a-fA-F]{4})*"\s*:|[^\x00-\x20"=&?]+=`) // handles JSON, logfmt, and query params
+	colorKeyRegex          = regexp.MustCompile(`"(?:\\["\\/bfnrt]|[^\x00-\x1f"\\]|\\u[0-9a-fA-F]{4})*"\s*:|[^\x00-\x20"=&?]+=`) // handles JSON, logfmt, and query params
+	ErrDeploymentCompleted = errors.New("deployment completed")                                                                  // tail canceled because of deployment completion
 )
 
 type ServiceStatus string


### PR DESCRIPTION
## Description

Exposing `cli.ErrDeploymentCompleted` so that the new v1 Defang Pulumi Provider can test for it when tailing logs in https://github.com/DefangLabs/pulumi-defang/pull/54.

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

