### PR TITLE
Add latest tag to setup

### DIFF
--- a/src/pkg/mcp/setup.go
+++ b/src/pkg/mcp/setup.go
@@ -117,7 +117,7 @@ func getClientConfigPath(client string) (string, error) {
 func getDefangMCPConfig() MCPServerConfig {
 	return MCPServerConfig{
 		Command: "npx",
-		Args:    []string{"-y", "defang", "mcp", "serve"},
+		Args:    []string{"-y", "defang@latest", "mcp", "serve"},
 	}
 }
 
@@ -126,7 +126,7 @@ func getVSCodeDefangMCPConfig() VSCodeMCPServerConfig {
 	return VSCodeMCPServerConfig{
 		Type:    "stdio",
 		Command: "npx",
-		Args:    []string{"-y", "defang", "mcp", "serve"},
+		Args:    []string{"-y", "defang@latest", "mcp", "serve"},
 	}
 }
 


### PR DESCRIPTION
## Description

I notice after the build that when I called
npx it did not update my version. So to make
sure that the latest version is used, I
added a tag to the setup.go file.

![Screenshot 2025-04-19 at 2 08 35 AM](https://github.com/user-attachments/assets/5ec029d9-54d6-4f45-8862-1c44d13f5849)
![Screenshot 2025-04-19 at 2 08 58 AM](https://github.com/user-attachments/assets/bb8dffef-6851-4a21-b7e1-9c4ff7de257d)

<!-- Concise description of what this PR is tackling. -->

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

