### PR TITLE
Configure VSCode so that golangci-lint warnings are visible inline

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "go.lintTool": "golangci-lint"
+}


### PR DESCRIPTION
## Description

This PR configures vscode to use `golangci-lint` to present lint warnings inline. We already use `golangci-lint` in git hooks, so adding this configuration will further "shift left" these lint warnings.
