### PR TITLE
fix: defang token does not need to load the project

### DIFF
--- a/src/cmd/cli/command/commands.go
+++ b/src/cmd/cli/command/commands.go
@@ -1009,12 +1009,6 @@ var tokenCmd = &cobra.Command{
 		var s, _ = cmd.Flags().GetString("scope")
 		var expires, _ = cmd.Flags().GetDuration("expires")
 
-		loader := configureLoader(cmd)
-		_, err := getProvider(cmd.Context(), loader)
-		if err != nil {
-			return err
-		}
-
 		// TODO: should default to use the current tenant, not the default tenant
 		return cli.Token(cmd.Context(), client, gitHubClientId, types.DEFAULT_TENANT, expires, scope.Scope(s))
 	},


### PR DESCRIPTION
## Description

`defang token` does not need to load a project, so we can skip the loader (and the cloud provider picker).


## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

