### PR TITLE
Hide upgrade hints using a variable instead of os.Setenv

### DIFF
--- a/src/cmd/cli/command/commands.go
+++ b/src/cmd/cli/command/commands.go
@@ -46,6 +46,7 @@ var (
 	doDebug        = false
 	gitHubClientId = pkg.Getenv("DEFANG_CLIENT_ID", "7b41848ca116eac4b125") // GitHub OAuth app
 	hasTty         = term.IsTerminal() && !pkg.GetenvBool("CI")
+	hideUpdate     = pkg.GetenvBool("DEFANG_HIDE_UPDATE")
 	nonInteractive = !hasTty
 	org            string
 	providerID     = cliClient.ProviderID(pkg.Getenv("DEFANG_PROVIDER", "auto"))
@@ -135,7 +136,7 @@ func Execute(ctx context.Context) error {
 		fmt.Println("For help with warnings, check our FAQ at https://docs.defang.io/docs/faq")
 	}
 
-	if hasTty && !pkg.GetenvBool("DEFANG_HIDE_UPDATE") && rand.Intn(10) == 0 {
+	if hasTty && !hideUpdate && rand.Intn(10) == 0 {
 		if latest, err := GetLatestVersion(ctx); err == nil && isNewer(GetCurrentVersion(), latest) {
 			term.Debug("Latest Version:", latest, "Current Version:", GetCurrentVersion())
 			fmt.Println("A newer version of the CLI is available at https://github.com/DefangLabs/defang/releases/latest")
@@ -338,8 +339,12 @@ var RootCmd = &cobra.Command{
 			term.Debug("Fabric:", v.Fabric, "CLI:", version, "CLI-Min:", v.CliMin)
 			if hasTty && isNewer(version, v.CliMin) && !isUpgradeCommand(cmd) {
 				term.Warn("Your CLI version is outdated. Please upgrade to the latest version by running:\n\n  defang upgrade\n")
-				os.Setenv("DEFANG_HIDE_UPDATE", "1") // hide the upgrade hint at the end
+				hideUpdate = true // hide the upgrade hint at the end
 			}
+		}
+
+		if isUpgradeCommand(cmd) {
+			hideUpdate = true
 		}
 
 		// Check if we are correctly logged in, but only if the command needs authorization
@@ -1082,6 +1087,7 @@ func IsCompletionCommand(cmd *cobra.Command) bool {
 }
 
 func isUpgradeCommand(cmd *cobra.Command) bool {
+	os.Setenv("DEFANG_HIDE_UPDATE", "1") // hide the upgrade hint
 	return cmd.Name() == "upgrade"
 }
 

--- a/src/cmd/cli/command/commands.go
+++ b/src/cmd/cli/command/commands.go
@@ -1087,7 +1087,6 @@ func IsCompletionCommand(cmd *cobra.Command) bool {
 }
 
 func isUpgradeCommand(cmd *cobra.Command) bool {
-	os.Setenv("DEFANG_HIDE_UPDATE", "1") // hide the upgrade hint
 	return cmd.Name() == "upgrade"
 }
 


### PR DESCRIPTION
## Description

Currently, there is an upgrade hint (different from a warning) that is shown randomly (1/10 chance) when a user runs a command. If they are running the `defang upgrade` command, we should suppress this hint in all cases.

This PR will suppress the hint on `defang upgrade`, and use a `hideUpdate` variable instead of `os.Setenv` to achieve this. 

## Linked Issues

Related to #1045 

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

