### PR TITLE
show warnings at end

### DIFF
--- a/src/cmd/cli/command/commands.go
+++ b/src/cmd/cli/command/commands.go
@@ -125,6 +125,8 @@ func Execute(ctx context.Context) error {
 	}
 
 	if hasTty && term.HadWarnings() {
+		term.Info("Some warnings were seen during this command:")
+		term.FlushWarnings()
 		fmt.Println("For help with warnings, check our FAQ at https://docs.defang.io/docs/faq")
 	}
 

--- a/src/cmd/cli/command/commands.go
+++ b/src/cmd/cli/command/commands.go
@@ -125,7 +125,7 @@ func Execute(ctx context.Context) error {
 	}
 
 	if hasTty && term.HadWarnings() {
-		term.Info("Some warnings were seen during this command:")
+		fmt.Println("Some warnings were seen during this command:")
 		term.FlushWarnings()
 		fmt.Println("For help with warnings, check our FAQ at https://docs.defang.io/docs/faq")
 	}

--- a/src/cmd/cli/command/compose.go
+++ b/src/cmd/cli/command/compose.go
@@ -316,6 +316,7 @@ func makeComposeDownCmd() *cobra.Command {
 				}
 				return err
 			}
+
 			term.Info("Done.")
 			return nil
 		},

--- a/src/cmd/cli/command/compose.go
+++ b/src/cmd/cli/command/compose.go
@@ -316,7 +316,6 @@ func makeComposeDownCmd() *cobra.Command {
 				}
 				return err
 			}
-
 			term.Info("Done.")
 			return nil
 		},

--- a/src/pkg/term/colorizer.go
+++ b/src/pkg/term/colorizer.go
@@ -95,10 +95,6 @@ func (t *Term) IsTerminal() bool {
 	return t.isTerminal
 }
 
-func (t *Term) ClearCachedWarnings() {
-	t.warnings = nil
-}
-
 func (t *Term) HadWarnings() bool {
 	return len(t.warnings) > 0
 }
@@ -250,14 +246,16 @@ func (t *Term) Fatalf(format string, v ...any) {
 	os.Exit(1)
 }
 
-func (t *Term) GetAllWarnings() []string {
+func (t *Term) getAllWarnings() []string {
 	slices.Sort(t.warnings)
 	return slices.Compact(t.warnings)
 }
 
 func (t *Term) FlushWarnings() (int, error) {
-	uniqueWarnings := t.GetAllWarnings()
+	uniqueWarnings := t.getAllWarnings()
 	bytesWritten := 0
+
+	// unique warnings only
 	for _, w := range uniqueWarnings {
 		bytes, err := output(t.out, WarnColor, w)
 		bytesWritten += bytes
@@ -347,10 +345,6 @@ func HasDarkBackground() bool {
 
 func IsTerminal() bool {
 	return DefaultTerm.IsTerminal()
-}
-
-func ClearCachedWarnings() {
-	DefaultTerm.ClearCachedWarnings()
 }
 
 func HadWarnings() bool {

--- a/src/pkg/term/colorizer_test.go
+++ b/src/pkg/term/colorizer_test.go
@@ -175,7 +175,7 @@ func TestWarn(t *testing.T) {
 				defaultTerm.Warn(msg)
 			}
 
-			uniqueWarnings := defaultTerm.GetAllWarnings()
+			uniqueWarnings := defaultTerm.getAllWarnings()
 			if len(uniqueWarnings) != len(test.expected) {
 				t.Errorf("Expected %d unique warnings, got %d", len(test.expected), len(uniqueWarnings))
 			}


### PR DESCRIPTION
## Description

Show all unique warnings at the end of CLI execution so users are aware of any potential issues. Logs may have flown by too fast for users to see.

## Linked Issues

Address part of #1084 

## Checklist

- [X] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

