### PR TITLE
Only send Slack notification for main or tag

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -436,24 +436,12 @@ jobs:
 
   on-failure:
     runs-on: ubuntu-latest
-    if: failure() && github.ref == 'refs/heads/main'
-    needs: [go-test, go-playground-test, build-and-sign-mac, build-and-sign, nix-shell-test]
+    if: failure() && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
+    needs: [go-release, post-release, go-playground-test, nix-shell-test]
     steps:
     - name: Slack Notification
       uses: rtCamp/action-slack-notify@v2
       env:
         SLACK_TITLE: Defang CLI workflow failed
-        MSG_MINIMAL: actions url
-        SLACK_WEBHOOK: ${{ secrets.SLACK_NOTIFIER_WEBHOOK_URL }}
-
-  on-release-failure:
-    runs-on: ubuntu-latest
-    if: failure()
-    needs: [go-release, post-release]
-    steps:
-    - name: Slack Notification
-      uses: rtCamp/action-slack-notify@v2
-      env:
-        SLACK_TITLE: Defang CLI release workflow failed
         MSG_MINIMAL: actions url
         SLACK_WEBHOOK: ${{ secrets.SLACK_NOTIFIER_WEBHOOK_URL }}


### PR DESCRIPTION
## Description

PR test failures were triggering Slack notifications. This was because I had misunderstood how `needs` works, so the `on-release-failure` was still triggered, even though we weren't doing a release.


## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

