### PR TITLE
make PR instead of draft PR on winget repo

### DIFF
--- a/src/.goreleaser.yml
+++ b/src/.goreleaser.yml
@@ -138,7 +138,7 @@ winget:
       branch: "Defang-{{.Version}}"
       pull_request:
         check_boxes: true
-        draft: true
+        draft: false
         enabled: true
         base:
           owner: microsoft


### PR DESCRIPTION
## Description

On release of now CLI, have goreleaser make a PR rather than a draft, now that we have confirmed the mechanics of making windows releases.

## Linked Issues

fixes #950 

## Checklist

- [X] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

