### PR TITLE
Lio/print debug cmd

### DIFF
--- a/src/pkg/cli/debug.go
+++ b/src/pkg/cli/debug.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/AlecAivazis/survey/v2"
@@ -38,6 +39,33 @@ type DebugConfig struct {
 	Provider       client.Provider
 	Since          time.Time
 	Until          time.Time
+}
+
+func (dc DebugConfig) String() string {
+	cmd := "debug"
+	if dc.Etag != "" {
+		cmd += " --etag=" + string(dc.Etag)
+	}
+	if dc.ModelId != "" {
+		cmd += " --model=" + dc.ModelId
+	}
+	if !dc.Since.IsZero() {
+		cmd += " --since=" + dc.Since.UTC().Format(time.RFC3339Nano)
+	}
+	if !dc.Until.IsZero() {
+		cmd += " --until=" + dc.Until.UTC().Format(time.RFC3339Nano)
+	}
+	if dc.Project.WorkingDir != "" {
+		cmd += " --cwd=" + dc.Project.WorkingDir
+	}
+	if dc.Project != nil {
+		cmd += " --project-name=" + dc.Project.Name
+	}
+	if len(dc.FailedServices) > 0 {
+		cmd += " " + strings.Join(dc.FailedServices, " ")
+	}
+	// TODO: do we need to add --provider= or rely on the Fabric-supplied value?
+	return cmd
 }
 
 func InteractiveDebugDeployment(ctx context.Context, client client.FabricClient, debugConfig DebugConfig) error {

--- a/src/pkg/cli/tail.go
+++ b/src/pkg/cli/tail.go
@@ -34,28 +34,6 @@ var (
 	colorKeyRegex = regexp.MustCompile(`"(?:\\["\\/bfnrt]|[^\x00-\x1f"\\]|\\u[0-9a-fA-F]{4})*"\s*:|[^\x00-\x20"=&?]+=`) // handles JSON, logfmt, and query params
 )
 
-type ServiceStatus string
-
-const (
-	ServiceUnspecified ServiceStatus = "UNSPECIFIED"
-
-	// build states
-	ServiceBuildQueued       ServiceStatus = "BUILD_QUEUED"
-	ServiceBuildProvisioning ServiceStatus = "BUILD_PROVISIONING"
-	ServiceBuildPending      ServiceStatus = "BUILD_PENDING"
-	ServiceBuildActivating   ServiceStatus = "BUILD_ACTIVATING"
-	ServiceBuildRunning      ServiceStatus = "BUILD_RUNNING"
-	ServiceBuildDeactivating ServiceStatus = "BUILD_DEACTIVATING" // build completed
-
-	// update states
-	ServiceUpdateQueued ServiceStatus = "UPDATE_QUEUED" // queued for deployment
-
-	// deplpyment states
-	ServicePending   ServiceStatus = "PENDING"
-	ServiceCompleted ServiceStatus = "COMPLETED"
-	ServiceFailed    ServiceStatus = "FAILED"
-)
-
 // Deprecated: use Subscribe instead #851
 type EndLogConditional struct {
 	Service  string


### PR DESCRIPTION
## Description

This PR prints the `defang debug` command when a deployment fails. The intent is for this to be visible even in the CI, but it's possible that currently it won't get shown because `term.IsTerminal()` likely returns `false` when running in GHA. Need to confirm this. 

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

