### PR TITLE
Use openai-access-gateway for model runner

### DIFF
--- a/pkgs/defang/cli.nix
+++ b/pkgs/defang/cli.nix
@@ -7,7 +7,7 @@ buildGoModule {
   pname = "defang-cli";
   version = "git";
   src = ../../src;
-  vendorHash = "sha256-bWqMeT8EeO7wv0mXu/x2BLgn0YWnVbAIVbUdRijMHN4="; # TODO: use fetchFromGitHub
+  vendorHash = "sha256-Mc5I7mXvut/D1X4d+FIpLmMTtuuAgDa1k0qjBPpuCZU="; # TODO: use fetchFromGitHub
 
   subPackages = [ "cmd/cli" ];
 

--- a/src/go.mod
+++ b/src/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/aws/smithy-go v1.22.1
 	github.com/awslabs/goformation/v7 v7.13.1
 	github.com/bufbuild/connect-go v1.10.0
-	github.com/compose-spec/compose-go/v2 v2.4.3
+	github.com/compose-spec/compose-go/v2 v2.6.2
 	github.com/digitalocean/godo v1.131.1
 	github.com/docker/docker v25.0.6+incompatible
 	github.com/golang-jwt/jwt/v5 v5.2.2
@@ -98,6 +98,7 @@ require (
 	github.com/rivo/uniseg v0.4.2 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/spiffe/go-spiffe/v2 v2.5.0 // indirect
+	github.com/xhit/go-str2duration/v2 v2.1.0 // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	github.com/zeebo/errs v1.4.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
@@ -154,7 +155,6 @@ require (
 	go.opentelemetry.io/otel/metric v1.35.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.35.0 // indirect
 	go.opentelemetry.io/otel/trace v1.35.0 // indirect
-	golang.org/x/exp v0.0.0-20240112132812-db7319d0e0e3 // indirect; compose-go is using the older slices.sortFunc API
 	golang.org/x/sync v0.13.0 // indirect
 	golang.org/x/text v0.24.0 // indirect
 	golang.org/x/time v0.11.0 // indirect

--- a/src/go.sum
+++ b/src/go.sum
@@ -112,8 +112,8 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cncf/xds/go v0.0.0-20250121191232-2f005788dc42 h1:Om6kYQYDUk5wWbT0t0q6pvyM49i9XZAv9dDrkDA7gjk=
 github.com/cncf/xds/go v0.0.0-20250121191232-2f005788dc42/go.mod h1:W+zGtBO5Y1IgJhy4+A9GOqVhqLpfZi+vwmdNXUehLA8=
-github.com/compose-spec/compose-go/v2 v2.4.3 h1:4+Nd9IqIGobbPles9ZuRS5uJfFfRgBo4Wdcv+8VNex8=
-github.com/compose-spec/compose-go/v2 v2.4.3/go.mod h1:lFN0DrMxIncJGYAXTfWuajfwj5haBJqrBkarHcnjJKc=
+github.com/compose-spec/compose-go/v2 v2.6.2 h1:31uZNNLeRrKjtUCc56CzPpPykW1Tm6SxLn4gx9Jjzqw=
+github.com/compose-spec/compose-go/v2 v2.6.2/go.mod h1:vPlkN0i+0LjLf9rv52lodNMUTJF5YHVfHVGLLIP67NA=
 github.com/containerd/log v0.1.0 h1:TCJt7ioM2cr/tfR8GPbGf9/VRAX8D2B4PjzCpfX540I=
 github.com/containerd/log v0.1.0/go.mod h1:VRRf09a7mHDIRezVKTRCrOq78v577GXq3bSa3EhrzVo=
 github.com/cpuguy83/go-md2man/v2 v2.0.6 h1:XJtiaUW6dEEqVuZiMTn1ldk455QWwEIsMIJlo5vtkx0=
@@ -290,6 +290,8 @@ github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 h1:EzJWgHo
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
 github.com/xeipuuv/gojsonschema v1.2.0 h1:LhYJRs+L4fBtjZUfuSZIKGeVu0QRy8e5Xi7D17UxZ74=
 github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=
+github.com/xhit/go-str2duration/v2 v2.1.0 h1:lxklc02Drh6ynqX+DdPyp5pCKLUQpRT8bp8Ydu2Bstc=
+github.com/xhit/go-str2duration/v2 v2.1.0/go.mod h1:ohY8p+0f07DiV6Em5LKB0s2YpLtXVyJfNt1+BlmyAsU=
 github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=
 github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
@@ -329,8 +331,6 @@ golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.37.0 h1:kJNSjF/Xp7kU0iB2Z+9viTPMW4EqqsrywMXLJOOsXSE=
 golang.org/x/crypto v0.37.0/go.mod h1:vg+k43peMZ0pUMhYmVAWysMK35e6ioLh3wB8ZCAfbVc=
-golang.org/x/exp v0.0.0-20240112132812-db7319d0e0e3 h1:hNQpMuAJe5CtcUqCXaWga3FHu+kQvCqcsoVaQgSV60o=
-golang.org/x/exp v0.0.0-20240112132812-db7319d0e0e3/go.mod h1:idGWGoKP1toJGkd5/ig9ZLuPcZBC3ewk7SzmH0uou08=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=

--- a/src/pkg/cli/compose/fixup.go
+++ b/src/pkg/cli/compose/fixup.go
@@ -133,6 +133,10 @@ func FixupServices(ctx context.Context, provider client.Provider, project *types
 			}
 		}
 
+		if svccfg.Provider != nil && svccfg.Provider.Type == "model" && svccfg.Image == "" && svccfg.Deploy == nil {
+			svccfg.Image = "defangio/openai-access-gateway"
+		}
+
 		_, postgres := svccfg.Extensions["x-defang-postgres"]
 		if postgres {
 			if _, ok := provider.(*client.PlaygroundProvider); ok {

--- a/src/pkg/cli/compose/fixup.go
+++ b/src/pkg/cli/compose/fixup.go
@@ -2,6 +2,7 @@ package compose
 
 import (
 	"context"
+	"fmt"
 	"slices"
 	"strconv"
 	"strings"
@@ -108,95 +109,26 @@ func FixupServices(ctx context.Context, provider client.Provider, project *types
 			term.Warnf("service %q: environment variable(s) %s overridden by config", svccfg.Name, pkg.QuotedArray(overriddenCfg))
 		}
 
-		_, redis := svccfg.Extensions["x-defang-redis"]
-		if redis {
-			if _, ok := provider.(*client.PlaygroundProvider); ok {
-				term.Warnf("service %q: Managed redis is not supported in the Playground; consider using BYOC (https://s.defang.io/byoc)", svccfg.Name)
-				delete(svccfg.Extensions, "x-defang-redis")
-			} else if len(svccfg.Ports) == 0 {
-				// HACK: we must have at least one host port to get a CNAME for the service https://redis.io/docs/latest/operate/oss_and_stack/management/config/
-				var port uint32 = 6379
-				// Check entrypoint or command for --port argument
-				args := append(svccfg.Entrypoint, svccfg.Command...)
-				for i, arg := range args {
-					if arg == "--port" {
-						if p, err := strconv.ParseUint(args[i+1], 10, 16); err != nil {
-							return err
-						} else {
-							port = uint32(p)
-							break
-						}
-					}
-				}
-				term.Debugf("service %q: adding redis host port %d", svccfg.Name, port)
-				svccfg.Ports = []types.ServicePortConfig{{Target: port, Mode: Mode_HOST, Protocol: Protocol_TCP}}
+		_, managedRedis := svccfg.Extensions["x-defang-redis"]
+		if managedRedis {
+			if err := fixupRedisService(&svccfg, provider); err != nil {
+				return fmt.Errorf("service %q: %w", svccfg.Name, err)
 			}
 		}
 
-		if svccfg.Provider != nil && svccfg.Provider.Type == "model" && svccfg.Image == "" && svccfg.Build == nil {
-			envName := strings.ToUpper(svccfg.Name) // TODO: handle characters that are not allowed in env vars, like '-'
-			urlEnv := envName + "_URL"
-			urlVal := "http://" + provider.ServiceDNS(NormalizeServiceName(svccfg.Name)) + "/api/v1/"
-			modelEnv := envName + "_MODEL"
-			modelVal := svccfg.Provider.Options["model"]
-
-			empty := ""
-			svccfg.Environment = types.MappingWithEquals{"OPENAI_API_KEY": &empty} // disable auth
-			svccfg.Image = "defangio/openai-access-gateway"
-			svccfg.Provider = nil // remove "provider:" because current backend will not accept it
-			svccfg.Ports = []types.ServicePortConfig{{Target: 80, Mode: Mode_HOST, Protocol: Protocol_TCP}}
-			// svccfg.Deploy.Resources.Reservations.Limits = &types.Resources{} TODO: avoid memory limits warning
-			// svccfg.HealthCheck = &types.ServiceHealthCheckConfig{} TODO: add healthcheck
-
-			// Set environment variables (url and model) for any service that depends on the provider pseudo service
-			for _, dependency := range project.Services {
-				if _, ok := dependency.DependsOn[svccfg.Name]; ok {
-					if dependency.Environment == nil {
-						dependency.Environment = make(types.MappingWithEquals)
-					}
-					if _, ok := dependency.Environment[urlEnv]; !ok {
-						dependency.Environment[urlEnv] = &urlVal
-					}
-					if _, ok := dependency.Environment[modelEnv]; !ok && modelVal != "" {
-						dependency.Environment[modelEnv] = &modelVal
-					}
-				}
+		_, managedPostgres := svccfg.Extensions["x-defang-postgres"]
+		if managedPostgres {
+			if err := fixupPostgresService(&svccfg, provider); err != nil {
+				return fmt.Errorf("service %q: %w", svccfg.Name, err)
 			}
 		}
 
-		_, postgres := svccfg.Extensions["x-defang-postgres"]
-		if postgres {
-			if _, ok := provider.(*client.PlaygroundProvider); ok {
-				term.Warnf("service %q: managed postgres is not supported in the Playground; consider using BYOC (https://s.defang.io/byoc)", svccfg.Name)
-				delete(svccfg.Extensions, "x-defang-postgres")
-			} else if len(svccfg.Ports) == 0 {
-				// HACK: we must have at least one host port to get a CNAME for the service
-				var port uint32 = 5432
-				// Check PGPORT environment variable for port number https://www.postgresql.org/docs/current/libpq-envars.html
-				if pgport := svccfg.Environment["PGPORT"]; pgport != nil {
-					if p, err := strconv.ParseUint(*pgport, 10, 16); err != nil {
-						return err
-					} else {
-						port = uint32(p)
-					}
-				}
-				term.Debugf("service %q: adding postgres host port %d", svccfg.Name, port)
-				svccfg.Ports = []types.ServicePortConfig{{Target: port, Mode: Mode_HOST, Protocol: Protocol_TCP}}
-			}
+		if svccfg.Provider != nil && svccfg.Provider.Type == "model" {
+			fixupModelProvider(&svccfg, provider, project)
 		}
 
 		if _, llm := svccfg.Extensions["x-defang-llm"]; llm {
-			image := getImageRepo(svccfg.Image)
-			if strings.HasSuffix(image, "/openai-access-gateway") && len(svccfg.Ports) == 0 {
-				// HACK: we must have at least one host port to get a CNAME for the service
-				var port uint32 = 80
-				term.Debugf("service %q: adding LLM host port %d", svccfg.Name, port)
-				svccfg.Ports = []types.ServicePortConfig{{Target: port, Mode: Mode_HOST, Protocol: Protocol_TCP}}
-			}
-		}
-
-		if !redis && !postgres && isStatefulImage(svccfg.Image) {
-			term.Warnf("service %q: stateful service will lose data on restart; use a managed service instead", svccfg.Name)
+			fixupLLM(&svccfg)
 		}
 
 		_, scaling := svccfg.Extensions["x-defang-autoscaling"]
@@ -211,6 +143,103 @@ func FixupServices(ctx context.Context, provider client.Provider, project *types
 	}
 
 	return nil
+}
+
+func parsePortString(port string) (uint32, error) {
+	if p, err := strconv.ParseUint(port, 10, 16); err != nil {
+		return 0, fmt.Errorf("invalid port number %q: %w", port, err)
+	} else {
+		return uint32(p), nil
+	}
+}
+
+func fixupLLM(svccfg *types.ServiceConfig) {
+	image := getImageRepo(svccfg.Image)
+	if strings.HasSuffix(image, "/openai-access-gateway") && len(svccfg.Ports) == 0 {
+		// HACK: we must have at least one host port to get a CNAME for the service
+		var port uint32 = 80
+		term.Debugf("service %q: adding LLM host port %d", svccfg.Name, port)
+		svccfg.Ports = []types.ServicePortConfig{{Target: port, Mode: Mode_HOST, Protocol: Protocol_TCP}}
+	}
+}
+
+func fixupPostgresService(svccfg *types.ServiceConfig, provider client.Provider) error {
+	if _, ok := provider.(*client.PlaygroundProvider); ok {
+		term.Warnf("service %q: managed postgres is not supported in the Playground; consider using BYOC (https://s.defang.io/byoc)", svccfg.Name)
+		delete(svccfg.Extensions, "x-defang-postgres")
+	} else if len(svccfg.Ports) == 0 {
+		// HACK: we must have at least one host port to get a CNAME for the service
+		var port uint32 = 5432
+		// Check PGPORT environment variable for port number https://www.postgresql.org/docs/current/libpq-envars.html
+		if pgport := svccfg.Environment["PGPORT"]; pgport != nil {
+			var err error
+			port, err = parsePortString(*pgport)
+			if err != nil {
+				return err
+			}
+		}
+		term.Debugf("service %q: adding postgres host port %d", svccfg.Name, port)
+		svccfg.Ports = []types.ServicePortConfig{{Target: port, Mode: Mode_HOST, Protocol: Protocol_TCP}}
+	}
+	return nil
+}
+
+func fixupRedisService(svccfg *types.ServiceConfig, provider client.Provider) error {
+	if _, ok := provider.(*client.PlaygroundProvider); ok {
+		term.Warnf("service %q: Managed redis is not supported in the Playground; consider using BYOC (https://s.defang.io/byoc)", svccfg.Name)
+		delete(svccfg.Extensions, "x-defang-redis")
+	} else if len(svccfg.Ports) == 0 {
+		// HACK: we must have at least one host port to get a CNAME for the service https://redis.io/docs/latest/operate/oss_and_stack/management/config/
+		var port uint32 = 6379
+		// Check entrypoint or command for --port argument
+		args := append(svccfg.Entrypoint, svccfg.Command...)
+		for i, arg := range args {
+			if arg == "--port" {
+				var err error
+				port, err = parsePortString(args[i+1])
+				if err != nil {
+					return err
+				}
+			}
+		}
+		term.Debugf("service %q: adding redis host port %d", svccfg.Name, port)
+		svccfg.Ports = []types.ServicePortConfig{{Target: port, Mode: Mode_HOST, Protocol: Protocol_TCP}}
+	}
+	return nil
+}
+
+func fixupModelProvider(svccfg *types.ServiceConfig, provider client.Provider, project *types.Project) {
+	if svccfg.Image == "" && svccfg.Build == nil {
+		// Local Docker sets [SERVICE]_URL and [SERVICE]_MODEL environment variables on the dependent services
+		envName := strings.ToUpper(svccfg.Name) // TODO: handle characters that are not allowed in env vars, like '-'
+		urlEnv := envName + "_URL"
+		urlVal := "http://" + provider.ServiceDNS(NormalizeServiceName(svccfg.Name)) + "/api/v1/"
+		modelEnv := envName + "_MODEL"
+		modelVal := svccfg.Provider.Options["model"]
+
+		empty := ""
+		svccfg.Environment = types.MappingWithEquals{"OPENAI_API_KEY": &empty} // disable auth; see https://github.com/DefangLabs/openai-access-gateway/pull/5
+		svccfg.Image = "defangio/openai-access-gateway"
+		svccfg.Provider = nil // remove "provider:" because current backend will not accept it
+		svccfg.Ports = []types.ServicePortConfig{{Target: 80, Mode: Mode_HOST, Protocol: Protocol_TCP}}
+		// svccfg.Deploy.Resources.Reservations.Limits = &types.Resources{} TODO: avoid memory limits warning
+		// svccfg.HealthCheck = &types.ServiceHealthCheckConfig{} TODO: add healthcheck
+
+		// Set environment variables (url and model) for any service that depends on the provider pseudo service
+		for _, dependency := range project.Services {
+			if _, ok := dependency.DependsOn[svccfg.Name]; ok {
+				if dependency.Environment == nil {
+					dependency.Environment = make(types.MappingWithEquals)
+				}
+				if _, ok := dependency.Environment[urlEnv]; !ok {
+					dependency.Environment[urlEnv] = &urlVal
+				}
+				if _, ok := dependency.Environment[modelEnv]; !ok && modelVal != "" {
+					dependency.Environment[modelEnv] = &modelVal
+				}
+			}
+		}
+	}
 }
 
 func getImageRepo(imageRepo string) string {

--- a/src/pkg/cli/compose/validation_test.go
+++ b/src/pkg/cli/compose/validation_test.go
@@ -217,7 +217,7 @@ func TestManagedStoreParams(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := ValidateManagedStore(tt.extension); err != nil {
+			if err := validateManagedStore(tt.extension); err != nil {
 				if len(tt.errors) == 0 {
 					t.Fatalf("ValidateManagedStore() unexpected err = %v", err)
 				}

--- a/src/testdata/provider/compose.yaml
+++ b/src/testdata/provider/compose.yaml
@@ -1,18 +1,11 @@
 services:
   chat:
     image: my-chat-app
-    # image: alpine
-    # command: "sh -c 'export'"
-    # image: node
-    # command: "node -e 'console.log(process.env)'"
-    # image: python
-    # command: "python -c 'import os; print(os.environ)'"
-    # image: golang
-    # command: ["sh", "-c", "printf 'package main\n\nimport \"fmt\"\nimport \"os\"\nfunc main() {\n\tfmt.Println(os.Environ())\n}' > hello.go && go run hello.go"]
     # image: curlimages/curl
-    # command: "sh -c 'echo $AI-RUNNER_URL'"
-    # environment:
-    #   - AI_RUNNER_URL=a
+    # command:
+    #   - "sh"
+    #   - "-c"
+    #   - "curl -sf $${AI_RUNNER_URL}chat/completions -H 'Content-Type: application/json' -d '{\"model\":\"anthropic.claude-3-5-sonnet-20241022-v2:0\",\"messages\":[{\"role\":\"user\",\"content\":\"Hello, world!\"}]}'; sleep 5"
     depends_on:
       - ai_runner
 
@@ -21,3 +14,4 @@ services:
       type: model
       options:
         model: ai/smollm2
+    # x-defang-llm: true

--- a/src/testdata/provider/compose.yaml
+++ b/src/testdata/provider/compose.yaml
@@ -1,0 +1,23 @@
+services:
+  chat:
+    image: my-chat-app
+    # image: alpine
+    # command: "sh -c 'export'"
+    # image: node
+    # command: "node -e 'console.log(process.env)'"
+    # image: python
+    # command: "python -c 'import os; print(os.environ)'"
+    # image: golang
+    # command: ["sh", "-c", "printf 'package main\n\nimport \"fmt\"\nimport \"os\"\nfunc main() {\n\tfmt.Println(os.Environ())\n}' > hello.go && go run hello.go"]
+    # image: curlimages/curl
+    # command: "sh -c 'echo $AI-RUNNER_URL'"
+    # environment:
+    #   - AI_RUNNER_URL=a
+    depends_on:
+      - ai_runner
+
+  ai_runner:
+    provider:
+      type: model
+      options:
+        model: ai/smollm2

--- a/src/testdata/provider/compose.yaml.fixup
+++ b/src/testdata/provider/compose.yaml.fixup
@@ -2,16 +2,20 @@
   "ai_runner": {
     "command": null,
     "entrypoint": null,
-    "provider": {
-      "driver": "model",
-      "options": {
-        "model": "ai/smollm2"
-      }
+    "environment": {
+      "OPENAI_API_KEY": ""
     },
     "image": "defangio/openai-access-gateway",
     "networks": {
       "default": null
-    }
+    },
+    "ports": [
+      {
+        "mode": "host",
+        "target": 80,
+        "protocol": "tcp"
+      }
+    ]
   },
   "chat": {
     "command": null,
@@ -22,6 +26,10 @@
       }
     },
     "entrypoint": null,
+    "environment": {
+      "AI_RUNNER_MODEL": "ai/smollm2",
+      "AI_RUNNER_URL": "http://ai-runner/api/v1/"
+    },
     "image": "my-chat-app",
     "networks": {
       "default": null

--- a/src/testdata/provider/compose.yaml.fixup
+++ b/src/testdata/provider/compose.yaml.fixup
@@ -1,0 +1,30 @@
+{
+  "ai_runner": {
+    "command": null,
+    "entrypoint": null,
+    "provider": {
+      "driver": "model",
+      "options": {
+        "model": "ai/smollm2"
+      }
+    },
+    "image": "defangio/openai-access-gateway",
+    "networks": {
+      "default": null
+    }
+  },
+  "chat": {
+    "command": null,
+    "depends_on": {
+      "ai_runner": {
+        "condition": "service_started",
+        "required": true
+      }
+    },
+    "entrypoint": null,
+    "image": "my-chat-app",
+    "networks": {
+      "default": null
+    }
+  }
+}

--- a/src/testdata/provider/compose.yaml.golden
+++ b/src/testdata/provider/compose.yaml.golden
@@ -1,0 +1,20 @@
+name: provider
+services:
+  ai_runner:
+    provider:
+      type: model
+      options:
+        model: ai/smollm2
+    networks:
+      default: null
+  chat:
+    depends_on:
+      ai_runner:
+        condition: service_started
+        required: true
+    image: my-chat-app
+    networks:
+      default: null
+networks:
+  default:
+    name: provider_default

--- a/src/testdata/provider/compose.yaml.warnings
+++ b/src/testdata/provider/compose.yaml.warnings
@@ -1,0 +1,2 @@
+ ! service "ai_runner": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors
+ ! service "chat": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors


### PR DESCRIPTION
## Description

When we detect a Docker Model Runner `provider:`, we transparently replace that with the `openai-access-gateway`, so that the project works as-is! This still requires changing the model name, local vs cloud, but the future "model map" can take care of that.


## Checklist

- [x] I have performed a self-review of my code
- [x] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

