### PR TITLE
Move DNS helpers to dns package

### DIFF
--- a/src/pkg/cli/cert.go
+++ b/src/pkg/cli/cert.go
@@ -197,7 +197,7 @@ func waitForTLS(ctx context.Context, domain string) error {
 
 func waitForCNAME(ctx context.Context, domain string, targets []string, client client.FabricClient) error {
 	for i, target := range targets {
-		targets[i] = dns.Normalize(strings.ToLower(target))
+		targets[i] = dns.Normalize(target)
 	}
 
 	ticker := time.NewTicker(5 * time.Second)

--- a/src/pkg/cli/client/byoc/baseclient.go
+++ b/src/pkg/cli/client/byoc/baseclient.go
@@ -9,6 +9,7 @@ import (
 	"github.com/DefangLabs/defang/src/pkg"
 	"github.com/DefangLabs/defang/src/pkg/cli/client"
 	"github.com/DefangLabs/defang/src/pkg/cli/compose"
+	"github.com/DefangLabs/defang/src/pkg/dns"
 	"github.com/DefangLabs/defang/src/pkg/term"
 	"github.com/DefangLabs/defang/src/pkg/types"
 	defangv1 "github.com/DefangLabs/defang/src/protos/io/defang/v1"
@@ -92,7 +93,7 @@ func (b *ByocBaseClient) SetCanIUseConfig(quotas *defangv1.CanIUseResponse) {
 }
 
 func (b *ByocBaseClient) ServiceDNS(name string) string {
-	return DnsSafeLabel(name) // TODO: consider merging this with getPrivateFqdn
+	return dns.SafeLabel(name) // TODO: consider merging this with getPrivateFqdn
 }
 
 func (b *ByocBaseClient) RemoteProjectName(ctx context.Context) (string, error) {
@@ -120,11 +121,12 @@ func (b *ByocBaseClient) GetProjectDomain(projectName, zone string) string {
 	if projectName == "" {
 		return "" // no project name => no custom domain
 	}
-	projectLabel := DnsSafeLabel(projectName)
-	if projectLabel == DnsSafeLabel(b.TenantName) {
-		return DnsSafe(zone) // the zone will already have the tenant ID
+	projectLabel := dns.SafeLabel(projectName)
+	tenantLabel := dns.SafeLabel(b.TenantName)
+	if projectLabel == tenantLabel { // avoid stuttering
+		return dns.Normalize(zone) // the zone will already have the tenant ID
 	}
-	domain := projectLabel + "." + DnsSafe(zone)
+	domain := projectLabel + "." + dns.Normalize(zone)
 	if hasStack, ok := b.projectBackend.(HasStackSupport); ok {
 		domain = hasStack.GetStackName() + "." + domain
 	}
@@ -287,7 +289,7 @@ func (b *ByocBaseClient) GetEndpoint(fqn string, projectName, delegateDomain str
 	if projectDomain == "" {
 		return ":443" // placeholder for the public ALB/distribution
 	}
-	safeFqn := DnsSafeLabel(fqn)
+	safeFqn := dns.SafeLabel(fqn)
 	return fmt.Sprintf("%s--%d.%s", safeFqn, port.Target, projectDomain)
 }
 
@@ -296,12 +298,12 @@ func (b *ByocBaseClient) GetPublicFqdn(projectName, delegateDomain, fqn string) 
 	if projectName == "" {
 		return "" //b.fqdn
 	}
-	safeFqn := DnsSafeLabel(fqn)
+	safeFqn := dns.SafeLabel(fqn)
 	return fmt.Sprintf("%s.%s", safeFqn, b.GetProjectDomain(projectName, delegateDomain))
 }
 
 // This function was copied from Fabric controller and slightly modified to work with BYOC
 func (b ByocBaseClient) GetPrivateFqdn(projectName string, fqn string) string {
-	safeFqn := DnsSafeLabel(fqn)
+	safeFqn := dns.SafeLabel(fqn)
 	return fmt.Sprintf("%s.%s", safeFqn, GetPrivateDomain(projectName)) // TODO: consider merging this with ServiceDNS
 }

--- a/src/pkg/cli/client/byoc/common.go
+++ b/src/pkg/cli/client/byoc/common.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/DefangLabs/defang/src/pkg"
+	"github.com/DefangLabs/defang/src/pkg/dns"
 	"github.com/DefangLabs/defang/src/pkg/term"
 )
 
@@ -42,15 +43,6 @@ func GetPulumiBackend(stateUrl string) (string, string, error) {
 	}
 }
 
-// This function was copied from Fabric controller and slightly modified to work with BYOC
-func DnsSafeLabel(fqn string) string {
-	return strings.ReplaceAll(DnsSafe(fqn), ".", "-")
-}
-
-func DnsSafe(fqdn string) string {
-	return strings.ToLower(fqdn)
-}
-
 func runLocalCommand(ctx context.Context, dir string, env []string, cmd ...string) error {
 	command := exec.CommandContext(ctx, cmd[0], cmd[1:]...)
 	command.Dir = dir
@@ -83,5 +75,5 @@ func DebugPulumi(ctx context.Context, env []string, cmd ...string) error {
 }
 
 func GetPrivateDomain(projectName string) string {
-	return DnsSafeLabel(projectName) + ".internal"
+	return dns.SafeLabel(projectName) + ".internal"
 }

--- a/src/pkg/dns/check.go
+++ b/src/pkg/dns/check.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"net"
 	"slices"
-	"strings"
 
 	"github.com/DefangLabs/defang/src/pkg/term"
 )
@@ -23,10 +22,6 @@ var (
 
 	errDNSNotInSync = errors.New("DNS not in sync")
 )
-
-func Normalize(domain string) string {
-	return strings.TrimSuffix(domain, ".")
-}
 
 // The DNS is considered ready if the CNAME of the domain is pointing to the ALB domain and in sync
 // OR if the A record of the domain is pointing to the same IP addresses of the ALB domain and in sync

--- a/src/pkg/dns/utils.go
+++ b/src/pkg/dns/utils.go
@@ -1,0 +1,11 @@
+package dns
+
+import "strings"
+
+func SafeLabel(fqn string) string {
+	return strings.ReplaceAll(strings.ToLower(fqn), ".", "-")
+}
+
+func Normalize(domain string) string {
+	return strings.ToLower(strings.TrimSuffix(domain, "."))
+}

--- a/src/pkg/dns/utils_test.go
+++ b/src/pkg/dns/utils_test.go
@@ -1,0 +1,39 @@
+package dns
+
+import "testing"
+
+func TestSafeLabel(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"example.project", "example-project"},
+		{"EXAMPLE.PROJECT", "example-project"},
+		{"example.project.", "example-project-"},
+	}
+
+	for _, test := range tests {
+		result := SafeLabel(test.input)
+		if result != test.expected {
+			t.Errorf("SafeLabel(%q) = %q; want %q", test.input, result, test.expected)
+		}
+	}
+}
+
+func TestNormalize(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"example.com", "example.com"},
+		{"EXAMPLE.COM", "example.com"},
+		{"example.com.", "example.com"},
+	}
+
+	for _, test := range tests {
+		result := Normalize(test.input)
+		if result != test.expected {
+			t.Errorf("Normalize(%q) = %q; want %q", test.input, result, test.expected)
+		}
+	}
+}


### PR DESCRIPTION
## Description

These can be used by Fabric. 


## Checklist

- [x] I have performed a self-review of my code
- [x] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

