### PR TITLE
Add `--random` flag for generating random config values

### DIFF
--- a/src/cmd/cli/command/commands.go
+++ b/src/cmd/cli/command/commands.go
@@ -752,20 +752,9 @@ var configSetCmd = &cobra.Command{
 			// Trim the newline at the end because single line values are common
 			value = strings.TrimSuffix(string(bytes), "\n")
 		} else if random {
-			// Prompt to generate and set a random value for config
-			var wantRandomConfig bool
-			if err := survey.AskOne(&survey.Confirm{
-				Message: fmt.Sprintf("Set a randomly generated base64 value for %q?", name),
-			}, &wantRandomConfig, survey.WithStdio(term.DefaultTerm.Stdio())); err != nil {
-				return err
-			}
-			if wantRandomConfig {
-				value = CreateRandomConfigValue()
-				term.Info("Generated random value: " + value)
-			} else {
-				term.Info("No changes made to", name)
-				return nil
-			}
+			// Generate a random value for the config
+			value = CreateRandomConfigValue()
+			term.Info("Generated random value: " + value)
 		} else {
 			// Prompt for sensitive value
 			var sensitivePrompt = &survey.Password{

--- a/src/cmd/cli/command/commands.go
+++ b/src/cmd/cli/command/commands.go
@@ -751,33 +751,31 @@ var configSetCmd = &cobra.Command{
 			}
 			// Trim the newline at the end because single line values are common
 			value = strings.TrimSuffix(string(bytes), "\n")
-		} else {
-			if random {
-				// Prompt to generate and set a random value for config
-				var wantRandomConfig bool
-				if err := survey.AskOne(&survey.Confirm{
-					Message: fmt.Sprintf("Set a randomly generated base64 value for %q?", name),
-				}, &wantRandomConfig, survey.WithStdio(term.DefaultTerm.Stdio())); err != nil {
-					return err
-				}
-				if wantRandomConfig {
-					value = CreateRandomConfigValue()
-					term.Info("Generated random value: " + value)
-				} else {
-					term.Info("No changes made to", name)
-					return nil
-				}
+		} else if random {
+			// Prompt to generate and set a random value for config
+			var wantRandomConfig bool
+			if err := survey.AskOne(&survey.Confirm{
+				Message: fmt.Sprintf("Set a randomly generated base64 value for %q?", name),
+			}, &wantRandomConfig, survey.WithStdio(term.DefaultTerm.Stdio())); err != nil {
+				return err
+			}
+			if wantRandomConfig {
+				value = CreateRandomConfigValue()
+				term.Info("Generated random value: " + value)
 			} else {
-				// Prompt for sensitive value
-				var sensitivePrompt = &survey.Password{
-					Message: fmt.Sprintf("Enter value for %q:", name),
-					Help:    "The value will be stored securely and cannot be retrieved later.",
-				}
+				term.Info("No changes made to", name)
+				return nil
+			}
+		} else {
+			// Prompt for sensitive value
+			var sensitivePrompt = &survey.Password{
+				Message: fmt.Sprintf("Enter value for %q:", name),
+				Help:    "The value will be stored securely and cannot be retrieved later.",
+			}
 
-				err := survey.AskOne(sensitivePrompt, &value, survey.WithStdio(term.DefaultTerm.Stdio()))
-				if err != nil {
-					return err
-				}
+			err := survey.AskOne(sensitivePrompt, &value, survey.WithStdio(term.DefaultTerm.Stdio()))
+			if err != nil {
+				return err
 			}
 		}
 

--- a/src/cmd/cli/command/configrandom.go
+++ b/src/cmd/cli/command/configrandom.go
@@ -1,0 +1,17 @@
+package command
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"regexp"
+)
+
+func CreateRandomConfigValue() string {
+	// Note that no error handling is necessary, as Read always succeeds.
+	key := make([]byte, 32)
+	rand.Read(key)
+	str := base64.StdEncoding.EncodeToString(key)
+	re := regexp.MustCompile("[+/=]")
+	str = re.ReplaceAllString(str, "")
+	return str
+}

--- a/src/cmd/cli/command/configrandom_test.go
+++ b/src/cmd/cli/command/configrandom_test.go
@@ -1,0 +1,57 @@
+package command
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/DefangLabs/secret-detector/pkg/scanner"
+)
+
+func TestCreateRandomConfigValue(t *testing.T) {
+	// create the scanner with specific detectors
+	// the '3' is the entropy threshold value (0 = low entropy, 4 = high entropy)
+	jsonCfg := `{
+		"detectors": ["high_entropy_string"],
+		"detectors_configs": {"high_entropy_string": ["3"]}
+		}`
+	cfg, err := scanner.NewConfigFromJson(strings.NewReader(jsonCfg))
+	if err != nil {
+		t.Fatalf("Failed to make a config detector: " + err.Error())
+	}
+	scannerClient, err := scanner.NewScannerFromConfig(cfg)
+	if err != nil {
+		t.Fatalf("Failed to make a config detector: " + err.Error())
+	}
+
+	// a map for storing generated results to check if they are unique
+	var uniqueConfigList = make(map[string]bool)
+
+	var testIterations = 5
+	for range testIterations {
+		// call the function to create a random config
+		randomConfig := CreateRandomConfigValue()
+
+		// store generated configs as unique keys in a map
+		uniqueConfigList[randomConfig] = true
+
+		// scan the config
+		ds, err := scannerClient.Scan(randomConfig)
+		if err != nil {
+			t.Fatalf("Failed to scan input: " + err.Error())
+		}
+
+		// the length of ds (detected secrets) should be one
+		for _, d := range ds {
+			// check if the config meets the threshold for high entropy (randomness)
+			if d.Type != "High entropy string" {
+				t.Errorf("did not meet the entropy threshold: generated value of %q", randomConfig)
+			}
+		}
+	}
+
+	// check if the length of the map matches the number of test iterations (should be equal if all keys are unique)
+	numOfUniqueConfigs := len(uniqueConfigList)
+	if numOfUniqueConfigs < testIterations {
+		t.Errorf("generated result was not unique: expected numOfUniqueConfigs to be %d, but got %d", testIterations, numOfUniqueConfigs)
+	}
+}


### PR DESCRIPTION
## Description
Added a `--random` flag to `defang config create` (aka. `defang config set`) to generate a random base64 value and set it as sensitive config for a user.

Uses https://pkg.go.dev/crypto/rand for creating random values. 

## Linked Issues

Fixes #939 

## Checklist

- [ ] I have performed a self-review of my code
- [x] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

