### PR TITLE
Fix token refresh issue with grpc client

### DIFF
--- a/src/cmd/cli/command/mcp.go
+++ b/src/cmd/cli/command/mcp.go
@@ -58,7 +58,7 @@ var mcpServerCmd = &cobra.Command{
 		resources.SetupResources(s)
 
 		// Setup tools
-		tools.SetupTools(s, client, getCluster(), gitHubClientId)
+		tools.SetupTools(s, getCluster(), gitHubClientId)
 
 		// Start the server
 		term.Info("Starting Defang Services MCP server")

--- a/src/pkg/mcp/tools/deploy.go
+++ b/src/pkg/mcp/tools/deploy.go
@@ -9,7 +9,6 @@ import (
 	"github.com/pkg/browser"
 
 	"github.com/DefangLabs/defang/src/pkg/cli"
-	"github.com/DefangLabs/defang/src/pkg/cli/client"
 	cliClient "github.com/DefangLabs/defang/src/pkg/cli/client"
 	"github.com/DefangLabs/defang/src/pkg/cli/compose"
 	"github.com/DefangLabs/defang/src/pkg/term"
@@ -19,7 +18,7 @@ import (
 )
 
 // setupDeployTool configures and adds the deployment tool to the MCP server
-func setupDeployTool(s *server.MCPServer, client client.GrpcClient) {
+func setupDeployTool(s *server.MCPServer, cluster string) {
 	term.Info("Creating deployment tool")
 	composeUpTool := mcp.NewTool("deploy",
 		mcp.WithDescription("Deploy services using defang"),
@@ -53,6 +52,8 @@ func setupDeployTool(s *server.MCPServer, client client.GrpcClient) {
 
 			return mcp.NewToolResultText(fmt.Sprintf("Local deployment failed: %v. Please provide a valid compose file path.", err)), nil
 		}
+
+		client := cli.NewGrpcClient(ctx, cluster)
 
 		provider, err := cli.NewProvider(ctx, cliClient.ProviderDefang, client)
 		if err != nil {

--- a/src/pkg/mcp/tools/destroy.go
+++ b/src/pkg/mcp/tools/destroy.go
@@ -16,7 +16,7 @@ import (
 )
 
 // setupDestroyTool configures and adds the destroy tool to the MCP server
-func setupDestroyTool(s *server.MCPServer, client client.GrpcClient) {
+func setupDestroyTool(s *server.MCPServer, cluster string) {
 	term.Info("Creating destroy tool")
 	composeDownTool := mcp.NewTool("destroy",
 		mcp.WithDescription("Remove services using defang. Only one argument should be given and used at a time"),
@@ -32,6 +32,7 @@ func setupDestroyTool(s *server.MCPServer, client client.GrpcClient) {
 	s.AddTool(composeDownTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		term.Info("Compose down tool called - removing services")
 
+		client := cli.NewGrpcClient(ctx, cluster)
 		provider, err := cli.NewProvider(ctx, cliClient.ProviderDefang, client)
 		if err != nil {
 			term.Error("Failed to get new provider", "error", err)

--- a/src/pkg/mcp/tools/login.go
+++ b/src/pkg/mcp/tools/login.go
@@ -5,14 +5,13 @@ import (
 	"fmt"
 
 	"github.com/DefangLabs/defang/src/pkg/cli"
-	"github.com/DefangLabs/defang/src/pkg/cli/client"
 	"github.com/DefangLabs/defang/src/pkg/term"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 )
 
 // setupLoginTool configures and adds the login tool to the MCP server
-func setupLoginTool(s *server.MCPServer, client client.GrpcClient, cluster string, gitHubClientId string) {
+func setupLoginTool(s *server.MCPServer, cluster string, gitHubClientId string) {
 	term.Info("Creating login tool")
 	loginTool := mcp.NewTool("login",
 		mcp.WithDescription("Login to Defang"),
@@ -23,6 +22,7 @@ func setupLoginTool(s *server.MCPServer, client client.GrpcClient, cluster strin
 	term.Info("Adding login tool handler")
 	s.AddTool(loginTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		// Test token
+		client := cli.NewGrpcClient(ctx, cluster)
 		err := cli.InteractiveLogin(ctx, client, gitHubClientId, cluster, true)
 		if err != nil {
 			return mcp.NewToolResultText(fmt.Sprintf("Failed to login: %v", err)), nil

--- a/src/pkg/mcp/tools/services.go
+++ b/src/pkg/mcp/tools/services.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 
 	"github.com/DefangLabs/defang/src/pkg/cli"
-	"github.com/DefangLabs/defang/src/pkg/cli/client"
 	cliClient "github.com/DefangLabs/defang/src/pkg/cli/client"
 	"github.com/DefangLabs/defang/src/pkg/mcp/deployment_info"
 	"github.com/DefangLabs/defang/src/pkg/term"
@@ -19,7 +18,7 @@ import (
 )
 
 // setupServicesTool configures and adds the services tool to the MCP server
-func setupServicesTool(s *server.MCPServer, client client.GrpcClient) {
+func setupServicesTool(s *server.MCPServer, cluster string) {
 	term.Info("Creating services tool")
 	servicesTool := mcp.NewTool("services",
 		mcp.WithDescription("List information about services in Defang"),
@@ -44,6 +43,8 @@ func setupServicesTool(s *server.MCPServer, client client.GrpcClient) {
 		}
 
 		loader := configureLoader(request)
+
+		client := cli.NewGrpcClient(ctx, cluster)
 
 		// Create a Defang client
 		provider, err := cli.NewProvider(ctx, cliClient.ProviderDefang, client)

--- a/src/pkg/mcp/tools/tools.go
+++ b/src/pkg/mcp/tools/tools.go
@@ -1,28 +1,27 @@
 package tools
 
 import (
-	"github.com/DefangLabs/defang/src/pkg/cli/client"
 	"github.com/DefangLabs/defang/src/pkg/term"
 	"github.com/mark3labs/mcp-go/server"
 )
 
 // SetupTools configures and adds all the MCP tools to the server
-func SetupTools(s *server.MCPServer, client client.GrpcClient, cluster string, gitHubClientId string) {
+func SetupTools(s *server.MCPServer, cluster string, gitHubClientId string) {
 	// Create a tool for logging in and getting a new token
 	term.Info("Setting up login tool")
-	setupLoginTool(s, client, cluster, gitHubClientId)
+	setupLoginTool(s, cluster, gitHubClientId)
 
 	// Create a tool for listing services
 	term.Info("Setting up services tool")
-	setupServicesTool(s, client)
+	setupServicesTool(s, cluster)
 
 	// Create a tool for deployment
 	term.Info("Setting up deployment tool")
-	setupDeployTool(s, client)
+	setupDeployTool(s, cluster)
 
 	// Create a tool for destroying services
 	term.Info("Setting up destroy tool")
-	setupDestroyTool(s, client)
+	setupDestroyTool(s, cluster)
 
 	term.Info("All MCP tools have been set up successfully")
 }


### PR DESCRIPTION
## Description
When we were making a call to the grpc client, we were not refreshing the token before making the call. This caused the client was not reconstructed with the new token. So now with every tool call we just remake the grpc client with the new token.

![Screenshot 2025-04-21 at 2 48 43 PM](https://github.com/user-attachments/assets/ba7516fc-6210-4eba-8c34-21098f91e3ec)

![Screenshot 2025-04-21 at 2 48 54 PM](https://github.com/user-attachments/assets/6d2f94de-8081-4804-bf65-41cd8981d383)


<!-- Concise description of what this PR is tackling. -->

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

