### PR TITLE
Ensure dirty revision builds

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -7,7 +7,7 @@ BINARY_NAME:=defang
 GOFLAGS:=-ldflags "-X main.version=$(VERSION)"
 GOSRC := $(shell find . -name '*.go')
 
-$(BINARY_NAME): $(PROTOS) $(GOSRC)
+$(BINARY_NAME): $(PROTOS) $(GOSRC) go.mod go.sum
 	go build -o $@ $(GOFLAGS) ./cmd/cli
 
 .PHONY: build

--- a/src/Makefile
+++ b/src/Makefile
@@ -6,7 +6,7 @@ PROTOS := protos/io/defang/v1/fabric.pb.go protos/io/defang/v1/defangv1connect/f
 BINARY_NAME:=defang
 GOFLAGS:=-ldflags "-X main.version=$(VERSION)"
 
-$(BINARY_NAME): test
+$(BINARY_NAME):
 	go build -o $@ $(GOFLAGS) ./cmd/cli
 
 .PHONY: protos
@@ -16,7 +16,7 @@ $(PROTOS) &: protos/io/defang/v1/fabric.proto buf.gen.yaml
 	buf generate protos
 
 .PHONY: install
-install: $(BINARY_NAME)
+install: $(BINARY_NAME) test
 	install $(BINARY_NAME) "${HOME}/.local/bin/"
 
 .PHONY: test

--- a/src/Makefile
+++ b/src/Makefile
@@ -5,9 +5,13 @@ PROTOS := protos/io/defang/v1/fabric.pb.go protos/io/defang/v1/defangv1connect/f
 
 BINARY_NAME:=defang
 GOFLAGS:=-ldflags "-X main.version=$(VERSION)"
+GOSRC := $(shell find . -name '*.go')
 
-$(BINARY_NAME):
+$(BINARY_NAME): $(PROTOS) $(GOSRC)
 	go build -o $@ $(GOFLAGS) ./cmd/cli
+
+.PHONY: build
+build: $(BINARY_NAME)
 
 .PHONY: protos
 protos: $(PROTOS)


### PR DESCRIPTION
## Description

I was trying to test the cli locally, but running `make -C src install` was not replacing the installed build. I was not making commits between each test, so the version number was staying the same.

This PR makes the following changes to the `src/Makefile`:
* the `$(BINARY_NAME)` target depends on all of the go source files.
* create a phony `build` target for convenience
* remove `test` dependency from `build` target to `install` target. Sometimes I want to run `make build` before committing to fixing broken tests.

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

