### PR TITLE
handle x-defang-llm fixup only openai-access-gateway image

### DIFF
--- a/src/pkg/cli/compose/fixup.go
+++ b/src/pkg/cli/compose/fixup.go
@@ -155,9 +155,8 @@ func FixupServices(ctx context.Context, provider client.Provider, project *types
 		}
 
 		if _, llm := svccfg.Extensions["x-defang-llm"]; llm {
-			image := strings.ToLower(svccfg.Image)
-			image, _, _ = strings.Cut(image, ":")
-			if strings.HasSuffix(image, "/openai-access-gateway") && len(svccfg.Ports) == 0 {
+			image := getImageRoot(svccfg.Image)
+			if strings.HasSuffix(image, "defang.io/openai-access-gateway") && len(svccfg.Ports) == 0 {
 				// HACK: we must have at least one host port to get a CNAME for the service
 				var port uint32 = 80
 				term.Debugf("service %q: adding LLM host port %d", svccfg.Name, port)
@@ -181,4 +180,10 @@ func FixupServices(ctx context.Context, provider client.Provider, project *types
 	}
 
 	return nil
+}
+
+func getImageRoot(imageRepo string) string {
+	image := strings.ToLower(imageRepo)
+	image, _, _ = strings.Cut(image, ":")
+	return image
 }

--- a/src/pkg/cli/compose/fixup.go
+++ b/src/pkg/cli/compose/fixup.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"slices"
 	"strconv"
+	"strings"
 
 	"github.com/DefangLabs/defang/src/pkg"
 	"github.com/DefangLabs/defang/src/pkg/cli/client"
@@ -154,7 +155,7 @@ func FixupServices(ctx context.Context, provider client.Provider, project *types
 		}
 
 		_, llm := svccfg.Extensions["x-defang-llm"]
-		if llm {
+		if llm && strings.Contains(svccfg.Image, "openai-access-gateway") {
 			if _, ok := provider.(*client.PlaygroundProvider); ok {
 				term.Warnf("service %q: managed LLM is not supported in the Playground; consider using BYOC (https://s.defang.io/byoc)", svccfg.Name)
 				delete(svccfg.Extensions, "x-defang-llm")

--- a/src/pkg/cli/compose/fixup.go
+++ b/src/pkg/cli/compose/fixup.go
@@ -155,7 +155,7 @@ func FixupServices(ctx context.Context, provider client.Provider, project *types
 		}
 
 		if _, llm := svccfg.Extensions["x-defang-llm"]; llm {
-			image := getImageRoot(svccfg.Image)
+			image := getImageRepo(svccfg.Image)
 			if strings.HasSuffix(image, "/openai-access-gateway") && len(svccfg.Ports) == 0 {
 				// HACK: we must have at least one host port to get a CNAME for the service
 				var port uint32 = 80

--- a/src/pkg/cli/compose/fixup.go
+++ b/src/pkg/cli/compose/fixup.go
@@ -155,11 +155,6 @@ func FixupServices(ctx context.Context, provider client.Provider, project *types
 		}
 
 		if _, llm := svccfg.Extensions["x-defang-llm"]; llm {
-			if _, ok := provider.(*client.PlaygroundProvider); ok {
-				term.Warnf("service %q: managed LLM is not supported in the Playground; consider using BYOC (https://s.defang.io/byoc)", svccfg.Name)
-				delete(svccfg.Extensions, "x-defang-llm")
-			}
-
 			if strings.Contains(svccfg.Image, "openai-access-gateway") && len(svccfg.Ports) == 0 {
 				// HACK: we must have at least one host port to get a CNAME for the service
 				var port uint32 = 80

--- a/src/pkg/cli/compose/fixup.go
+++ b/src/pkg/cli/compose/fixup.go
@@ -156,7 +156,7 @@ func FixupServices(ctx context.Context, provider client.Provider, project *types
 
 		if _, llm := svccfg.Extensions["x-defang-llm"]; llm {
 			image := getImageRoot(svccfg.Image)
-			if strings.HasSuffix(image, "defang.io/openai-access-gateway") && len(svccfg.Ports) == 0 {
+			if strings.HasSuffix(image, "/openai-access-gateway") && len(svccfg.Ports) == 0 {
 				// HACK: we must have at least one host port to get a CNAME for the service
 				var port uint32 = 80
 				term.Debugf("service %q: adding LLM host port %d", svccfg.Name, port)
@@ -182,7 +182,7 @@ func FixupServices(ctx context.Context, provider client.Provider, project *types
 	return nil
 }
 
-func getImageRoot(imageRepo string) string {
+func getImageRepo(imageRepo string) string {
 	image := strings.ToLower(imageRepo)
 	image, _, _ = strings.Cut(image, ":")
 	return image

--- a/src/pkg/cli/compose/fixup.go
+++ b/src/pkg/cli/compose/fixup.go
@@ -154,12 +154,13 @@ func FixupServices(ctx context.Context, provider client.Provider, project *types
 			}
 		}
 
-		_, llm := svccfg.Extensions["x-defang-llm"]
-		if llm && strings.Contains(svccfg.Image, "openai-access-gateway") {
+		if _, llm := svccfg.Extensions["x-defang-llm"]; llm {
 			if _, ok := provider.(*client.PlaygroundProvider); ok {
 				term.Warnf("service %q: managed LLM is not supported in the Playground; consider using BYOC (https://s.defang.io/byoc)", svccfg.Name)
 				delete(svccfg.Extensions, "x-defang-llm")
-			} else if len(svccfg.Ports) == 0 {
+			}
+
+			if strings.Contains(svccfg.Image, "openai-access-gateway") && len(svccfg.Ports) == 0 {
 				// HACK: we must have at least one host port to get a CNAME for the service
 				var port uint32 = 80
 				term.Debugf("service %q: adding LLM host port %d", svccfg.Name, port)

--- a/src/pkg/cli/compose/fixup.go
+++ b/src/pkg/cli/compose/fixup.go
@@ -155,7 +155,9 @@ func FixupServices(ctx context.Context, provider client.Provider, project *types
 		}
 
 		if _, llm := svccfg.Extensions["x-defang-llm"]; llm {
-			if strings.Contains(svccfg.Image, "openai-access-gateway") && len(svccfg.Ports) == 0 {
+			image := strings.ToLower(svccfg.Image)
+			image, _, _ = strings.Cut(image, ":")
+			if strings.HasSuffix(image, "/openai-access-gateway") && len(svccfg.Ports) == 0 {
 				// HACK: we must have at least one host port to get a CNAME for the service
 				var port uint32 = 80
 				term.Debugf("service %q: adding LLM host port %d", svccfg.Name, port)

--- a/src/pkg/cli/compose/validation.go
+++ b/src/pkg/cli/compose/validation.go
@@ -304,8 +304,8 @@ func validateService(svccfg *composeTypes.ServiceConfig, project *composeTypes.P
 
 	if redisExtension, ok := svccfg.Extensions["x-defang-redis"]; ok {
 		// Ensure the image is a valid Redis image
-		repo := strings.SplitN(svccfg.Image, ":", 2)[0]
-		if !strings.HasSuffix(repo, "redis") {
+		image := getImageRoot(svccfg.Image)
+		if !strings.HasSuffix(image, "redis") {
 			term.Warnf("service %q: managed Redis service should use a redis image", svccfg.Name)
 		}
 		if err = ValidateManagedStore(redisExtension); err != nil {
@@ -315,8 +315,8 @@ func validateService(svccfg *composeTypes.ServiceConfig, project *composeTypes.P
 
 	if postgresExtension, ok := svccfg.Extensions["x-defang-postgres"]; ok {
 		// Ensure the image is a valid Postgres image; FIXME: there are several valid Postgres images
-		repo := strings.SplitN(svccfg.Image, ":", 2)[0]
-		if !strings.HasSuffix(repo, "postgres") {
+		image := getImageRoot(svccfg.Image)
+		if !strings.HasSuffix(image, "postgres") {
 			term.Warnf("service %q: managed Postgres service should use a postgres image", svccfg.Name)
 		}
 		if err = ValidateManagedStore(postgresExtension); err != nil {

--- a/src/pkg/cli/compose/validation.go
+++ b/src/pkg/cli/compose/validation.go
@@ -304,7 +304,7 @@ func validateService(svccfg *composeTypes.ServiceConfig, project *composeTypes.P
 
 	if redisExtension, ok := svccfg.Extensions["x-defang-redis"]; ok {
 		// Ensure the image is a valid Redis image
-		image := getImageRoot(svccfg.Image)
+		image := getImageRepo(svccfg.Image)
 		if !strings.HasSuffix(image, "redis") {
 			term.Warnf("service %q: managed Redis service should use a redis image", svccfg.Name)
 		}
@@ -315,7 +315,7 @@ func validateService(svccfg *composeTypes.ServiceConfig, project *composeTypes.P
 
 	if postgresExtension, ok := svccfg.Extensions["x-defang-postgres"]; ok {
 		// Ensure the image is a valid Postgres image; FIXME: there are several valid Postgres images
-		image := getImageRoot(svccfg.Image)
+		image := getImageRepo(svccfg.Image)
 		if !strings.HasSuffix(image, "postgres") {
 			term.Warnf("service %q: managed Postgres service should use a postgres image", svccfg.Name)
 		}

--- a/src/testdata/llm/Dockerfile
+++ b/src/testdata/llm/Dockerfile
@@ -1,0 +1,1 @@
+# This file intentionally left blank

--- a/src/testdata/llm/Dockerfile
+++ b/src/testdata/llm/Dockerfile
@@ -1,1 +1,0 @@
-# This file intentionally left blank

--- a/src/testdata/llm/compose.yaml
+++ b/src/testdata/llm/compose.yaml
@@ -1,0 +1,14 @@
+services:
+  llm:
+    x-defang-llm: true
+    image: "llm:latest"
+
+  gateway-with-ports:
+    x-defang-llm: true
+    image: "defang.io/openai-access-gateway:latest"
+    ports:
+      - 5678:5678
+
+  gateway-without-ports:
+    x-defang-llm: true
+    image: "defang.io/openai-access-gateway:latest"

--- a/src/testdata/llm/compose.yaml
+++ b/src/testdata/llm/compose.yaml
@@ -13,6 +13,6 @@ services:
     x-defang-llm: true
     image: "defang.io/openai-access-gateway:latest"
 
-  not-our-gateway:
+  alt-repo:
     x-defang-llm: true
-    image: "fakerepo.com/openai-access-gateway:latest"
+    image: "altrepo.com/openai-access-gateway:latest"

--- a/src/testdata/llm/compose.yaml
+++ b/src/testdata/llm/compose.yaml
@@ -12,3 +12,7 @@ services:
   gateway-without-ports:
     x-defang-llm: true
     image: "defang.io/openai-access-gateway:latest"
+
+  not-our-gateway:
+    x-defang-llm: true
+    image: "fakerepo.com/openai-access-gateway:latest"

--- a/src/testdata/llm/compose.yaml.fixup
+++ b/src/testdata/llm/compose.yaml.fixup
@@ -1,4 +1,19 @@
 {
+  "alt-repo": {
+    "command": null,
+    "entrypoint": null,
+    "image": "altrepo.com/openai-access-gateway:latest",
+    "networks": {
+      "default": null
+    },
+    "ports": [
+      {
+        "mode": "host",
+        "target": 80,
+        "protocol": "tcp"
+      }
+    ]
+  },
   "gateway-with-ports": {
     "command": null,
     "entrypoint": null,
@@ -35,14 +50,6 @@
     "command": null,
     "entrypoint": null,
     "image": "llm:latest",
-    "networks": {
-      "default": null
-    }
-  },
-  "not-our-gateway": {
-    "command": null,
-    "entrypoint": null,
-    "image": "fakerepo.com/openai-access-gateway:latest",
     "networks": {
       "default": null
     }

--- a/src/testdata/llm/compose.yaml.fixup
+++ b/src/testdata/llm/compose.yaml.fixup
@@ -1,0 +1,42 @@
+{
+  "gateway-with-ports": {
+    "command": null,
+    "entrypoint": null,
+    "image": "defang.io/openai-access-gateway:latest",
+    "networks": {
+      "default": null
+    },
+    "ports": [
+      {
+        "mode": "ingress",
+        "target": 5678,
+        "published": "5678",
+        "protocol": "tcp",
+        "app_protocol": "http"
+      }
+    ]
+  },
+  "gateway-without-ports": {
+    "command": null,
+    "entrypoint": null,
+    "image": "defang.io/openai-access-gateway:latest",
+    "networks": {
+      "default": null
+    },
+    "ports": [
+      {
+        "mode": "host",
+        "target": 80,
+        "protocol": "tcp"
+      }
+    ]
+  },
+  "llm": {
+    "command": null,
+    "entrypoint": null,
+    "image": "llm:latest",
+    "networks": {
+      "default": null
+    }
+  }
+}

--- a/src/testdata/llm/compose.yaml.fixup
+++ b/src/testdata/llm/compose.yaml.fixup
@@ -38,5 +38,13 @@
     "networks": {
       "default": null
     }
+  },
+  "not-our-gateway": {
+    "command": null,
+    "entrypoint": null,
+    "image": "fakerepo.com/openai-access-gateway:latest",
+    "networks": {
+      "default": null
+    }
   }
 }

--- a/src/testdata/llm/compose.yaml.golden
+++ b/src/testdata/llm/compose.yaml.golden
@@ -1,5 +1,10 @@
 name: llm
 services:
+  alt-repo:
+    image: altrepo.com/openai-access-gateway:latest
+    networks:
+      default: null
+    x-defang-llm: true
   gateway-with-ports:
     image: defang.io/openai-access-gateway:latest
     networks:
@@ -17,11 +22,6 @@ services:
     x-defang-llm: true
   llm:
     image: llm:latest
-    networks:
-      default: null
-    x-defang-llm: true
-  not-our-gateway:
-    image: fakerepo.com/openai-access-gateway:latest
     networks:
       default: null
     x-defang-llm: true

--- a/src/testdata/llm/compose.yaml.golden
+++ b/src/testdata/llm/compose.yaml.golden
@@ -1,0 +1,25 @@
+name: llm
+services:
+  gateway-with-ports:
+    image: defang.io/openai-access-gateway:latest
+    networks:
+      default: null
+    ports:
+      - mode: ingress
+        target: 5678
+        published: "5678"
+        protocol: tcp
+    x-defang-llm: true
+  gateway-without-ports:
+    image: defang.io/openai-access-gateway:latest
+    networks:
+      default: null
+    x-defang-llm: true
+  llm:
+    image: llm:latest
+    networks:
+      default: null
+    x-defang-llm: true
+networks:
+  default:
+    name: llm_default

--- a/src/testdata/llm/compose.yaml.golden
+++ b/src/testdata/llm/compose.yaml.golden
@@ -20,6 +20,11 @@ services:
     networks:
       default: null
     x-defang-llm: true
+  not-our-gateway:
+    image: fakerepo.com/openai-access-gateway:latest
+    networks:
+      default: null
+    x-defang-llm: true
 networks:
   default:
     name: llm_default

--- a/src/testdata/llm/compose.yaml.warnings
+++ b/src/testdata/llm/compose.yaml.warnings
@@ -1,5 +1,5 @@
+ ! service "alt-repo": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors
  ! service "gateway-with-ports": ingress port without healthcheck defaults to GET / HTTP/1.1
  ! service "gateway-with-ports": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors
  ! service "gateway-without-ports": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors
  ! service "llm": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors
- ! service "not-our-gateway": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors

--- a/src/testdata/llm/compose.yaml.warnings
+++ b/src/testdata/llm/compose.yaml.warnings
@@ -2,3 +2,4 @@
  ! service "gateway-with-ports": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors
  ! service "gateway-without-ports": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors
  ! service "llm": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors
+ ! service "not-our-gateway": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors

--- a/src/testdata/llm/compose.yaml.warnings
+++ b/src/testdata/llm/compose.yaml.warnings
@@ -1,0 +1,4 @@
+ ! service "gateway-with-ports": ingress port without healthcheck defaults to GET / HTTP/1.1
+ ! service "gateway-with-ports": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors
+ ! service "gateway-without-ports": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors
+ ! service "llm": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors


### PR DESCRIPTION
## Description

For openai-access-gateway we want to set a default port configuration if one is not defined.
Also allow in playground.

## Linked Issues

None - this is a continuation of PR #1138

## Checklist

- [X] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

