### PR TITLE
Remove support for Goreleaser to publish a nix derivation

### DIFF
--- a/src/.goreleaser.yml
+++ b/src/.goreleaser.yml
@@ -96,19 +96,19 @@ release:
   # replace_existing_draft: true
   # prerelease: "true"
 
-nix:
-  - homepage: https://defang.io/
-    # commit_author: defang-io
-    description: Defang is the easiest way for developers to create and deploy their containerized applications
-    license: "mit"
-    repository:
-      owner: DefangLabs
-      name: defang
-    post_install: |
-      installShellCompletion --cmd defang \
-        --bash <($out/bin/defang completion bash) \
-        --zsh <($out/bin/defang completion zsh) \
-        --fish <($out/bin/defang completion fish)
+# nix:
+#   - homepage: https://defang.io/
+#     # commit_author: defang-io
+#     description: Defang is the easiest way for developers to create and deploy their containerized applications
+#     license: "mit"
+#     repository:
+#       owner: DefangLabs
+#       name: defang
+#     post_install: |
+#       installShellCompletion --cmd defang \
+#         --bash <($out/bin/defang completion bash) \
+#         --zsh <($out/bin/defang completion zsh) \
+#         --fish <($out/bin/defang completion fish)
 
 changelog:
   use: github-native


### PR DESCRIPTION
## Description
After exploring many options and a lot of discussion we have decided to just remove the support for GoReleaserbot can generate and publish a nix derivation.
The cons outweight the pros to keep the Nix support for goreleaser. 

For more context please read the attached issue below.

<!-- Concise description of what this PR is tackling. -->

## Linked Issues
#24 
<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

