### PR TITLE
Print deployment results as a table

### DIFF
--- a/src/cmd/cli/command/cd.go
+++ b/src/cmd/cli/command/cd.go
@@ -200,9 +200,9 @@ var cdPreviewCmd = &cobra.Command{
 		}
 
 		tailOptions := cli.TailOptions{
-			Etag:    resp.Etag,
-			Verbose: verbose,
-			LogType: logs.LogTypeAll,
+			Deployment: resp.Etag,
+			Verbose:    verbose,
+			LogType:    logs.LogTypeAll,
 		}
 		return cli.Tail(cmd.Context(), provider, project.Name, tailOptions)
 	},

--- a/src/cmd/cli/command/commands.go
+++ b/src/cmd/cli/command/commands.go
@@ -897,7 +897,7 @@ var debugCmd = &cobra.Command{
 		}
 
 		debugConfig := cli.DebugConfig{
-			Etag:           deployment,
+			Deployment:     deployment,
 			FailedServices: args,
 			ModelId:        modelId,
 			Project:        project,
@@ -937,7 +937,7 @@ var deleteCmd = &cobra.Command{
 		}
 
 		since := time.Now()
-		etag, err := cli.Delete(cmd.Context(), projectName, client, provider, names...)
+		deployment, err := cli.Delete(cmd.Context(), projectName, client, provider, names...)
 		if err != nil {
 			if connect.CodeOf(err) == connect.CodeNotFound {
 				// Show a warning (not an error) if the service was not found
@@ -947,20 +947,20 @@ var deleteCmd = &cobra.Command{
 			return err
 		}
 
-		term.Info("Deleted service", names, "with deployment ID", etag)
+		term.Info("Deleted service", names, "with deployment ID", deployment)
 
 		if !tail {
-			printDefangHint("To track the update, do:", "tail --deployment "+etag)
+			printDefangHint("To track the update, do:", "tail --deployment "+deployment)
 			return nil
 		}
 
 		term.Info("Tailing logs for update; press Ctrl+C to detach:")
 
 		tailOptions := cli.TailOptions{
-			Etag:    etag,
-			LogType: logs.LogTypeAll,
-			Since:   since,
-			Verbose: verbose,
+			Deployment: deployment,
+			LogType:    logs.LogTypeAll,
+			Since:      since,
+			Verbose:    verbose,
 		}
 		return cli.Tail(cmd.Context(), provider, projectName, tailOptions)
 	},

--- a/src/cmd/cli/command/compose.go
+++ b/src/cmd/cli/command/compose.go
@@ -170,11 +170,11 @@ func makeComposeUpCmd() *cobra.Command {
 					// Tail got canceled because of deployment failure: prompt to show the debugger
 					term.Warn(errDeploymentFailed)
 					debugConfig := cli.DebugConfig{
-						Etag:     deploy.Etag,
-						ModelId:  modelId,
-						Project:  project,
-						Provider: provider,
-						Since:    since,
+						Deployment: deploy.Etag,
+						ModelId:    modelId,
+						Project:    project,
+						Provider:   provider,
+						Since:      since,
 					}
 					if errDeploymentFailed.Service != "" {
 						debugConfig.FailedServices = []string{errDeploymentFailed.Service}
@@ -292,7 +292,7 @@ func makeComposeDownCmd() *cobra.Command {
 			}
 
 			since := time.Now()
-			etag, err := cli.ComposeDown(cmd.Context(), projectName, client, provider, args...)
+			deployment, err := cli.ComposeDown(cmd.Context(), projectName, client, provider, args...)
 			if err != nil {
 				if connect.CodeOf(err) == connect.CodeNotFound {
 					// Show a warning (not an error) if the service was not found
@@ -302,10 +302,10 @@ func makeComposeDownCmd() *cobra.Command {
 				return err
 			}
 
-			term.Info("Deleted services, deployment ID", etag)
+			term.Info("Deleted services, deployment ID", deployment)
 
 			if detach {
-				printDefangHint("To track the update, do:", "tail --deployment "+etag)
+				printDefangHint("To track the update, do:", "tail --deployment "+deployment)
 				return nil
 			}
 
@@ -314,7 +314,7 @@ func makeComposeDownCmd() *cobra.Command {
 				{Service: "cd", Host: "pulumi", EventLog: "Update succeeded in "},
 			}
 			tailOptions := cli.TailOptions{
-				Etag:               etag,
+				Deployment:         deployment,
 				Since:              since,
 				EndEventDetectFunc: cli.CreateEndLogEventDetectFunc(endLogConditions),
 				Verbose:            verbose,
@@ -492,14 +492,14 @@ func makeComposeLogsCmd() *cobra.Command {
 			}
 
 			tailOptions := cli.TailOptions{
-				Etag:     deployment,
-				Filter:   filter,
-				LogType:  logType,
-				Raw:      raw,
-				Services: services,
-				Since:    sinceTs,
-				Until:    untilTs,
-				Verbose:  verbose,
+				Deployment: deployment,
+				Filter:     filter,
+				LogType:    logType,
+				Raw:        raw,
+				Services:   services,
+				Since:      sinceTs,
+				Until:      untilTs,
+				Verbose:    verbose,
 			}
 
 			return cli.Tail(cmd.Context(), provider, projectName, tailOptions)

--- a/src/cmd/cli/command/compose.go
+++ b/src/cmd/cli/command/compose.go
@@ -305,7 +305,7 @@ func makeComposeDownCmd() *cobra.Command {
 			term.Info("Deleted services, deployment ID", etag)
 
 			if detach {
-				printDefangHint("To track the update, do:", "tail --etag "+etag)
+				printDefangHint("To track the update, do:", "tail --deployment "+etag)
 				return nil
 			}
 
@@ -434,12 +434,17 @@ func makeComposeLogsCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var name, _ = cmd.Flags().GetString("name")
 			var etag, _ = cmd.Flags().GetString("etag")
+			var deployment, _ = cmd.Flags().GetString("deployment")
 			var raw, _ = cmd.Flags().GetBool("raw")
 			var since, _ = cmd.Flags().GetString("since")
 			var utc, _ = cmd.Flags().GetBool("utc")
 			var verbose, _ = cmd.Flags().GetBool("verbose")
 			var filter, _ = cmd.Flags().GetString("filter")
 			var until, _ = cmd.Flags().GetString("until")
+
+			if etag != "" && deployment == "" {
+				deployment = etag
+			}
 
 			if utc {
 				cli.EnableUTCMode()
@@ -487,7 +492,7 @@ func makeComposeLogsCmd() *cobra.Command {
 			}
 
 			tailOptions := cli.TailOptions{
-				Etag:     etag,
+				Etag:     deployment,
 				Filter:   filter,
 				LogType:  logType,
 				Raw:      raw,
@@ -503,6 +508,8 @@ func makeComposeLogsCmd() *cobra.Command {
 	logsCmd.Flags().StringP("name", "n", "", "name of the service (backwards compat)")
 	logsCmd.Flags().MarkHidden("name")
 	logsCmd.Flags().String("etag", "", "deployment ID (ETag) of the service")
+	logsCmd.Flags().MarkHidden("etag")
+	logsCmd.Flags().String("deployment", "", "deployment ID of the service")
 	logsCmd.Flags().Bool("follow", false, "follow log output") // NOTE: -f is already used by --file
 	logsCmd.Flags().MarkHidden("follow")                       // TODO: implement this
 	logsCmd.Flags().BoolP("raw", "r", false, "show raw (unparsed) logs")

--- a/src/cmd/cli/command/compose.go
+++ b/src/cmd/cli/command/compose.go
@@ -196,7 +196,10 @@ func makeComposeUpCmd() *cobra.Command {
 			}
 
 			// Print the current service states of the deployment
-			printServiceStatesAndEndpoints(deploy.Services)
+			err = printServiceStatesAndEndpoints(deploy.Services)
+			if err != nil {
+				return err
+			}
 
 			term.Info("Done.")
 			return nil

--- a/src/cmd/cli/command/deploymentinfo.go
+++ b/src/cmd/cli/command/deploymentinfo.go
@@ -23,7 +23,7 @@ func printPlaygroundPortalServiceURLs(serviceInfos []*defangv1.ServiceInfo) {
 }
 
 type ServiceTableItem struct {
-	Id         string `json:"Id"`
+	Deployment string `json:"Deployment"`
 	Status     string `json:"Status"`
 	Name       string `json:"Name"`
 	DomainName string `json:"DomainName"`
@@ -45,7 +45,7 @@ func printServiceStatesAndEndpoints(serviceInfos []*defangv1.ServiceInfo) error 
 			}
 		}
 		serviceTableItems = append(serviceTableItems, ServiceTableItem{
-			Id:         serviceInfo.Etag,
+			Deployment: serviceInfo.Etag,
 			Name:       serviceInfo.Service.Name,
 			Status:     serviceInfo.State.String(),
 			DomainName: domainname,
@@ -53,11 +53,9 @@ func printServiceStatesAndEndpoints(serviceInfos []*defangv1.ServiceInfo) error 
 		})
 	}
 
-	var attrs []string
+	attrs := []string{"Deployment", "Name", "Status", "Endpoints"}
 	if showDomainNameColumn {
-		attrs = []string{"Id", "Name", "Status", "Endpoints", "DomainName"}
-	} else {
-		attrs = []string{"Id", "Name", "Status", "Endpoints"}
+		attrs = append(attrs, "DomainName")
 	}
 
 	err := term.Table(serviceTableItems, attrs)

--- a/src/cmd/cli/command/deploymentinfo.go
+++ b/src/cmd/cli/command/deploymentinfo.go
@@ -24,7 +24,7 @@ func printPlaygroundPortalServiceURLs(serviceInfos []*defangv1.ServiceInfo) {
 
 type ServiceTableItem struct {
 	Id         string `json:"Id"`
-	State      string `json:"State"`
+	Status     string `json:"Status"`
 	Name       string `json:"Name"`
 	DomainName string `json:"DomainName"`
 	Endpoints  string `json:"Endpoints"`
@@ -47,7 +47,7 @@ func printServiceStatesAndEndpoints(serviceInfos []*defangv1.ServiceInfo) error 
 		serviceTableItems = append(serviceTableItems, ServiceTableItem{
 			Id:         serviceInfo.Etag,
 			Name:       serviceInfo.Service.Name,
-			State:      serviceInfo.State.String(),
+			Status:     serviceInfo.State.String(),
 			DomainName: domainname,
 			Endpoints:  strings.Join(serviceInfo.Endpoints, ", "),
 		})
@@ -55,9 +55,9 @@ func printServiceStatesAndEndpoints(serviceInfos []*defangv1.ServiceInfo) error 
 
 	var attrs []string
 	if showDomainNameColumn {
-		attrs = []string{"Id", "Name", "State", "Endpoints", "DomainName"}
+		attrs = []string{"Id", "Name", "Status", "Endpoints", "DomainName"}
 	} else {
-		attrs = []string{"Id", "Name", "State", "Endpoints"}
+		attrs = []string{"Id", "Name", "Status", "Endpoints"}
 	}
 
 	err := term.Table(serviceTableItems, attrs)

--- a/src/cmd/cli/command/deploymentinfo_test.go
+++ b/src/cmd/cli/command/deploymentinfo_test.go
@@ -59,7 +59,7 @@ func TestPrintServiceStatesAndEndpoints(t *testing.T) {
 				"service1.internal",
 			},
 		}})
-	const expectedOutput = `Id  Name      State          Endpoints
+	const expectedOutput = `Id  Name      Status         Endpoints
     service1  NOT_SPECIFIED  example.com, service1.internal
 `
 	receivedLines := strings.Split(stdout.String(), "\n")
@@ -103,7 +103,7 @@ func TestPrintServiceStatesAndEndpointsAndDomainname(t *testing.T) {
 			},
 		}})
 	expectedLines := []string{
-		"Id  Name      State          Endpoints                       DomainName",
+		"Id  Name      Status         Endpoints                       DomainName",
 		"    service1  NOT_SPECIFIED  example.com, service1.internal  https://example.com",
 		" * Run `defang cert generate` to get a TLS certificate for your service(s)",
 		"",

--- a/src/cmd/cli/command/deploymentinfo_test.go
+++ b/src/cmd/cli/command/deploymentinfo_test.go
@@ -3,6 +3,7 @@ package command
 import (
 	"bytes"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/DefangLabs/defang/src/pkg/cli"
@@ -43,7 +44,7 @@ func TestPrintServiceStatesAndEndpoints(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	term.DefaultTerm = term.NewTerm(os.Stdin, &stdout, &stderr)
 
-	printServiceStatesAndEndpoints([]*defangv1.ServiceInfo{
+	_ = printServiceStatesAndEndpoints([]*defangv1.ServiceInfo{
 		{
 			Service: &defangv1.Service{
 				Name: "service1",
@@ -58,11 +59,20 @@ func TestPrintServiceStatesAndEndpoints(t *testing.T) {
 				"service1.internal",
 			},
 		}})
-	const want = ` * Service service1 has status UNKNOWN and will be available at:
-   - https://example.com
-   - service1.internal
+	const expectedOutput = `Id  Name      State          DomainName
+    service1  NOT_SPECIFIED
 `
-	if got := stdout.String(); got != want {
-		t.Errorf("got %q, want %q", got, want)
+	receivedLines := strings.Split(stdout.String(), "\n")
+	expectedLines := strings.Split(expectedOutput, "\n")
+
+	if len(receivedLines) != len(expectedLines) {
+		t.Errorf("Expected %v lines, received %v", len(expectedLines), len(receivedLines))
+	}
+
+	for i, receivedLine := range receivedLines {
+		receivedLine = strings.TrimRight(receivedLine, " ")
+		if receivedLine != expectedLines[i] {
+			t.Errorf("\n-%v\n+%v", expectedLines[i], receivedLine)
+		}
 	}
 }

--- a/src/cmd/cli/command/deploymentinfo_test.go
+++ b/src/cmd/cli/command/deploymentinfo_test.go
@@ -59,8 +59,8 @@ func TestPrintServiceStatesAndEndpoints(t *testing.T) {
 				"service1.internal",
 			},
 		}})
-	const expectedOutput = `Id  Name      Status         Endpoints
-    service1  NOT_SPECIFIED  example.com, service1.internal
+	const expectedOutput = `Deployment  Name      Status         Endpoints
+            service1  NOT_SPECIFIED  example.com, service1.internal
 `
 	receivedLines := strings.Split(stdout.String(), "\n")
 	expectedLines := strings.Split(expectedOutput, "\n")
@@ -103,8 +103,8 @@ func TestPrintServiceStatesAndEndpointsAndDomainname(t *testing.T) {
 			},
 		}})
 	expectedLines := []string{
-		"Id  Name      Status         Endpoints                       DomainName",
-		"    service1  NOT_SPECIFIED  example.com, service1.internal  https://example.com",
+		"Deployment  Name      Status         Endpoints                       DomainName",
+		"            service1  NOT_SPECIFIED  example.com, service1.internal  https://example.com",
 		" * Run `defang cert generate` to get a TLS certificate for your service(s)",
 		"",
 	}

--- a/src/cmd/cli/command/deploymentinfo_test.go
+++ b/src/cmd/cli/command/deploymentinfo_test.go
@@ -59,11 +59,56 @@ func TestPrintServiceStatesAndEndpoints(t *testing.T) {
 				"service1.internal",
 			},
 		}})
-	const expectedOutput = `Id  Name      State          DomainName
-    service1  NOT_SPECIFIED
+	const expectedOutput = `Id  Name      State          Endpoints
+    service1  NOT_SPECIFIED  example.com, service1.internal
 `
 	receivedLines := strings.Split(stdout.String(), "\n")
 	expectedLines := strings.Split(expectedOutput, "\n")
+
+	if len(receivedLines) != len(expectedLines) {
+		t.Errorf("Expected %v lines, received %v", len(expectedLines), len(receivedLines))
+	}
+
+	for i, receivedLine := range receivedLines {
+		receivedLine = strings.TrimRight(receivedLine, " ")
+		if receivedLine != expectedLines[i] {
+			t.Errorf("\n-%v\n+%v", expectedLines[i], receivedLine)
+		}
+	}
+}
+
+func TestPrintServiceStatesAndEndpointsAndDomainname(t *testing.T) {
+	defaultTerm := term.DefaultTerm
+	t.Cleanup(func() {
+		term.DefaultTerm = defaultTerm
+	})
+
+	var stdout, stderr bytes.Buffer
+	term.DefaultTerm = term.NewTerm(os.Stdin, &stdout, &stderr)
+
+	_ = printServiceStatesAndEndpoints([]*defangv1.ServiceInfo{
+		{
+			Service: &defangv1.Service{
+				Name: "service1",
+				Ports: []*defangv1.Port{
+					{Mode: defangv1.Mode_INGRESS},
+					{Mode: defangv1.Mode_HOST},
+				},
+			},
+			Status:     "UNKNOWN",
+			Domainname: "example.com",
+			Endpoints: []string{
+				"example.com",
+				"service1.internal",
+			},
+		}})
+	expectedLines := []string{
+		"Id  Name      State          Endpoints                       DomainName",
+		"    service1  NOT_SPECIFIED  example.com, service1.internal  https://example.com",
+		" * Run `defang cert generate` to get a TLS certificate for your service(s)",
+		"",
+	}
+	receivedLines := strings.Split(stdout.String(), "\n")
 
 	if len(receivedLines) != len(expectedLines) {
 		t.Errorf("Expected %v lines, received %v", len(expectedLines), len(receivedLines))

--- a/src/pkg/cli/bootstrap.go
+++ b/src/pkg/cli/bootstrap.go
@@ -23,7 +23,7 @@ func BootstrapCommand(ctx context.Context, projectName string, verbose bool, p c
 		return err
 	}
 
-	return tail(ctx, p, projectName, TailOptions{Etag: etag, Since: since, LogType: logs.LogTypeBuild, Verbose: verbose})
+	return tail(ctx, p, projectName, TailOptions{Deployment: etag, Since: since, LogType: logs.LogTypeBuild, Verbose: verbose})
 }
 
 func SplitProjectStack(name string) (projectName string, stackName string) {

--- a/src/pkg/cli/composeUp.go
+++ b/src/pkg/cli/composeUp.go
@@ -145,8 +145,8 @@ func ComposeUp(ctx context.Context, project *compose.Project, c client.FabricCli
 }
 
 func TailUp(ctx context.Context, provider client.Provider, project *compose.Project, deploy *defangv1.DeployResponse, tailOptions TailOptions) error {
-	if tailOptions.Etag == "" {
-		tailOptions.Etag = deploy.Etag
+	if tailOptions.Deployment == "" {
+		tailOptions.Deployment = deploy.Etag
 	}
 	if tailOptions.Since.IsZero() {
 		tailOptions.Since = time.Now()
@@ -232,11 +232,11 @@ func WaitAndTail(ctx context.Context, project *compose.Project, client client.Fa
 
 func NewTailOptionsForDeploy(deploy *defangv1.DeployResponse, since time.Time, verbose bool) TailOptions {
 	return TailOptions{
-		Etag:    deploy.Etag,
-		Since:   since,
-		Raw:     false,
-		Verbose: verbose,
-		LogType: logs.LogTypeAll,
+		Deployment: deploy.Etag,
+		Since:      since,
+		Raw:        false,
+		Verbose:    verbose,
+		LogType:    logs.LogTypeAll,
 	}
 }
 

--- a/src/pkg/cli/debug.go
+++ b/src/pkg/cli/debug.go
@@ -32,7 +32,7 @@ var (
 )
 
 type DebugConfig struct {
-	Etag           types.ETag
+	Deployment     types.ETag
 	FailedServices []string
 	ModelId        string
 	Project        *compose.Project
@@ -43,8 +43,8 @@ type DebugConfig struct {
 
 func (dc DebugConfig) String() string {
 	cmd := "debug"
-	if dc.Etag != "" {
-		cmd += " --deployment=" + dc.Etag
+	if dc.Deployment != "" {
+		cmd += " --deployment=" + dc.Deployment
 	}
 	if dc.ModelId != "" {
 		cmd += " --model=" + dc.ModelId
@@ -82,21 +82,21 @@ func interactiveDebug(ctx context.Context, client client.FabricClient, debugConf
 		Message: "Would you like to debug the deployment with AI?",
 		Help:    "This will send logs and artifacts to our backend and attempt to diagnose the issue and provide a solution.",
 	}, &aiDebug, survey.WithStdio(term.DefaultTerm.Stdio())); err != nil {
-		track.Evt("Debug Prompt Failed", P("etag", debugConfig.Etag), P("reason", err), P("loadErr", loadError))
+		track.Evt("Debug Prompt Failed", P("etag", debugConfig.Deployment), P("reason", err), P("loadErr", loadError))
 		return err
 	} else if !aiDebug {
-		track.Evt("Debug Prompt Skipped", P("etag", debugConfig.Etag), P("loadErr", loadError))
+		track.Evt("Debug Prompt Skipped", P("etag", debugConfig.Deployment), P("loadErr", loadError))
 		return ErrDebugSkipped
 	}
 
-	track.Evt("Debug Prompt Accepted", P("etag", debugConfig.Etag), P("loadErr", loadError))
+	track.Evt("Debug Prompt Accepted", P("etag", debugConfig.Deployment), P("loadErr", loadError))
 
 	if loadError != nil {
 		if err := debugComposeFileLoadError(ctx, client, debugConfig.Project, loadError); err != nil {
 			term.Warnf("Failed to debug compose file load: %v", err)
 			return err
 		}
-	} else if debugConfig.Etag != "" {
+	} else if debugConfig.Deployment != "" {
 		if err := DebugDeployment(ctx, client, debugConfig); err != nil {
 			term.Warnf("Failed to debug deployment: %v", err)
 			return err
@@ -110,15 +110,15 @@ func interactiveDebug(ctx context.Context, client client.FabricClient, debugConf
 		Message: "Was the debugging helpful?",
 		Help:    "Please provide feedback to help us improve the debugging experience.",
 	}, &goodBad); err != nil {
-		track.Evt("Debug Feedback Prompt Failed", P("etag", debugConfig.Etag), P("reason", err), P("loadErr", loadError))
+		track.Evt("Debug Feedback Prompt Failed", P("etag", debugConfig.Deployment), P("reason", err), P("loadErr", loadError))
 	} else {
-		track.Evt("Debug Feedback Prompt Answered", P("etag", debugConfig.Etag), P("feedback", goodBad), P("loadErr", loadError))
+		track.Evt("Debug Feedback Prompt Answered", P("etag", debugConfig.Deployment), P("feedback", goodBad), P("loadErr", loadError))
 	}
 	return nil
 }
 
 func DebugDeployment(ctx context.Context, client client.FabricClient, debugConfig DebugConfig) error {
-	term.Debugf("Invoking AI debugger for deployment %q", debugConfig.Etag)
+	term.Debugf("Invoking AI debugger for deployment %q", debugConfig.Deployment)
 
 	files := findMatchingProjectFiles(debugConfig.Project, debugConfig.FailedServices)
 
@@ -135,7 +135,7 @@ func DebugDeployment(ctx context.Context, client client.FabricClient, debugConfi
 		untilTs = timestamppb.New(until)
 	}
 	req := defangv1.DebugRequest{
-		Etag:     debugConfig.Etag,
+		Etag:     debugConfig.Deployment,
 		Files:    files,
 		ModelId:  debugConfig.ModelId,
 		Project:  debugConfig.Project.Name,

--- a/src/pkg/cli/debug.go
+++ b/src/pkg/cli/debug.go
@@ -44,7 +44,7 @@ type DebugConfig struct {
 func (dc DebugConfig) String() string {
 	cmd := "debug"
 	if dc.Etag != "" {
-		cmd += " --etag=" + dc.Etag
+		cmd += " --deployment=" + dc.Etag
 	}
 	if dc.ModelId != "" {
 		cmd += " --model=" + dc.ModelId

--- a/src/pkg/cli/debug_test.go
+++ b/src/pkg/cli/debug_test.go
@@ -64,7 +64,7 @@ func TestQueryHasProject(t *testing.T) {
 
 	var mockClient = MockDebugFabricClient{}
 	var debugConfig = DebugConfig{
-		Etag:           "etag",
+		Deployment:     "etag",
 		FailedServices: []string{"service"},
 		Project:        project,
 		Provider:       MustHaveProjectNameQueryProvider{},

--- a/src/pkg/cli/deploymentsList.go
+++ b/src/pkg/cli/deploymentsList.go
@@ -10,7 +10,7 @@ import (
 )
 
 type PrintDeployment struct {
-	Id         string
+	Deployment string
 	Provider   string
 	DeployedAt string
 }
@@ -33,11 +33,11 @@ func DeploymentsList(ctx context.Context, projectName string, client client.Grpc
 	deployments := make([]PrintDeployment, numDeployments)
 	for i, d := range response.Deployments {
 		deployments[i] = PrintDeployment{
-			Id:         d.Id,
+			Deployment: d.Id,
 			Provider:   d.Provider,
 			DeployedAt: d.Timestamp.AsTime().Format(time.RFC3339),
 		}
 	}
 
-	return term.Table(deployments, []string{"Id", "Provider", "DeployedAt"})
+	return term.Table(deployments, []string{"Deployment", "Provider", "DeployedAt"})
 }

--- a/src/pkg/cli/deploymentsList_test.go
+++ b/src/pkg/cli/deploymentsList_test.go
@@ -73,8 +73,8 @@ func TestDeploymentsList(t *testing.T) {
 		if err != nil {
 			t.Fatalf("DeploymentsList() error = %v", err)
 		}
-		expectedOutput := `Id      Provider    DeployedAt
-a1b2c3  playground  ` + timestamppb.Now().AsTime().Format("2006-01-02T15:04:05Z07:00") + `
+		expectedOutput := `Deployment  Provider    DeployedAt
+a1b2c3      playground  ` + timestamppb.Now().AsTime().Format("2006-01-02T15:04:05Z07:00") + `
 `
 
 		receivedLines := strings.Split(stdout.String(), "\n")

--- a/src/pkg/cli/getServices.go
+++ b/src/pkg/cli/getServices.go
@@ -62,5 +62,5 @@ func GetServices(ctx context.Context, projectName string, provider client.Provid
 		servicesResponse.Services[i] = nil
 	}
 
-	return term.Table(printServices, []string{"Service", "Deployment", "PublicFqdn", "PrivateFqdn", "Status"})
+	return term.Table(printServices, []string{"Service", "Deployment", "PublicFqdn", "PrivateFqdn", "State"})
 }

--- a/src/pkg/cli/getServices.go
+++ b/src/pkg/cli/getServices.go
@@ -62,5 +62,5 @@ func GetServices(ctx context.Context, projectName string, provider client.Provid
 		servicesResponse.Services[i] = nil
 	}
 
-	return term.Table(printServices, []string{"Service", "Deployment", "PublicFqdn", "PrivateFqdn", "State"})
+	return term.Table(printServices, []string{"Service", "Deployment", "PublicFqdn", "PrivateFqdn", "Status"})
 }

--- a/src/pkg/cli/getServices.go
+++ b/src/pkg/cli/getServices.go
@@ -21,6 +21,7 @@ func (e ErrNoServices) Error() string {
 
 type printService struct {
 	Service string
+	ID      string
 	*defangv1.ServiceInfo
 }
 
@@ -55,10 +56,11 @@ func GetServices(ctx context.Context, projectName string, provider client.Provid
 	for i, si := range servicesResponse.Services {
 		printServices[i] = printService{
 			Service:     si.Service.Name,
+			ID:          si.Etag,
 			ServiceInfo: si,
 		}
 		servicesResponse.Services[i] = nil
 	}
 
-	return term.Table(printServices, []string{"Service", "Etag", "PublicFqdn", "PrivateFqdn", "Status"})
+	return term.Table(printServices, []string{"Service", "ID", "PublicFqdn", "PrivateFqdn", "Status"})
 }

--- a/src/pkg/cli/getServices.go
+++ b/src/pkg/cli/getServices.go
@@ -20,8 +20,8 @@ func (e ErrNoServices) Error() string {
 }
 
 type printService struct {
-	Service string
-	ID      string
+	Service    string
+	Deployment string
 	*defangv1.ServiceInfo
 }
 
@@ -56,11 +56,11 @@ func GetServices(ctx context.Context, projectName string, provider client.Provid
 	for i, si := range servicesResponse.Services {
 		printServices[i] = printService{
 			Service:     si.Service.Name,
-			ID:          si.Etag,
+			Deployment:  si.Etag,
 			ServiceInfo: si,
 		}
 		servicesResponse.Services[i] = nil
 	}
 
-	return term.Table(printServices, []string{"Service", "ID", "PublicFqdn", "PrivateFqdn", "Status"})
+	return term.Table(printServices, []string{"Service", "Deployment", "PublicFqdn", "PrivateFqdn", "Status"})
 }

--- a/src/pkg/cli/getServices_test.go
+++ b/src/pkg/cli/getServices_test.go
@@ -35,10 +35,10 @@ func (g *mockGetServicesHandler) GetServices(ctx context.Context, req *connect.R
 				Service: &defangv1.Service{
 					Name: "foo",
 				},
+				State:       defangv1.ServiceState_BUILD_ACTIVATING,
 				Endpoints:   []string{},
 				Project:     "test",
 				Etag:        "a1b2c3",
-				Status:      "UNKNOWN",
 				PublicFqdn:  "test-foo.prod1.defang.dev",
 				PrivateFqdn: "",
 				CreatedAt:   timestamppb.New(mockCreatedAt),
@@ -82,8 +82,8 @@ func TestGetServices(t *testing.T) {
 		if err != nil {
 			t.Fatalf("GetServices() error = %v", err)
 		}
-		expectedOutput := `Service  Deployment  PublicFqdn                 PrivateFqdn  Status
-foo      a1b2c3      test-foo.prod1.defang.dev               UNKNOWN
+		expectedOutput := `Service  Deployment  PublicFqdn                 PrivateFqdn  State
+foo      a1b2c3      test-foo.prod1.defang.dev               BUILD_ACTIVATING
 `
 
 		receivedLines := strings.Split(stdout.String(), "\n")
@@ -125,7 +125,7 @@ foo      a1b2c3      test-foo.prod1.defang.dev               UNKNOWN
 			"      publicFqdn: test-foo.prod1.defang.dev\n" +
 			"      service:\n" +
 			"        name: foo\n" +
-			"      status: UNKNOWN\n\n"
+			"      state: BUILD_ACTIVATING\n\n"
 
 		receivedLines := stdout.String()
 		expectedLines := expectedOutput

--- a/src/pkg/cli/getServices_test.go
+++ b/src/pkg/cli/getServices_test.go
@@ -35,10 +35,10 @@ func (g *mockGetServicesHandler) GetServices(ctx context.Context, req *connect.R
 				Service: &defangv1.Service{
 					Name: "foo",
 				},
-				State:       defangv1.ServiceState_BUILD_ACTIVATING,
 				Endpoints:   []string{},
 				Project:     "test",
 				Etag:        "a1b2c3",
+				Status:      "UNKNOWN",
 				PublicFqdn:  "test-foo.prod1.defang.dev",
 				PrivateFqdn: "",
 				CreatedAt:   timestamppb.New(mockCreatedAt),
@@ -82,8 +82,8 @@ func TestGetServices(t *testing.T) {
 		if err != nil {
 			t.Fatalf("GetServices() error = %v", err)
 		}
-		expectedOutput := `Service  Deployment  PublicFqdn                 PrivateFqdn  State
-foo      a1b2c3      test-foo.prod1.defang.dev               BUILD_ACTIVATING
+		expectedOutput := `Service  Deployment  PublicFqdn                 PrivateFqdn  Status
+foo      a1b2c3      test-foo.prod1.defang.dev               UNKNOWN
 `
 
 		receivedLines := strings.Split(stdout.String(), "\n")
@@ -125,7 +125,7 @@ foo      a1b2c3      test-foo.prod1.defang.dev               BUILD_ACTIVATING
 			"      publicFqdn: test-foo.prod1.defang.dev\n" +
 			"      service:\n" +
 			"        name: foo\n" +
-			"      state: BUILD_ACTIVATING\n\n"
+			"      status: UNKNOWN\n\n"
 
 		receivedLines := stdout.String()
 		expectedLines := expectedOutput

--- a/src/pkg/cli/getServices_test.go
+++ b/src/pkg/cli/getServices_test.go
@@ -82,7 +82,7 @@ func TestGetServices(t *testing.T) {
 		if err != nil {
 			t.Fatalf("GetServices() error = %v", err)
 		}
-		expectedOutput := `Service  Etag    PublicFqdn                 PrivateFqdn  Status
+		expectedOutput := `Service  ID      PublicFqdn                 PrivateFqdn  Status
 foo      a1b2c3  test-foo.prod1.defang.dev               UNKNOWN
 `
 

--- a/src/pkg/cli/getServices_test.go
+++ b/src/pkg/cli/getServices_test.go
@@ -82,8 +82,8 @@ func TestGetServices(t *testing.T) {
 		if err != nil {
 			t.Fatalf("GetServices() error = %v", err)
 		}
-		expectedOutput := `Service  ID      PublicFqdn                 PrivateFqdn  Status
-foo      a1b2c3  test-foo.prod1.defang.dev               UNKNOWN
+		expectedOutput := `Service  Deployment  PublicFqdn                 PrivateFqdn  Status
+foo      a1b2c3      test-foo.prod1.defang.dev               UNKNOWN
 `
 
 		receivedLines := strings.Split(stdout.String(), "\n")

--- a/src/pkg/cli/tail.go
+++ b/src/pkg/cli/tail.go
@@ -46,7 +46,7 @@ type TailDetectStopEventFunc func(services []string, host string, eventlog strin
 
 type TailOptions struct {
 	EndEventDetectFunc TailDetectStopEventFunc // Deprecated: use Subscribe instead #851
-	Etag               types.ETag
+	Deployment         types.ETag
 	Filter             string
 	LogType            logs.LogType
 	Raw                bool
@@ -64,8 +64,8 @@ func (to TailOptions) String() string {
 	} else {
 		cmd = "logs" + cmd + " --until=" + to.Until.UTC().Format(time.RFC3339Nano)
 	}
-	if to.Etag != "" {
-		cmd += " --deployment=" + to.Etag
+	if to.Deployment != "" {
+		cmd += " --deployment=" + to.Deployment
 	}
 	if to.Raw {
 		cmd += " --raw"
@@ -216,7 +216,7 @@ func tail(ctx context.Context, provider client.Provider, projectName string, opt
 	}
 
 	tailRequest := &defangv1.TailRequest{
-		Etag:     options.Etag,
+		Etag:     options.Deployment,
 		LogType:  uint32(options.LogType),
 		Pattern:  options.Filter,
 		Project:  projectName,
@@ -379,7 +379,7 @@ func tail(ctx context.Context, provider client.Provider, projectName string, opt
 			for i, line := range strings.Split(trimmed, "\n") {
 				if i == 0 {
 					prefixLen, _ = buf.Printc(tsColor, tsString, " ")
-					if options.Etag == "" {
+					if options.Deployment == "" {
 						l, _ := buf.Printc(termenv.ANSIYellow, etag, " ")
 						prefixLen += l
 					}

--- a/src/pkg/cli/tail.go
+++ b/src/pkg/cli/tail.go
@@ -65,7 +65,7 @@ func (to TailOptions) String() string {
 		cmd = "logs" + cmd + " --until=" + to.Until.UTC().Format(time.RFC3339Nano)
 	}
 	if to.Etag != "" {
-		cmd += " --etag=" + to.Etag
+		cmd += " --deployment=" + to.Etag
 	}
 	if to.Raw {
 		cmd += " --raw"


### PR DESCRIPTION
## Description

Use `term.Table` to print deployed services with their id, name, status, endpoints, and domain names.

## Linked Issues


## Checklist

- [x] I have performed a self-review of my code
- [x] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

