### PR TITLE
Improve error when project name is needed

### DIFF
--- a/src/pkg/cli/compose/loader.go
+++ b/src/pkg/cli/compose/loader.go
@@ -73,6 +73,9 @@ func (c *Loader) LoadProjectName(ctx context.Context) (string, error) {
 
 	project, err := c.LoadProject(ctx)
 	if err != nil {
+		if errors.Is(err, types.ErrComposeFileNotFound) {
+			return "", fmt.Errorf("no --project-name specified and %w", err)
+		}
 		return "", err
 	}
 


### PR DESCRIPTION
## Description

When you do for example `defang deployments list` outside a project folder, the error message reads `Error: no compose.yaml file found`, which is correct but forgets to mention that you only need that file when you don't specify `--project-name`. 

This applies to other commands that need project name, but don't actual need the Compose project. This PR will show `no --project-name specified and no compose.yaml file found`.


## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

