### PR TITLE
Deprecate the old Nix derivation

### DIFF
--- a/pkgs/defang/default.nix
+++ b/pkgs/defang/default.nix
@@ -23,7 +23,7 @@ let
     aarch64-darwin = "https://github.com/DefangLabs/defang/releases/download/v1.1.9/defang_1.1.9_macOS.zip";
   };
 in
-stdenvNoCC.mkDerivation {
+lib.warn "This binary derivation for defang-cli is deprecated and no longer updated" stdenvNoCC.mkDerivation {
   pname = "defang";
   version = "1.1.9";
   src = fetchurl {


### PR DESCRIPTION

## Description

Using `lib.warn` to issue a warning during evaluation.

## Linked Issues

Goreleaser nix rule was commented in #1078

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

