### PR TITLE
Only repeat warnings for compose up

### DIFF
--- a/src/cmd/cli/command/commands.go
+++ b/src/cmd/cli/command/commands.go
@@ -125,9 +125,7 @@ func Execute(ctx context.Context) error {
 	}
 
 	if hasTty && term.HadWarnings() {
-		fmt.Println("Some warnings were seen during this command:")
-		term.FlushWarnings()
-		fmt.Println("For help with warnings, check our FAQ at https://docs.defang.io/docs/faq")
+		fmt.Println("For help with warnings, check our FAQ at https://s.defang.io/warnings")
 	}
 
 	if hasTty && !hideUpdate && rand.Intn(10) == 0 {
@@ -372,6 +370,7 @@ var RootCmd = &cobra.Command{
 			if connect.CodeOf(err) == connect.CodeUnauthenticated {
 				term.Debug("Server error:", err)
 				term.Warn("Please log in to continue.")
+				term.ResetWarnings() // clear any previous warnings so we don't show them again
 
 				defer func() { track.Cmd(nil, "Login", P("reason", err)) }()
 				if err = cli.InteractiveLogin(cmd.Context(), client, gitHubClientId, getCluster(), false); err != nil {
@@ -966,7 +965,8 @@ var deleteCmd = &cobra.Command{
 			Since:      since,
 			Verbose:    verbose,
 		}
-		return cli.Tail(cmd.Context(), provider, projectName, tailOptions)
+		tailCtx := cmd.Context() // FIXME: stop Tail when the deployment is done
+		return cli.Tail(tailCtx, provider, projectName, tailOptions)
 	},
 }
 

--- a/src/cmd/cli/command/compose.go
+++ b/src/cmd/cli/command/compose.go
@@ -190,6 +190,7 @@ func makeComposeUpCmd() *cobra.Command {
 			}
 
 			term.Info("Done.")
+			flushWarnings()
 			return nil
 		},
 	}
@@ -205,6 +206,13 @@ func makeComposeUpCmd() *cobra.Command {
 	_ = composeUpCmd.Flags().MarkHidden("wait")
 	composeUpCmd.Flags().Int("wait-timeout", -1, "maximum duration to wait for the project to be running|healthy") // docker-compose compatibility
 	return composeUpCmd
+}
+
+func flushWarnings() {
+	if hasTty && term.HadWarnings() {
+		fmt.Println("\nSome warnings were seen during this command:")
+		term.FlushWarnings()
+	}
 }
 
 func makeComposeStartCmd() *cobra.Command {
@@ -308,7 +316,7 @@ func makeComposeDownCmd() *cobra.Command {
 				Verbose:            verbose,
 				LogType:            logs.LogTypeAll,
 			}
-			tailCtx := cmd.Context()
+			tailCtx := cmd.Context() // FIXME: stop Tail when the deployment is done
 			err = cli.Tail(tailCtx, provider, projectName, tailOptions)
 			if err != nil {
 				if connect.CodeOf(err) == connect.CodePermissionDenied {
@@ -489,7 +497,6 @@ func makeComposeLogsCmd() *cobra.Command {
 				Until:      untilTs,
 				Verbose:    verbose,
 			}
-
 			return cli.Tail(cmd.Context(), provider, projectName, tailOptions)
 		},
 	}

--- a/src/pkg/term/colorizer.go
+++ b/src/pkg/term/colorizer.go
@@ -237,11 +237,13 @@ func (t *Term) Errorf(format string, v ...any) (int, error) {
 	return output(t.err, ErrorColor, line)
 }
 
+// Deprecated: use proper error handling instead
 func (t *Term) Fatal(msg any) {
 	Error("Error:", msg)
 	os.Exit(1)
 }
 
+// Deprecated: use proper error handling instead
 func (t *Term) Fatalf(format string, v ...any) {
 	Errorf("Error: "+format, v...)
 	os.Exit(1)
@@ -254,6 +256,7 @@ func (t *Term) getAllWarnings() []string {
 
 func (t *Term) FlushWarnings() (int, error) {
 	uniqueWarnings := t.getAllWarnings()
+	t.ResetWarnings()
 	bytesWritten := 0
 
 	// unique warnings only
@@ -266,6 +269,10 @@ func (t *Term) FlushWarnings() (int, error) {
 	}
 
 	return bytesWritten, nil
+}
+
+func (t *Term) ResetWarnings() {
+	t.warnings = nil
 }
 
 func Print(v ...any) (int, error) {
@@ -316,16 +323,22 @@ func Errorf(format string, v ...any) (int, error) {
 	return DefaultTerm.Errorf(format, v...)
 }
 
+// Deprecated: use proper error handling instead
 func Fatal(msg any) {
 	DefaultTerm.Fatal(msg)
 }
 
+// Deprecated: use proper error handling instead
 func Fatalf(format string, v ...any) {
 	DefaultTerm.Fatalf(format, v...)
 }
 
 func FlushWarnings() (int, error) {
 	return DefaultTerm.FlushWarnings()
+}
+
+func ResetWarnings() {
+	DefaultTerm.ResetWarnings()
 }
 
 func ForceColor(color bool) {

--- a/src/pkg/term/colorizer_test.go
+++ b/src/pkg/term/colorizer_test.go
@@ -236,6 +236,10 @@ func TestFlushWarnings(t *testing.T) {
 			if bytesInExpected != bytesWritten {
 				t.Errorf("FlushWarnings() expected %d byteWritten, got %d", bytesInExpected, bytesWritten)
 			}
+
+			if term.getAllWarnings() != nil {
+				t.Errorf("after FlushWarnings() expected no warnings, got %v", term.getAllWarnings())
+			}
 		})
 	}
 }


### PR DESCRIPTION
## Description

Most commands have very little output, so it's not useful to print the warnings once more at the end of the command. In particular, it's the `compose up` command that has tons of output, such that the original warnings have scrolled off the screen.

This PR also fixes the unnecessary repetition of the "Please log in" warning.


## Checklist

- [x] I have performed a self-review of my code
- [x] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

