### PR TITLE
Reapply "enable winget-pkg manifest creation and PR (#1054)" (#1064)

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -207,10 +207,11 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/v') # skip this step for snapshots because we don't know the name of the archive
         env:
           GITHUB_REF_NAME: ${{ github.ref_name }}
+          # the prefix "defang-win" should match the id in the build section of .goreleaser.yml
         run: |
           $version = $env:GITHUB_REF_NAME -replace '^v', ''
-          Compress-Archive -Path defang-cli_windows_amd64_v1\* -DestinationPath "defang_${version}_windows_amd64.zip" -Update
-          Compress-Archive -Path defang-cli_windows_arm64*\* -DestinationPath "defang_${version}_windows_arm64.zip" -Update
+          Compress-Archive -Path defang-win_windows_amd64_v1\* -DestinationPath "defang_${version}_windows_amd64.zip" -Update
+          Compress-Archive -Path defang-win_windows_arm64*\* -DestinationPath "defang_${version}_windows_arm64.zip" -Update
         shell: pwsh
         working-directory: src\dist\windows
 

--- a/src/.goreleaser.yml
+++ b/src/.goreleaser.yml
@@ -16,11 +16,21 @@ builds:
       post:
         - ./bin/codesign.sh "{{ .Path }}"
 
-  - id: defang-cli
+  - id: defang-linux
     main: ./cmd/cli
     binary: defang
     goos:
       - linux
+    goarch:
+      - amd64
+      - arm64
+    flags:
+      - -trimpath
+
+  - id: defang-win
+    main: ./cmd/cli
+    binary: defang
+    goos:
       - windows
     goarch:
       - amd64
@@ -126,13 +136,14 @@ winget:
       owner: DefangLabs
       name: winget-pkgs
       branch: "Defang-{{.Version}}"
-      # pull_request:
-      #   enabled: true
-      #   draft: true
-      #   base:
-      #     owner: microsoft
-      #     name: winget-pkgs
-      #     branch: master
+      pull_request:
+        check_boxes: true
+        draft: true
+        enabled: true
+        base:
+          owner: microsoft
+          name: winget-pkgs
+          branch: master
 
 announce:
   discord:


### PR DESCRIPTION
This reverts commit d9e2ac5.## Description

Enable creation of winget-pkg PR to be automatically created on release. Definition was already existing. Was able to make a draft release PR, this bypass the need for the Defang's fork of the winget-pkg repo.

## Linked Issues

fixes #950 

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

