### PR TITLE
add GetProjectUpdate to Provider interface

### DIFF
--- a/src/pkg/cli/client/playground.go
+++ b/src/pkg/cli/client/playground.go
@@ -25,6 +25,10 @@ func (g *PlaygroundProvider) Preview(ctx context.Context, req *defangv1.DeployRe
 	return nil, errors.New("the preview command is not valid for the Defang playground; did you forget --provider?")
 }
 
+func (g *PlaygroundProvider) GetProjectUpdate(context.Context, string) (*defangv1.ProjectUpdate, error) {
+	return nil, errors.New("the project update command is not valid for the Defang playground; did you forget --provider?")
+}
+
 func (g *PlaygroundProvider) GetService(ctx context.Context, req *defangv1.GetRequest) (*defangv1.ServiceInfo, error) {
 	return getMsg(g.GetController().Get(ctx, connect.NewRequest(req)))
 }

--- a/src/pkg/cli/client/provider.go
+++ b/src/pkg/cli/client/provider.go
@@ -131,6 +131,7 @@ type Provider interface {
 	DelayBeforeRetry(context.Context) error
 	Destroy(context.Context, *defangv1.DestroyRequest) (types.ETag, error)
 	Follow(context.Context, *defangv1.TailRequest) (ServerStream[defangv1.TailResponse], error)
+	GetProjectUpdate(context.Context, string) (*defangv1.ProjectUpdate, error)
 	GetService(context.Context, *defangv1.GetRequest) (*defangv1.ServiceInfo, error)
 	GetServices(context.Context, *defangv1.GetServicesRequest) (*defangv1.GetServicesResponse, error)
 	ListConfig(context.Context, *defangv1.ListConfigsRequest) (*defangv1.Secrets, error)

--- a/src/pkg/cli/composeUp.go
+++ b/src/pkg/cli/composeUp.go
@@ -185,7 +185,7 @@ func TailUp(ctx context.Context, provider client.Provider, project *compose.Proj
 	return nil
 }
 
-func WaitAndTail(ctx context.Context, project *compose.Project, client client.GrpcClient, provider client.Provider, deploy *defangv1.DeployResponse, waitTimeout time.Duration, since time.Time, verbose bool) error {
+func WaitAndTail(ctx context.Context, project *compose.Project, client client.FabricClient, provider client.Provider, deploy *defangv1.DeployResponse, waitTimeout time.Duration, since time.Time, verbose bool) error {
 	ctx, cancelTail := context.WithCancelCause(ctx)
 	defer cancelTail(nil) // to cancel WaitServiceState and clean-up context
 


### PR DESCRIPTION
## Description

The new pulumi provider needs to be able to call `GetProjectUpdate` on the Provider client, so this PR adds that method to the public interface. It is not implemented for playground—only for BYOC providers.

## Linked Issues

https://github.com/DefangLabs/pulumi-defang/pull/54

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

