### PR TITLE
debug with DEFANG_PULUMI_DIR

### DIFF
--- a/src/pkg/cli/client/byoc/aws/byoc.go
+++ b/src/pkg/cli/client/byoc/aws/byoc.go
@@ -452,7 +452,7 @@ func (b *ByocAws) runCdCommand(ctx context.Context, cmd cdCmd) (ecs.TaskArn, err
 	}
 	env["DEFANG_MODE"] = strings.ToLower(cmd.mode.String())
 
-	if term.DoDebug() {
+	if term.DoDebug() || os.Getenv("DEFANG_PULUMI_DIR") != "" {
 		// Convert the environment to a human-readable array of KEY=VALUE strings for debugging
 		debugEnv := []string{"AWS_REGION=" + b.driver.Region.String()}
 		if awsProfile := os.Getenv("AWS_PROFILE"); awsProfile != "" {


### PR DESCRIPTION
## Description

I spent a lot of time trying to use `DEFANG_PULUMI_DIR` today before eventually digging up the source code and realizing that it was ignored unless you also passed `--debug`. 🤦  This change lets you use `DEFANG_PULUMI_DIR` regardless of the `debug` flag.

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

