### PR TITLE
enable winget-pkg manifest creation and PR

### DIFF
--- a/src/.goreleaser.yml
+++ b/src/.goreleaser.yml
@@ -16,7 +16,7 @@ builds:
       post:
         - ./bin/codesign.sh "{{ .Path }}"
 
-  - id: defang-cli
+  - id: defang-linux
     main: ./cmd/cli
     binary: defang
     goos:

--- a/src/.goreleaser.yml
+++ b/src/.goreleaser.yml
@@ -21,6 +21,16 @@ builds:
     binary: defang
     goos:
       - linux
+    goarch:
+      - amd64
+      - arm64
+    flags:
+      - -trimpath
+
+  - id: defang-win
+    main: ./cmd/cli
+    binary: defang
+    goos:
       - windows
     goarch:
       - amd64
@@ -126,13 +136,14 @@ winget:
       owner: DefangLabs
       name: winget-pkgs
       branch: "Defang-{{.Version}}"
-      # pull_request:
-      #   enabled: true
-      #   draft: true
-      #   base:
-      #     owner: microsoft
-      #     name: winget-pkgs
-      #     branch: master
+      pull_request:
+        check_boxes: true
+        draft: true
+        enabled: true
+        base:
+          owner: microsoft
+          name: winget-pkgs
+          branch: master
 
 announce:
   discord:


### PR DESCRIPTION
## Description

Enable creation of winget-pkg PR to be automatically created on release. Definition was already existing. Was able to make a draft release PR, this bypass the need for the Defang's fork of the winget-pkg repo.

## Linked Issues

[link](https://github.com/DefangLabs/defang/issues/950)

## Checklist

- [X] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

