### PR TITLE
Return file name from function

### DIFF
--- a/src/pkg/cli/compose/context.go
+++ b/src/pkg/cli/compose/context.go
@@ -170,7 +170,7 @@ func tryReadIgnoreFile(cwd, ignorefile string) io.ReadCloser {
 
 // writeDefaultIgnoreFile writes a default
 // .dockerignore file to the specified directory.
-// Returns a path to the written file and an error.
+// Returns the filename of the written file and an error.
 func writeDefaultIgnoreFile(cwd string) (string, error) {
 	path := filepath.Join(cwd, dotdockerignore)
 	term.Debug("Writing .dockerignore file to", path)


### PR DESCRIPTION
## Description
Changes:
- err := writeDefaultIgnoreFile(root) -> dockerignore, err = writeDefaultIgnoreFile(root) 
   By doing this we can make sure that the caller knows the name of the file that was written, which make it more explicit 
   and easier to understand. 

- I also changed term.Info() to term.Warn() to make the text popout.

- Added a constant

This is tech debt from the #1068 

<!-- Concise description of what this PR is tackling. -->

## Linked Issues
#1015 
<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added appropriate tests (Test would be unchanged)
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

