### PR TITLE
Enable secrets manager API when needed in config put api

### DIFF
--- a/src/pkg/cli/client/byoc/aws/domain.go
+++ b/src/pkg/cli/client/byoc/aws/domain.go
@@ -97,6 +97,9 @@ func getOrCreateDelegationSetByZone(ctx context.Context, zone *types.HostedZone,
 			term.Debug("Route53 delegation set already created:", err)
 			delegationSet, err = aws.GetDelegationSetByZone(ctx, zone.Id, r53Client)
 		}
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// Ensure the zone's NS records match the ones from the delegation set if the zone already exists


### PR DESCRIPTION
## Description
When a fresh account running gcp byoc, and user tries to put a config without deployments, it may encounter permission error as the API has not been enabled.
The code here tries to enable it if the first put api call fails.

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

