### PR TITLE
factor out cli.WaitAndTail for use by new pulumi provider

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,5 +1,6 @@
 {
     "recommendations": [
-        "github.vscode-pull-request-github"
+        "github.vscode-pull-request-github",
+        "wayou.vscode-todo-highlight"
     ]
 }

--- a/src/cmd/cli/command/compose.go
+++ b/src/cmd/cli/command/compose.go
@@ -211,10 +211,6 @@ func makeComposeUpCmd() *cobra.Command {
 				return err
 			}
 
-			for _, service := range deploy.Services {
-				service.State = targetState
-			}
-
 			// Print the current service states of the deployment
 			printServiceStatesAndEndpoints(deploy.Services)
 
@@ -257,6 +253,10 @@ func WaitAndTail(ctx context.Context, project *compose.Project, client cliClient
 				term.Warnf("error waiting for deployment completion: %v", err) // TODO: don't print in Go-routine
 			}
 		} else {
+			for _, service := range deploy.Services {
+				service.State = targetState
+			}
+
 			cancelTail(errCompleted)
 		}
 	}()

--- a/src/cmd/cli/command/compose.go
+++ b/src/cmd/cli/command/compose.go
@@ -1,7 +1,6 @@
 package command
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -161,7 +160,7 @@ func makeComposeUpCmd() *cobra.Command {
 			err = cli.WaitAndTail(ctx, project, client, provider, deploy, time.Duration(waitTimeout)*time.Second, since, verbose)
 			if err != nil {
 				var errDeploymentFailed pkg.ErrDeploymentFailed
-				if errors.As(context.Cause(ctx), &errDeploymentFailed) || errors.As(err, &errDeploymentFailed) {
+				if errors.As(err, &errDeploymentFailed) {
 					// Tail got canceled because of deployment failure: prompt to show the debugger
 					term.Warn(errDeploymentFailed)
 					if !nonInteractive {

--- a/src/cmd/cli/command/compose.go
+++ b/src/cmd/cli/command/compose.go
@@ -182,6 +182,8 @@ func makeComposeUpCmd() *cobra.Command {
 						if nil == cli.InteractiveDebugDeployment(ctx, client, debugConfig) {
 							return err // don't show the defang hint if debugging was successful
 						}
+						tailOptions := cli.NewTailOptionsForDeploy(deploy, since, true)
+						printDefangHint("To see the logs of the failed service, do:", tailOptions.String())
 					}
 				}
 				return err

--- a/src/cmd/cli/command/compose.go
+++ b/src/cmd/cli/command/compose.go
@@ -213,57 +213,29 @@ func makeComposeUpCmd() *cobra.Command {
 				Verbose: verbose,
 				LogType: logs.LogTypeAll,
 			}
-			if err := cli.Tail(tailCtx, provider, project.Name, tailOptions); err != nil {
-				term.Debug("Tail stopped with", err)
-
-				// FIXME: This code needs to be refactored
-				if connect.CodeOf(err) == connect.CodePermissionDenied {
-					// If tail fails because of missing permission, we wait for the deployment to finish
-					term.Warn("Unable to tail logs. Waiting for the deployment to finish.")
-					<-tailCtx.Done()
-					// Get the actual error from the context so we won't print "Error: missing tail permission"
-					err = context.Cause(tailCtx)
-				} else if !(errors.Is(tailCtx.Err(), context.Canceled) || errors.Is(tailCtx.Err(), context.DeadlineExceeded) || errors.As(err, &pkg.ErrDeploymentFailed{})) {
-					return err // any error other than cancelation
-				}
-
-				// The tail was canceled; check if it was because of deployment failure or explicit cancelation or wait-timeout reached
-				if errors.Is(context.Cause(tailCtx), context.Canceled) {
-					// Tail was canceled by the user before deployment completion/failure; show a warning and exit with an error
-					term.Warn("Deployment is not finished. Service(s) might not be running.")
-					return err
-				} else if errors.Is(context.Cause(tailCtx), context.DeadlineExceeded) {
-					// Tail was canceled when wait-timeout is reached; show a warning and exit with an error
-					term.Warn("Wait-timeout exceeded, detaching from logs. Deployment still in progress.")
-					return err
-				}
-
-				var errDeploymentFailed pkg.ErrDeploymentFailed
-				if errors.As(context.Cause(tailCtx), &errDeploymentFailed) || errors.As(err, &errDeploymentFailed) {
-					// Tail got canceled because of deployment failure: prompt to show the debugger
-					term.Warn(errDeploymentFailed)
-					if !nonInteractive {
-						var failedServices []string
-						if errDeploymentFailed.Service != "" {
-							failedServices = []string{errDeploymentFailed.Service}
-						}
-						track.Evt("Debug Prompted", P("failedServices", failedServices), P("etag", deploy.Etag), P("reason", errDeploymentFailed))
-
-						// Call the AI debug endpoint using the original command context (not the tailCtx which is canceled)
-						var debugConfig = cli.DebugConfig{
-							Etag:           deploy.Etag,
-							FailedServices: failedServices,
-							Project:        project,
-							Provider:       provider,
-							Since:          since,
-						}
-						if nil == cli.InteractiveDebugDeployment(cmd.Context(), client, debugConfig) {
-							return err // don't show the defang hint if debugging was successful
-						}
+			err = cli.TailUp(ctx, provider, project, deploy, tailOptions)
+			var errDeploymentFailed pkg.ErrDeploymentFailed
+			if errors.As(context.Cause(ctx), &errDeploymentFailed) || errors.As(err, &errDeploymentFailed) {
+				// Tail got canceled because of deployment failure: prompt to show the debugger
+				term.Warn(errDeploymentFailed)
+				if !nonInteractive {
+					var failedServices []string
+					if errDeploymentFailed.Service != "" {
+						failedServices = []string{errDeploymentFailed.Service}
 					}
-					tailOptions.Verbose = true // show all logs for debugging
-					printDefangHint("To see the logs of the failed service, do:", tailOptions.String())
-					return err
+					track.Evt("Debug Prompted", P("failedServices", failedServices), P("etag", deploy.Etag), P("reason", errDeploymentFailed))
+
+					// Call the AI debug endpoint using the original command context (not the tailCtx which is canceled)
+					var debugConfig = cli.DebugConfig{
+						Etag:           deploy.Etag,
+						FailedServices: failedServices,
+						Project:        project,
+						Provider:       provider,
+						Since:          since,
+					}
+					if nil == cli.InteractiveDebugDeployment(ctx, client, debugConfig) {
+						return err // don't show the defang hint if debugging was successful
+					}
 				}
 			}
 

--- a/src/cmd/cli/command/compose.go
+++ b/src/cmd/cli/command/compose.go
@@ -216,7 +216,7 @@ func makeComposeUpCmd() *cobra.Command {
 			}
 
 			// Print the current service states of the deployment
-			printEndpoints(deploy.Services)
+			printServiceStatesAndEndpoints(deploy.Services)
 
 			term.Info("Done.")
 			return nil

--- a/src/cmd/cli/command/compose_test.go
+++ b/src/cmd/cli/command/compose_test.go
@@ -2,8 +2,6 @@ package command
 
 import (
 	"testing"
-
-	"github.com/compose-spec/compose-go/v2/types"
 )
 
 func TestInitializeTailCmd(t *testing.T) {
@@ -13,107 +11,6 @@ func TestInitializeTailCmd(t *testing.T) {
 				cmd.Execute()
 				return
 			}
-		}
-	})
-}
-
-func TestGetUnreferencedManagedResources(t *testing.T) {
-	t.Run("no services", func(t *testing.T) {
-		project := types.Services{}
-
-		managed, unmanaged := splitManagedAndUnmanagedServices(project)
-		if len(managed) != 0 {
-			t.Errorf("Expected 0 managed resources, got %d (%v)", len(managed), managed)
-		}
-
-		if len(unmanaged) != 0 {
-			t.Errorf("Expected 0 unmanaged resources, got %d (%v)", len(unmanaged), unmanaged)
-		}
-	})
-
-	t.Run("one service all managed", func(t *testing.T) {
-		project := types.Services{
-			"service1": types.ServiceConfig{
-				Extensions: map[string]any{"x-defang-postgres": true},
-			},
-		}
-
-		managed, unmanaged := splitManagedAndUnmanagedServices(project)
-		if len(managed) != 1 {
-			t.Errorf("Expected 1 managed resource, got %d (%v)", len(managed), managed)
-		}
-
-		if len(unmanaged) != 0 {
-			t.Errorf("Expected 0 unmanaged resource, got %d (%v)", len(unmanaged), unmanaged)
-		}
-	})
-
-	t.Run("one service unmanaged", func(t *testing.T) {
-		project := types.Services{
-			"service1": types.ServiceConfig{},
-		}
-
-		managed, unmanaged := splitManagedAndUnmanagedServices(project)
-		if len(managed) != 0 {
-			t.Errorf("Expected 0 managed resource, got %d (%v)", len(managed), managed)
-		}
-
-		if len(unmanaged) != 1 {
-			t.Errorf("Expected 1 unmanaged resource, got %d (%v)", len(unmanaged), unmanaged)
-		}
-	})
-
-	t.Run("one service unmanaged, one service managed", func(t *testing.T) {
-		project := types.Services{
-			"service1": types.ServiceConfig{},
-			"service2": types.ServiceConfig{
-				Extensions: map[string]any{"x-defang-postgres": true},
-			},
-		}
-
-		managed, unmanaged := splitManagedAndUnmanagedServices(project)
-		if len(managed) != 1 {
-			t.Errorf("Expected 1 managed resource, got %d (%v)", len(managed), managed)
-		}
-
-		if len(unmanaged) != 1 {
-			t.Errorf("Expected 1 unmanaged resource, got %d (%v)", len(unmanaged), unmanaged)
-		}
-	})
-
-	t.Run("two service two unmanaged", func(t *testing.T) {
-		project := types.Services{
-			"service1": types.ServiceConfig{},
-			"service2": types.ServiceConfig{},
-		}
-
-		managed, unmanaged := splitManagedAndUnmanagedServices(project)
-		if len(managed) != 0 {
-			t.Errorf("Expected 0 managed resource, got %d (%v)", len(managed), managed)
-		}
-
-		if len(unmanaged) != 2 {
-			t.Errorf("Expected 2 unmanaged resource, got %d (%v)", len(unmanaged), unmanaged)
-		}
-	})
-
-	t.Run("one service two managed", func(t *testing.T) {
-		project := types.Services{
-			"service1": types.ServiceConfig{},
-			"service2": types.ServiceConfig{
-				Extensions: map[string]any{"x-defang-postgres": true},
-			},
-			"service3": types.ServiceConfig{
-				Extensions: map[string]any{"x-defang-redis": true},
-			},
-		}
-
-		managed, unmanaged := splitManagedAndUnmanagedServices(project)
-		if len(managed) != 2 {
-			t.Errorf("Expected 2 managed resource, got %d (%v)", len(managed), managed)
-		}
-		if len(unmanaged) != 1 {
-			t.Errorf("Expected 1 unmanaged resource, got %d (%s)", len(unmanaged), unmanaged)
 		}
 	})
 }

--- a/src/cmd/cli/command/deploymentinfo.go
+++ b/src/cmd/cli/command/deploymentinfo.go
@@ -20,7 +20,7 @@ func printPlaygroundPortalServiceURLs(serviceInfos []*defangv1.ServiceInfo) {
 	}
 }
 
-func printEndpoints(serviceInfos []*defangv1.ServiceInfo) {
+func printServiceStatesAndEndpoints(serviceInfos []*defangv1.ServiceInfo) {
 	for _, serviceInfo := range serviceInfos {
 		andEndpoints := ""
 		if len(serviceInfo.Endpoints) > 0 {

--- a/src/cmd/cli/command/deploymentinfo_test.go
+++ b/src/cmd/cli/command/deploymentinfo_test.go
@@ -34,7 +34,7 @@ func TestPrintPlaygroundPortalServiceURLs(t *testing.T) {
 	}
 }
 
-func TestPrintEndpoints(t *testing.T) {
+func TestPrintServiceStatesAndEndpoints(t *testing.T) {
 	defaultTerm := term.DefaultTerm
 	t.Cleanup(func() {
 		term.DefaultTerm = defaultTerm
@@ -43,7 +43,7 @@ func TestPrintEndpoints(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	term.DefaultTerm = term.NewTerm(os.Stdin, &stdout, &stderr)
 
-	printEndpoints([]*defangv1.ServiceInfo{
+	printServiceStatesAndEndpoints([]*defangv1.ServiceInfo{
 		{
 			Service: &defangv1.Service{
 				Name: "service1",

--- a/src/pkg/cli/composeUp.go
+++ b/src/pkg/cli/composeUp.go
@@ -219,10 +219,15 @@ func WaitAndTail(ctx context.Context, project *compose.Project, client client.Gr
 	tailOptions := NewTailOptionsForDeploy(deploy, since, verbose)
 	// blocking call to tail
 	err := TailUp(ctx, provider, project, deploy, tailOptions)
+	var errDeploymentFailed pkg.ErrDeploymentFailed
+	if errors.As(context.Cause(ctx), &errDeploymentFailed) {
+		return errDeploymentFailed
+	}
 	if !errors.Is(context.Cause(ctx), errCompleted) {
 		return err
 	}
-	return err
+
+	return nil
 }
 
 func NewTailOptionsForDeploy(deploy *defangv1.DeployResponse, since time.Time, verbose bool) TailOptions {

--- a/src/pkg/cli/composeUp.go
+++ b/src/pkg/cli/composeUp.go
@@ -8,8 +8,10 @@ import (
 
 	"github.com/DefangLabs/defang/src/pkg/cli/client"
 	"github.com/DefangLabs/defang/src/pkg/cli/compose"
+	"github.com/DefangLabs/defang/src/pkg/logs"
 	"github.com/DefangLabs/defang/src/pkg/term"
 	defangv1 "github.com/DefangLabs/defang/src/protos/io/defang/v1"
+	"github.com/bufbuild/connect-go"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -139,4 +141,54 @@ func ComposeUp(ctx context.Context, project *compose.Project, c client.FabricCli
 		}
 	}
 	return resp, project, nil
+}
+
+func TailUp(ctx context.Context, provider client.Provider, project *compose.Project, deploy *defangv1.DeployResponse, tailOptions TailOptions) error {
+	// show users the current streaming logs
+	tailSource := "all services"
+	if deploy.Etag != "" {
+		tailSource = "deployment ID " + deploy.Etag
+	}
+
+	term.Info("Tailing logs for", tailSource, "; press Ctrl+C to detach:")
+
+	if tailOptions.Etag == "" {
+		tailOptions.Etag = deploy.Etag
+	}
+	if tailOptions.Since.IsZero() {
+		tailOptions.Since = time.Now()
+	}
+	if tailOptions.LogType == logs.LogTypeUnspecified {
+		tailOptions.LogType = logs.LogTypeAll
+	}
+
+	err := Tail(ctx, provider, project.Name, tailOptions)
+	if err != nil {
+		term.Debug("Tail stopped with", err)
+
+		if connect.CodeOf(err) == connect.CodePermissionDenied {
+			// If tail fails because of missing permission, we wait for the deployment to finish
+			term.Warn("Unable to tail logs. Waiting for the deployment to finish.")
+			<-ctx.Done()
+			// Get the actual error from the context so we won't print "Error: missing tail permission"
+			err = context.Cause(ctx)
+		} else if !(errors.Is(ctx.Err(), context.Canceled) || errors.Is(ctx.Err(), context.DeadlineExceeded)) {
+			return err // any error other than cancelation
+		}
+
+		// The tail was canceled; check if it was because of deployment failure or explicit cancelation or wait-timeout reached
+		if errors.Is(context.Cause(ctx), context.Canceled) {
+			// Tail was canceled by the user before deployment completion/failure; show a warning and exit with an error
+			term.Warn("Deployment is not finished. Service(s) might not be running.")
+			return err
+		} else if errors.Is(context.Cause(ctx), context.DeadlineExceeded) {
+			// Tail was canceled when wait-timeout is reached; show a warning and exit with an error
+			term.Warn("Wait-timeout exceeded, detaching from logs. Deployment still in progress.")
+			return err
+		}
+
+		return err
+	}
+
+	return nil
 }

--- a/src/pkg/cli/composeUp.go
+++ b/src/pkg/cli/composeUp.go
@@ -216,19 +216,23 @@ func WaitAndTail(ctx context.Context, project *compose.Project, client client.Gr
 		}
 	}()
 
+	tailOptions := NewTailOptionsForDeploy(deploy, since, verbose)
 	// blocking call to tail
-	tailOptions := TailOptions{
+	err := TailUp(ctx, provider, project, deploy, tailOptions)
+	if !errors.Is(context.Cause(ctx), errCompleted) {
+		return err
+	}
+	return err
+}
+
+func NewTailOptionsForDeploy(deploy *defangv1.DeployResponse, since time.Time, verbose bool) TailOptions {
+	return TailOptions{
 		Etag:    deploy.Etag,
 		Since:   since,
 		Raw:     false,
 		Verbose: verbose,
 		LogType: logs.LogTypeAll,
 	}
-	err := TailUp(ctx, provider, project, deploy, tailOptions)
-	if !errors.Is(context.Cause(ctx), errCompleted) {
-		return err
-	}
-	return nil
 }
 
 func isManagedService(service compose.ServiceConfig) bool {

--- a/src/pkg/cli/composeUp.go
+++ b/src/pkg/cli/composeUp.go
@@ -172,8 +172,6 @@ func TailUp(ctx context.Context, provider client.Provider, project *compose.Proj
 			<-ctx.Done()
 			// Get the actual error from the context so we won't print "Error: missing tail permission"
 			err = context.Cause(ctx)
-		} else if !(errors.Is(ctx.Err(), context.Canceled) || errors.Is(ctx.Err(), context.DeadlineExceeded)) {
-			return err // any error other than cancelation
 		}
 
 		// The tail was canceled; check if it was because of deployment failure or explicit cancelation or wait-timeout reached

--- a/src/pkg/cli/composeUp_test.go
+++ b/src/pkg/cli/composeUp_test.go
@@ -88,3 +88,104 @@ func TestComposeUp(t *testing.T) {
 		}
 	}
 }
+
+func TestGetUnreferencedManagedResources(t *testing.T) {
+	t.Run("no services", func(t *testing.T) {
+		project := types.Services{}
+
+		managed, unmanaged := SplitManagedAndUnmanagedServices(project)
+		if len(managed) != 0 {
+			t.Errorf("Expected 0 managed resources, got %d (%v)", len(managed), managed)
+		}
+
+		if len(unmanaged) != 0 {
+			t.Errorf("Expected 0 unmanaged resources, got %d (%v)", len(unmanaged), unmanaged)
+		}
+	})
+
+	t.Run("one service all managed", func(t *testing.T) {
+		project := types.Services{
+			"service1": types.ServiceConfig{
+				Extensions: map[string]any{"x-defang-postgres": true},
+			},
+		}
+
+		managed, unmanaged := SplitManagedAndUnmanagedServices(project)
+		if len(managed) != 1 {
+			t.Errorf("Expected 1 managed resource, got %d (%v)", len(managed), managed)
+		}
+
+		if len(unmanaged) != 0 {
+			t.Errorf("Expected 0 unmanaged resource, got %d (%v)", len(unmanaged), unmanaged)
+		}
+	})
+
+	t.Run("one service unmanaged", func(t *testing.T) {
+		project := types.Services{
+			"service1": types.ServiceConfig{},
+		}
+
+		managed, unmanaged := SplitManagedAndUnmanagedServices(project)
+		if len(managed) != 0 {
+			t.Errorf("Expected 0 managed resource, got %d (%v)", len(managed), managed)
+		}
+
+		if len(unmanaged) != 1 {
+			t.Errorf("Expected 1 unmanaged resource, got %d (%v)", len(unmanaged), unmanaged)
+		}
+	})
+
+	t.Run("one service unmanaged, one service managed", func(t *testing.T) {
+		project := types.Services{
+			"service1": types.ServiceConfig{},
+			"service2": types.ServiceConfig{
+				Extensions: map[string]any{"x-defang-postgres": true},
+			},
+		}
+
+		managed, unmanaged := SplitManagedAndUnmanagedServices(project)
+		if len(managed) != 1 {
+			t.Errorf("Expected 1 managed resource, got %d (%v)", len(managed), managed)
+		}
+
+		if len(unmanaged) != 1 {
+			t.Errorf("Expected 1 unmanaged resource, got %d (%v)", len(unmanaged), unmanaged)
+		}
+	})
+
+	t.Run("two service two unmanaged", func(t *testing.T) {
+		project := types.Services{
+			"service1": types.ServiceConfig{},
+			"service2": types.ServiceConfig{},
+		}
+
+		managed, unmanaged := SplitManagedAndUnmanagedServices(project)
+		if len(managed) != 0 {
+			t.Errorf("Expected 0 managed resource, got %d (%v)", len(managed), managed)
+		}
+
+		if len(unmanaged) != 2 {
+			t.Errorf("Expected 2 unmanaged resource, got %d (%v)", len(unmanaged), unmanaged)
+		}
+	})
+
+	t.Run("one service two managed", func(t *testing.T) {
+		project := types.Services{
+			"service1": types.ServiceConfig{},
+			"service2": types.ServiceConfig{
+				Extensions: map[string]any{"x-defang-postgres": true},
+			},
+			"service3": types.ServiceConfig{
+				Extensions: map[string]any{"x-defang-redis": true},
+			},
+		}
+
+		managed, unmanaged := SplitManagedAndUnmanagedServices(project)
+		if len(managed) != 2 {
+			t.Errorf("Expected 2 managed resource, got %d (%v)", len(managed), managed)
+		}
+		if len(unmanaged) != 1 {
+			t.Errorf("Expected 1 unmanaged resource, got %d (%s)", len(unmanaged), unmanaged)
+		}
+	})
+}


### PR DESCRIPTION
## Description

This PR does the following:
1. factor out `cli.WaitAndTail` to encapsulate the logic for setting up a Tail stream for monitoring a deployment. That way, the new V1 Defang Pulumi Provider in https://github.com/DefangLabs/pulumi-defang/pull/54 can tail logs after initiating a deployment.
3. move the following helpers (and their tests) from the `command` package, to the `cli` package. This way, they are co-located with `cli.TailUp`:
  * `isManagedService`
  * `splitManagedAndUnmanagedServices`

## Linked Issues

https://github.com/DefangLabs/pulumi-defang/pull/54

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

