### PR TITLE
Ask for confirmation for sus project names

### DIFF
--- a/src/cmd/cli/command/commands.go
+++ b/src/cmd/cli/command/commands.go
@@ -1049,22 +1049,25 @@ func configureLoader(cmd *cobra.Command) *compose.Loader {
 	}
 
 	// Avoid common mistakes
-	var doubleCheck bool
 	var prov cliClient.ProviderID
 	if prov.Set(projectName) == nil && !cmd.Flag("provider").Changed {
 		// using -p with a provider name instead of -P
 		term.Warnf("Project name %q looks like a provider name; did you mean to use -P=%s instead of -p?", projectName, projectName)
-		doubleCheck = true
+		doubleCheck(projectName)
 	} else if strings.HasPrefix(projectName, "roject-name") {
 		// -project-name= instead of --project-name
 		term.Warn("Did you mean to use --project-name instead of -project-name?")
-		doubleCheck = true
+		doubleCheck(projectName)
 	} else if strings.HasPrefix(projectName, "rovider") {
 		// -provider= instead of --provider
 		term.Warn("Did you mean to use --provider instead of -provider?")
-		doubleCheck = true
+		doubleCheck(projectName)
 	}
-	if !nonInteractive && doubleCheck {
+	return compose.NewLoader(compose.WithProjectName(projectName), compose.WithPath(configPaths...))
+}
+
+func doubleCheck(projectName string) {
+	if !nonInteractive {
 		var confirm bool
 		err := survey.AskOne(&survey.Confirm{
 			Message: "Continue with project: " + projectName + "?",
@@ -1074,7 +1077,6 @@ func configureLoader(cmd *cobra.Command) *compose.Loader {
 			os.Exit(1)
 		}
 	}
-	return compose.NewLoader(compose.WithProjectName(projectName), compose.WithPath(configPaths...))
 }
 
 func awsInEnv() bool {

--- a/src/cmd/cli/command/commands.go
+++ b/src/cmd/cli/command/commands.go
@@ -1047,19 +1047,31 @@ func configureLoader(cmd *cobra.Command) *compose.Loader {
 	if err != nil {
 		panic(err)
 	}
-	// Avoid common mistakes: using -p with a provider name instead of -P
+
+	// Avoid common mistakes
+	var doubleCheck bool
 	var prov cliClient.ProviderID
 	if prov.Set(projectName) == nil && !cmd.Flag("provider").Changed {
+		// using -p with a provider name instead of -P
 		term.Warnf("Project name %q looks like a provider name; did you mean to use -P=%s instead of -p?", projectName, projectName)
-		if !nonInteractive {
-			var confirm bool
-			err := survey.AskOne(&survey.Confirm{
-				Message: "Continue with project: " + projectName + "?",
-			}, &confirm, survey.WithStdio(term.DefaultTerm.Stdio()))
-			track.Evt("ProjectNameConfirm", P("project", projectName), P("confirm", confirm), P("err", err))
-			if err == nil && !confirm {
-				os.Exit(1)
-			}
+		doubleCheck = true
+	} else if strings.HasPrefix(projectName, "roject-name") {
+		// -project-name= instead of --project-name
+		term.Warn("Did you mean to use --project-name instead of -project-name?")
+		doubleCheck = true
+	} else if strings.HasPrefix(projectName, "rovider") {
+		// -provider= instead of --provider
+		term.Warn("Did you mean to use --provider instead of -provider?")
+		doubleCheck = true
+	}
+	if !nonInteractive && doubleCheck {
+		var confirm bool
+		err := survey.AskOne(&survey.Confirm{
+			Message: "Continue with project: " + projectName + "?",
+		}, &confirm, survey.WithStdio(term.DefaultTerm.Stdio()))
+		track.Evt("ProjectNameConfirm", P("project", projectName), P("confirm", confirm), P("err", err))
+		if err == nil && !confirm {
+			os.Exit(1)
 		}
 	}
 	return compose.NewLoader(compose.WithProjectName(projectName), compose.WithPath(configPaths...))


### PR DESCRIPTION
## Description

I had forgotten one dash and was confused why I didn't see any logs when I did `defang tail -project-name defang`. I figured it's not uncommon so I added a warning for it.

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

