### PR TITLE
Fix: only override x-defang-llm port settings if not set

### DIFF
--- a/src/pkg/cli/compose/fixup.go
+++ b/src/pkg/cli/compose/fixup.go
@@ -158,7 +158,7 @@ func FixupServices(ctx context.Context, provider client.Provider, project *types
 			if _, ok := provider.(*client.PlaygroundProvider); ok {
 				term.Warnf("service %q: managed LLM is not supported in the Playground; consider using BYOC (https://s.defang.io/byoc)", svccfg.Name)
 				delete(svccfg.Extensions, "x-defang-llm")
-			} else {
+			} else if len(svccfg.Ports) == 0 {
 				// HACK: we must have at least one host port to get a CNAME for the service
 				var port uint32 = 80
 				term.Debugf("service %q: adding LLM host port %d", svccfg.Name, port)


### PR DESCRIPTION
## Description

When x-defang-llm is defined for a service, it would always override the port settings, making it port 80 and mode set to host. This should only be a default, not an override.

## Linked Issues

None

## Checklist

- [X] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

