### PR TITLE
feat: add a 1ms delta to --until

### DIFF
--- a/src/pkg/cli/debug.go
+++ b/src/pkg/cli/debug.go
@@ -126,12 +126,13 @@ func DebugDeployment(ctx context.Context, client client.FabricClient, debugConfi
 		return ErrDryRun
 	}
 
-	var sinceTime, untilTime *timestamppb.Timestamp
+	var sinceTs, untilTs *timestamppb.Timestamp
 	if pkg.IsValidTime(debugConfig.Since) {
-		sinceTime = timestamppb.New(debugConfig.Since)
+		sinceTs = timestamppb.New(debugConfig.Since)
 	}
 	if pkg.IsValidTime(debugConfig.Until) {
-		untilTime = timestamppb.New(debugConfig.Until)
+		until := debugConfig.Until.Add(time.Millisecond) // add a millisecond to make it inclusive
+		untilTs = timestamppb.New(until)
 	}
 	req := defangv1.DebugRequest{
 		Etag:     debugConfig.Etag,
@@ -139,8 +140,8 @@ func DebugDeployment(ctx context.Context, client client.FabricClient, debugConfi
 		ModelId:  debugConfig.ModelId,
 		Project:  debugConfig.Project.Name,
 		Services: debugConfig.FailedServices,
-		Since:    sinceTime,
-		Until:    untilTime,
+		Since:    sinceTs,
+		Until:    untilTs,
 	}
 	err := debugConfig.Provider.QueryForDebug(ctx, &req)
 	if err != nil {


### PR DESCRIPTION
## Description

While debugging, I copy-pasted a time from the logs, but when I did `defang logs --since … --until 2025-03-27T19:58:12.166Z` the resulting logs did not include the event that I was looking for, because the timestamp of the log was slightly after the "until" time 2025-03-27T19:58:12.166Z, eg. it was at 2025-03-27T19:58:12.166555Z or so. 


## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

