### PR TITLE
Add -g to brew upgrade

### DIFF
--- a/src/pkg/cli/upgrade.go
+++ b/src/pkg/cli/upgrade.go
@@ -27,7 +27,7 @@ func Upgrade(ctx context.Context) error {
 
 	prefix, err := homebrewPrefix(ctx)
 	if err == nil && strings.HasPrefix(ex, prefix) {
-		printInstructions("brew upgrade defang")
+		printInstructions("brew upgrade -g defang")
 		return nil
 	}
 


### PR DESCRIPTION
## Description

By default, `brew upgrade defang` doesn't upgrade any already installed version of `defang` because it's a cask, and the user will have to first do `brew update`, but adding `-g` makes the upgrade "greedy" and will update the cask (and the tool).

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

