### PR TITLE
Rename Etag to Deployment for internal structs

### DIFF
--- a/src/cmd/cli/command/cd.go
+++ b/src/cmd/cli/command/cd.go
@@ -200,9 +200,9 @@ var cdPreviewCmd = &cobra.Command{
 		}
 
 		tailOptions := cli.TailOptions{
-			Etag:    resp.Etag,
-			Verbose: verbose,
-			LogType: logs.LogTypeAll,
+			Deployment: resp.Etag,
+			Verbose:    verbose,
+			LogType:    logs.LogTypeAll,
 		}
 		return cli.Tail(cmd.Context(), provider, project.Name, tailOptions)
 	},

--- a/src/cmd/cli/command/commands.go
+++ b/src/cmd/cli/command/commands.go
@@ -897,7 +897,7 @@ var debugCmd = &cobra.Command{
 		}
 
 		debugConfig := cli.DebugConfig{
-			Etag:           deployment,
+			Deployment:     deployment,
 			FailedServices: args,
 			ModelId:        modelId,
 			Project:        project,
@@ -937,7 +937,7 @@ var deleteCmd = &cobra.Command{
 		}
 
 		since := time.Now()
-		etag, err := cli.Delete(cmd.Context(), projectName, client, provider, names...)
+		deployment, err := cli.Delete(cmd.Context(), projectName, client, provider, names...)
 		if err != nil {
 			if connect.CodeOf(err) == connect.CodeNotFound {
 				// Show a warning (not an error) if the service was not found
@@ -947,20 +947,20 @@ var deleteCmd = &cobra.Command{
 			return err
 		}
 
-		term.Info("Deleted service", names, "with deployment ID", etag)
+		term.Info("Deleted service", names, "with deployment ID", deployment)
 
 		if !tail {
-			printDefangHint("To track the update, do:", "tail --deployment "+etag)
+			printDefangHint("To track the update, do:", "tail --deployment "+deployment)
 			return nil
 		}
 
 		term.Info("Tailing logs for update; press Ctrl+C to detach:")
 
 		tailOptions := cli.TailOptions{
-			Etag:    etag,
-			LogType: logs.LogTypeAll,
-			Since:   since,
-			Verbose: verbose,
+			Deployment: deployment,
+			LogType:    logs.LogTypeAll,
+			Since:      since,
+			Verbose:    verbose,
 		}
 		return cli.Tail(cmd.Context(), provider, projectName, tailOptions)
 	},

--- a/src/cmd/cli/command/compose.go
+++ b/src/cmd/cli/command/compose.go
@@ -170,11 +170,11 @@ func makeComposeUpCmd() *cobra.Command {
 					// Tail got canceled because of deployment failure: prompt to show the debugger
 					term.Warn(errDeploymentFailed)
 					debugConfig := cli.DebugConfig{
-						Etag:     deploy.Etag,
-						ModelId:  modelId,
-						Project:  project,
-						Provider: provider,
-						Since:    since,
+						Deployment: deploy.Etag,
+						ModelId:    modelId,
+						Project:    project,
+						Provider:   provider,
+						Since:      since,
 					}
 					if errDeploymentFailed.Service != "" {
 						debugConfig.FailedServices = []string{errDeploymentFailed.Service}
@@ -292,7 +292,7 @@ func makeComposeDownCmd() *cobra.Command {
 			}
 
 			since := time.Now()
-			etag, err := cli.ComposeDown(cmd.Context(), projectName, client, provider, args...)
+			deployment, err := cli.ComposeDown(cmd.Context(), projectName, client, provider, args...)
 			if err != nil {
 				if connect.CodeOf(err) == connect.CodeNotFound {
 					// Show a warning (not an error) if the service was not found
@@ -302,10 +302,10 @@ func makeComposeDownCmd() *cobra.Command {
 				return err
 			}
 
-			term.Info("Deleted services, deployment ID", etag)
+			term.Info("Deleted services, deployment ID", deployment)
 
 			if detach {
-				printDefangHint("To track the update, do:", "tail --deployment "+etag)
+				printDefangHint("To track the update, do:", "tail --deployment "+deployment)
 				return nil
 			}
 
@@ -314,7 +314,7 @@ func makeComposeDownCmd() *cobra.Command {
 				{Service: "cd", Host: "pulumi", EventLog: "Update succeeded in "},
 			}
 			tailOptions := cli.TailOptions{
-				Etag:               etag,
+				Deployment:         deployment,
 				Since:              since,
 				EndEventDetectFunc: cli.CreateEndLogEventDetectFunc(endLogConditions),
 				Verbose:            verbose,
@@ -492,14 +492,14 @@ func makeComposeLogsCmd() *cobra.Command {
 			}
 
 			tailOptions := cli.TailOptions{
-				Etag:     deployment,
-				Filter:   filter,
-				LogType:  logType,
-				Raw:      raw,
-				Services: services,
-				Since:    sinceTs,
-				Until:    untilTs,
-				Verbose:  verbose,
+				Deployment: deployment,
+				Filter:     filter,
+				LogType:    logType,
+				Raw:        raw,
+				Services:   services,
+				Since:      sinceTs,
+				Until:      untilTs,
+				Verbose:    verbose,
 			}
 
 			return cli.Tail(cmd.Context(), provider, projectName, tailOptions)

--- a/src/pkg/cli/bootstrap.go
+++ b/src/pkg/cli/bootstrap.go
@@ -23,7 +23,7 @@ func BootstrapCommand(ctx context.Context, projectName string, verbose bool, p c
 		return err
 	}
 
-	return tail(ctx, p, projectName, TailOptions{Etag: etag, Since: since, LogType: logs.LogTypeBuild, Verbose: verbose})
+	return tail(ctx, p, projectName, TailOptions{Deployment: etag, Since: since, LogType: logs.LogTypeBuild, Verbose: verbose})
 }
 
 func SplitProjectStack(name string) (projectName string, stackName string) {

--- a/src/pkg/cli/composeUp.go
+++ b/src/pkg/cli/composeUp.go
@@ -145,8 +145,8 @@ func ComposeUp(ctx context.Context, project *compose.Project, c client.FabricCli
 }
 
 func TailUp(ctx context.Context, provider client.Provider, project *compose.Project, deploy *defangv1.DeployResponse, tailOptions TailOptions) error {
-	if tailOptions.Etag == "" {
-		tailOptions.Etag = deploy.Etag
+	if tailOptions.Deployment == "" {
+		tailOptions.Deployment = deploy.Etag
 	}
 	if tailOptions.Since.IsZero() {
 		tailOptions.Since = time.Now()
@@ -232,11 +232,11 @@ func WaitAndTail(ctx context.Context, project *compose.Project, client client.Fa
 
 func NewTailOptionsForDeploy(deploy *defangv1.DeployResponse, since time.Time, verbose bool) TailOptions {
 	return TailOptions{
-		Etag:    deploy.Etag,
-		Since:   since,
-		Raw:     false,
-		Verbose: verbose,
-		LogType: logs.LogTypeAll,
+		Deployment: deploy.Etag,
+		Since:      since,
+		Raw:        false,
+		Verbose:    verbose,
+		LogType:    logs.LogTypeAll,
 	}
 }
 

--- a/src/pkg/cli/debug.go
+++ b/src/pkg/cli/debug.go
@@ -32,7 +32,7 @@ var (
 )
 
 type DebugConfig struct {
-	Etag           types.ETag
+	Deployment     types.ETag
 	FailedServices []string
 	ModelId        string
 	Project        *compose.Project
@@ -43,8 +43,8 @@ type DebugConfig struct {
 
 func (dc DebugConfig) String() string {
 	cmd := "debug"
-	if dc.Etag != "" {
-		cmd += " --deployment=" + dc.Etag
+	if dc.Deployment != "" {
+		cmd += " --deployment=" + dc.Deployment
 	}
 	if dc.ModelId != "" {
 		cmd += " --model=" + dc.ModelId
@@ -82,21 +82,21 @@ func interactiveDebug(ctx context.Context, client client.FabricClient, debugConf
 		Message: "Would you like to debug the deployment with AI?",
 		Help:    "This will send logs and artifacts to our backend and attempt to diagnose the issue and provide a solution.",
 	}, &aiDebug, survey.WithStdio(term.DefaultTerm.Stdio())); err != nil {
-		track.Evt("Debug Prompt Failed", P("etag", debugConfig.Etag), P("reason", err), P("loadErr", loadError))
+		track.Evt("Debug Prompt Failed", P("etag", debugConfig.Deployment), P("reason", err), P("loadErr", loadError))
 		return err
 	} else if !aiDebug {
-		track.Evt("Debug Prompt Skipped", P("etag", debugConfig.Etag), P("loadErr", loadError))
+		track.Evt("Debug Prompt Skipped", P("etag", debugConfig.Deployment), P("loadErr", loadError))
 		return ErrDebugSkipped
 	}
 
-	track.Evt("Debug Prompt Accepted", P("etag", debugConfig.Etag), P("loadErr", loadError))
+	track.Evt("Debug Prompt Accepted", P("etag", debugConfig.Deployment), P("loadErr", loadError))
 
 	if loadError != nil {
 		if err := debugComposeFileLoadError(ctx, client, debugConfig.Project, loadError); err != nil {
 			term.Warnf("Failed to debug compose file load: %v", err)
 			return err
 		}
-	} else if debugConfig.Etag != "" {
+	} else if debugConfig.Deployment != "" {
 		if err := DebugDeployment(ctx, client, debugConfig); err != nil {
 			term.Warnf("Failed to debug deployment: %v", err)
 			return err
@@ -110,15 +110,15 @@ func interactiveDebug(ctx context.Context, client client.FabricClient, debugConf
 		Message: "Was the debugging helpful?",
 		Help:    "Please provide feedback to help us improve the debugging experience.",
 	}, &goodBad); err != nil {
-		track.Evt("Debug Feedback Prompt Failed", P("etag", debugConfig.Etag), P("reason", err), P("loadErr", loadError))
+		track.Evt("Debug Feedback Prompt Failed", P("etag", debugConfig.Deployment), P("reason", err), P("loadErr", loadError))
 	} else {
-		track.Evt("Debug Feedback Prompt Answered", P("etag", debugConfig.Etag), P("feedback", goodBad), P("loadErr", loadError))
+		track.Evt("Debug Feedback Prompt Answered", P("etag", debugConfig.Deployment), P("feedback", goodBad), P("loadErr", loadError))
 	}
 	return nil
 }
 
 func DebugDeployment(ctx context.Context, client client.FabricClient, debugConfig DebugConfig) error {
-	term.Debugf("Invoking AI debugger for deployment %q", debugConfig.Etag)
+	term.Debugf("Invoking AI debugger for deployment %q", debugConfig.Deployment)
 
 	files := findMatchingProjectFiles(debugConfig.Project, debugConfig.FailedServices)
 
@@ -135,7 +135,7 @@ func DebugDeployment(ctx context.Context, client client.FabricClient, debugConfi
 		untilTs = timestamppb.New(until)
 	}
 	req := defangv1.DebugRequest{
-		Etag:     debugConfig.Etag,
+		Etag:     debugConfig.Deployment,
 		Files:    files,
 		ModelId:  debugConfig.ModelId,
 		Project:  debugConfig.Project.Name,

--- a/src/pkg/cli/debug_test.go
+++ b/src/pkg/cli/debug_test.go
@@ -64,7 +64,7 @@ func TestQueryHasProject(t *testing.T) {
 
 	var mockClient = MockDebugFabricClient{}
 	var debugConfig = DebugConfig{
-		Etag:           "etag",
+		Deployment:     "etag",
 		FailedServices: []string{"service"},
 		Project:        project,
 		Provider:       MustHaveProjectNameQueryProvider{},

--- a/src/pkg/cli/tail.go
+++ b/src/pkg/cli/tail.go
@@ -46,7 +46,7 @@ type TailDetectStopEventFunc func(services []string, host string, eventlog strin
 
 type TailOptions struct {
 	EndEventDetectFunc TailDetectStopEventFunc // Deprecated: use Subscribe instead #851
-	Etag               types.ETag
+	Deployment         types.ETag
 	Filter             string
 	LogType            logs.LogType
 	Raw                bool
@@ -64,8 +64,8 @@ func (to TailOptions) String() string {
 	} else {
 		cmd = "logs" + cmd + " --until=" + to.Until.UTC().Format(time.RFC3339Nano)
 	}
-	if to.Etag != "" {
-		cmd += " --deployment=" + to.Etag
+	if to.Deployment != "" {
+		cmd += " --deployment=" + to.Deployment
 	}
 	if to.Raw {
 		cmd += " --raw"
@@ -216,7 +216,7 @@ func tail(ctx context.Context, provider client.Provider, projectName string, opt
 	}
 
 	tailRequest := &defangv1.TailRequest{
-		Etag:     options.Etag,
+		Etag:     options.Deployment,
 		LogType:  uint32(options.LogType),
 		Pattern:  options.Filter,
 		Project:  projectName,
@@ -379,7 +379,7 @@ func tail(ctx context.Context, provider client.Provider, projectName string, opt
 			for i, line := range strings.Split(trimmed, "\n") {
 				if i == 0 {
 					prefixLen, _ = buf.Printc(tsColor, tsString, " ")
-					if options.Etag == "" {
+					if options.Deployment == "" {
 						l, _ := buf.Printc(termenv.ANSIYellow, etag, " ")
 						prefixLen += l
 					}


### PR DESCRIPTION
## Description

Rename Etag to Deployment for internal structs

## Linked Issues

Extracted from https://github.com/DefangLabs/defang/pull/1033

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

