### PR TITLE
Use project id as AccountID for gcp instead of email

### DIFF
--- a/src/pkg/cli/client/byoc/gcp/byoc.go
+++ b/src/pkg/cli/client/byoc/gcp/byoc.go
@@ -301,7 +301,7 @@ type GcpAccountInfo struct {
 }
 
 func (g GcpAccountInfo) AccountID() string {
-	return g.email
+	return g.projectId
 }
 
 func (g GcpAccountInfo) Region() string {
@@ -309,7 +309,7 @@ func (g GcpAccountInfo) Region() string {
 }
 
 func (g GcpAccountInfo) Details() string {
-	return g.projectId
+	return g.email
 }
 
 func (g GcpAccountInfo) Provider() client.ProviderID {


### PR DESCRIPTION
## Description
So deployment table will track the gcp project ID instead of email.

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

