### PR TITLE
config is not initialized after JSON unmarshal succeeds

### DIFF
--- a/src/pkg/mcp/setup.go
+++ b/src/pkg/mcp/setup.go
@@ -295,6 +295,10 @@ func SetupClient(client string) error {
 			}
 		}
 
+		if config.MCPServers == nil {
+			config.MCPServers = make(map[string]MCPServerConfig)
+		}
+
 		// Add or update the Defang MCP server config
 		config.MCPServers["defang"] = getDefangMCPConfig()
 


### PR DESCRIPTION
## Description
- If the JSON unmarshal succeeds, but the file on disk does not contain the MCPServers field (or it is null in the JSON), then after unmarshal, config.MCPServers will be nil. This is a subtle bug: If the config file exists and is missing the MCPServers field, unmarshal will not set it, leaving it as nil.

- Then, when I try to assign to config.MCPServers["defang"], causing the panic.

- Solution: map instantiation guard before assignment

Test are written in a different PR
<!-- Concise description of what this PR is tackling. -->

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

