### PR TITLE
fix: use new NotifyContext helper

### DIFF
--- a/src/cmd/cli/command/commands.go
+++ b/src/cmd/cli/command/commands.go
@@ -35,9 +35,7 @@ import (
 const authNeeded = "auth-needed" // annotation to indicate that a command needs authorization
 var authNeededAnnotation = map[string]string{authNeeded: ""}
 
-func P(name string, value interface{}) cliClient.Property {
-	return cliClient.Property{Name: name, Value: value}
-}
+var P = track.P
 
 // GLOBALS
 var (

--- a/src/pkg/cli/connect.go
+++ b/src/pkg/cli/connect.go
@@ -43,7 +43,7 @@ func NewGrpcClient(ctx context.Context, cluster string) client.GrpcClient {
 	accessToken := GetExistingToken(cluster)
 	term.Debug("Using tenant", tenantName, "for cluster", host)
 	grpcClient := client.NewGrpcClient(host, accessToken, tenantName)
-	track.Fabric = grpcClient // Update track client
+	track.Tracker = grpcClient // Update track client
 
 	resp, err := grpcClient.WhoAmI(ctx)
 	if err != nil {

--- a/src/pkg/cli/debug.go
+++ b/src/pkg/cli/debug.go
@@ -44,7 +44,7 @@ type DebugConfig struct {
 func (dc DebugConfig) String() string {
 	cmd := "debug"
 	if dc.Etag != "" {
-		cmd += " --etag=" + string(dc.Etag)
+		cmd += " --etag=" + dc.Etag
 	}
 	if dc.ModelId != "" {
 		cmd += " --model=" + dc.ModelId


### PR DESCRIPTION
## Description

Track ctrl-c interrupt in main goroutine to avoid WaitGroup panic

What must have happened is that we’re calling FlushAllTracking at the end of main but during the Wait another event happened in some go routine, so the WaitGroup went from 0->1 causing the panic. 

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

