### PR TITLE
Adds UTC timestamp option to CLI commands

### DIFF
--- a/src/cmd/cli/command/cd.go
+++ b/src/cmd/cli/command/cd.go
@@ -33,7 +33,6 @@ var cdDestroyCmd = &cobra.Command{
 	Args:        cobra.NoArgs,         // TODO: set MaximumNArgs(1),
 	Short:       "Destroy the service stack",
 	RunE: func(cmd *cobra.Command, args []string) error {
-
 		loader := configureLoader(cmd)
 		provider, err := getProvider(cmd.Context(), loader)
 		if err != nil {
@@ -61,7 +60,6 @@ var cdDownCmd = &cobra.Command{
 	Short:       "Refresh and then destroy the service stack",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		loader := configureLoader(cmd)
-
 		provider, err := getProvider(cmd.Context(), loader)
 		if err != nil {
 			return err
@@ -87,7 +85,6 @@ var cdRefreshCmd = &cobra.Command{
 	Args:        cobra.NoArgs,         // TODO: set MaximumNArgs(1),
 	Short:       "Refresh the service stack",
 	RunE: func(cmd *cobra.Command, args []string) error {
-
 		loader := configureLoader(cmd)
 		provider, err := getProvider(cmd.Context(), loader)
 		if err != nil {
@@ -114,7 +111,6 @@ var cdCancelCmd = &cobra.Command{
 	Args:        cobra.NoArgs,         // TODO: set MaximumNArgs(1),
 	Short:       "Cancel the current CD operation",
 	RunE: func(cmd *cobra.Command, args []string) error {
-
 		loader := configureLoader(cmd)
 		provider, err := getProvider(cmd.Context(), loader)
 		if err != nil {
@@ -140,7 +136,6 @@ var cdTearDownCmd = &cobra.Command{
 	Args:  cobra.NoArgs,
 	Short: "Destroy the CD cluster without destroying the services",
 	RunE: func(cmd *cobra.Command, args []string) error {
-
 		force, _ := cmd.Flags().GetBool("force")
 
 		loader := configureLoader(cmd)

--- a/src/cmd/cli/command/cd.go
+++ b/src/cmd/cli/command/cd.go
@@ -1,6 +1,8 @@
 package command
 
 import (
+	"time"
+
 	"github.com/DefangLabs/defang/src/pkg/cli"
 	cliClient "github.com/DefangLabs/defang/src/pkg/cli/client"
 	"github.com/DefangLabs/defang/src/pkg/cli/compose"
@@ -14,6 +16,15 @@ var cdCmd = &cobra.Command{
 	Aliases: []string{"bootstrap"},
 	Short:   "Manually run a command with the CD task (for BYOC only)",
 	Hidden:  true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		var utc, _ = cmd.Flags().GetBool("utc")
+
+		if utc {
+			time.Local = time.UTC // set the timezone to UTC
+		}
+
+		return nil
+	},
 }
 
 var cdDestroyCmd = &cobra.Command{
@@ -22,6 +33,7 @@ var cdDestroyCmd = &cobra.Command{
 	Args:        cobra.NoArgs,         // TODO: set MaximumNArgs(1),
 	Short:       "Destroy the service stack",
 	RunE: func(cmd *cobra.Command, args []string) error {
+
 		loader := configureLoader(cmd)
 		provider, err := getProvider(cmd.Context(), loader)
 		if err != nil {
@@ -49,6 +61,7 @@ var cdDownCmd = &cobra.Command{
 	Short:       "Refresh and then destroy the service stack",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		loader := configureLoader(cmd)
+
 		provider, err := getProvider(cmd.Context(), loader)
 		if err != nil {
 			return err
@@ -74,6 +87,7 @@ var cdRefreshCmd = &cobra.Command{
 	Args:        cobra.NoArgs,         // TODO: set MaximumNArgs(1),
 	Short:       "Refresh the service stack",
 	RunE: func(cmd *cobra.Command, args []string) error {
+
 		loader := configureLoader(cmd)
 		provider, err := getProvider(cmd.Context(), loader)
 		if err != nil {
@@ -100,6 +114,7 @@ var cdCancelCmd = &cobra.Command{
 	Args:        cobra.NoArgs,         // TODO: set MaximumNArgs(1),
 	Short:       "Cancel the current CD operation",
 	RunE: func(cmd *cobra.Command, args []string) error {
+
 		loader := configureLoader(cmd)
 		provider, err := getProvider(cmd.Context(), loader)
 		if err != nil {
@@ -125,6 +140,7 @@ var cdTearDownCmd = &cobra.Command{
 	Args:  cobra.NoArgs,
 	Short: "Destroy the CD cluster without destroying the services",
 	RunE: func(cmd *cobra.Command, args []string) error {
+
 		force, _ := cmd.Flags().GetBool("force")
 
 		loader := configureLoader(cmd)

--- a/src/cmd/cli/command/commands.go
+++ b/src/cmd/cli/command/commands.go
@@ -174,6 +174,7 @@ func SetupCommands(ctx context.Context, version string) {
 
 	// CD command
 	RootCmd.AddCommand(cdCmd)
+	cdCmd.Flags().Bool("utc", false, "Set the timezone to UTC")
 	cdCmd.PersistentFlags().StringVar(&byoc.DefangPulumiBackend, "pulumi-backend", "", `specify an alternate Pulumi backend URL or "pulumi-cloud"`)
 	cdCmd.AddCommand(cdDestroyCmd)
 	cdCmd.AddCommand(cdDownCmd)

--- a/src/cmd/cli/command/compose.go
+++ b/src/cmd/cli/command/compose.go
@@ -58,7 +58,12 @@ func makeComposeUpCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var force, _ = cmd.Flags().GetBool("force")
 			var detach, _ = cmd.Flags().GetBool("detach")
+			var utc, _ = cmd.Flags().GetBool("utc")
 			var waitTimeout, _ = cmd.Flags().GetInt("wait-timeout")
+
+			if utc {
+				time.Local = time.UTC // set the timezone to UTC
+			}
 
 			upload := compose.UploadModeDigest
 			if force {
@@ -199,6 +204,7 @@ func makeComposeUpCmd() *cobra.Command {
 	}
 	composeUpCmd.Flags().BoolP("detach", "d", false, "run in detached mode")
 	composeUpCmd.Flags().Bool("force", false, "force a build of the image even if nothing has changed")
+	composeUpCmd.Flags().Bool("utc", false, "show logs in UTC timezone (ie. TZ=UTC)")
 	composeUpCmd.Flags().Bool("tail", false, "tail the service logs after updating") // obsolete, but keep for backwards compatibility
 	_ = composeUpCmd.Flags().MarkHidden("tail")
 	composeUpCmd.Flags().VarP(&mode, "mode", "m", "deployment mode, possible values: "+strings.Join(allModes(), ", "))
@@ -260,6 +266,11 @@ func makeComposeDownCmd() *cobra.Command {
 		Short:       "Reads a Compose file and deprovisions its services",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var detach, _ = cmd.Flags().GetBool("detach")
+			var utc, _ = cmd.Flags().GetBool("utc")
+
+			if utc {
+				time.Local = time.UTC // set the timezone to UTC
+			}
 
 			loader := configureLoader(cmd)
 			provider, err := getProvider(cmd.Context(), loader)
@@ -324,6 +335,7 @@ func makeComposeDownCmd() *cobra.Command {
 		},
 	}
 	composeDownCmd.Flags().BoolP("detach", "d", false, "run in detached mode")
+	composeDownCmd.Flags().Bool("utc", false, "show logs in UTC timezone (ie. TZ=UTC)")
 	composeDownCmd.Flags().Bool("tail", false, "tail the service logs after deleting") // obsolete, but keep for backwards compatibility
 	_ = composeDownCmd.Flags().MarkHidden("tail")
 	return composeDownCmd
@@ -426,12 +438,12 @@ func makeComposeLogsCmd() *cobra.Command {
 			var filter, _ = cmd.Flags().GetString("filter")
 			var until, _ = cmd.Flags().GetString("until")
 
-			if !cmd.Flags().Changed("verbose") {
-				verbose = true // default verbose for explicit tail command
+			if utc {
+				time.Local = time.UTC // set the timezone to UTC
 			}
 
-			if utc {
-				os.Setenv("TZ", "") // used by Go's "time" package, see https://pkg.go.dev/time#Location
+			if !cmd.Flags().Changed("verbose") {
+				verbose = true // default verbose for explicit tail command
 			}
 
 			now := time.Now()

--- a/src/pkg/cli/tail_test.go
+++ b/src/pkg/cli/tail_test.go
@@ -236,7 +236,7 @@ func TestUTC(t *testing.T) {
 	localMock := &mockTailProvider{}
 	localMock = localMock.MockTimestamp(localTime)
 
-	// Start the terminal
+	// Start the terminal for local time test
 	err := Tail(context.Background(), localMock, projectName, TailOptions{Verbose: true}) // Output host
 	if err != nil {
 		t.Errorf("Tail() error = %v, want io.EOF", err)
@@ -260,8 +260,7 @@ func TestUTC(t *testing.T) {
 	// Create the UTC time object
 	utcTime := time.Now().Truncate(time.Second)
 
-	// Make a new Terminal object with new stream buffer for UTC time
-	// Setup terminal for local time test
+	// Setup terminal for UTC time test
 	stdout2, stderr, cleanup2 := setupTestTerminal()
 	if stderr.Len() > 0 {
 		t.Errorf("Unexpected stderr output: %v", stderr.String())

--- a/src/pkg/cli/tail_test.go
+++ b/src/pkg/cli/tail_test.go
@@ -226,7 +226,7 @@ func TestUTC(t *testing.T) {
 		t.Errorf("Unexpected stderr output: %v", stderr.String())
 	}
 
-	defer cleanup()
+	t.Cleanup(cleanup)
 
 	// Testing local time
 	localTime := time.Now().Truncate(time.Second)
@@ -266,7 +266,7 @@ func TestUTC(t *testing.T) {
 		t.Errorf("Unexpected stderr output: %v", stderr.String())
 	}
 
-	defer cleanup2()
+	t.Cleanup(cleanup2)
 
 	// Create new mock data for tail with UTC time
 	utcMock := &mockTailProvider{}


### PR DESCRIPTION
## Description
Introduces a UTC flag to display timestamps in UTC for various CLI commands.

<!-- Concise description of what this PR is tackling. -->

`time.Local = time.UTC` sets the default local timezone for the Go program to UTC. By default, Go uses the system's local timezone for operations involving time.Local. This line overrides that behavior, forcing all operations that rely on time.Local to use UTC instead.

Flag: --utc

Commands:
- compose up and up
- compose down and down
- compose tail and logs
- all cd commands

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->
#1053 

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added appropriate tests
- [x] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

