### PR TITLE
Add defang estimate command

### DIFF
--- a/pkgs/defang/cli.nix
+++ b/pkgs/defang/cli.nix
@@ -7,7 +7,7 @@ buildGoModule {
   pname = "defang-cli";
   version = "git";
   src = ../../src;
-  vendorHash = "sha256-HUMNGnWywA6aGDwa7ym8noGo90aPtv0YwG4asQlyfOE="; # TODO: use fetchFromGitHub
+  vendorHash = "sha256-cz8/CTwptYr6bm9vSX3WHOOdR5BXQOhd32t27+ukMp0="; # TODO: use fetchFromGitHub
 
   subPackages = [ "cmd/cli" ];
 

--- a/src/cmd/cli/command/commands.go
+++ b/src/cmd/cli/command/commands.go
@@ -260,6 +260,9 @@ func SetupCommands(ctx context.Context, version string) {
 	restart.Hidden = true // hidden from top-level menu
 	RootCmd.AddCommand(restart)
 
+	estimateCmd := makeComposeEstimateCmd()
+	RootCmd.AddCommand(estimateCmd)
+
 	// Debug Command
 	debugCmd.Flags().String("etag", "", "deployment ID (ETag) of the service")
 	debugCmd.Flags().MarkHidden("etag")

--- a/src/cmd/cli/command/commands.go
+++ b/src/cmd/cli/command/commands.go
@@ -260,7 +260,7 @@ func SetupCommands(ctx context.Context, version string) {
 	restart.Hidden = true // hidden from top-level menu
 	RootCmd.AddCommand(restart)
 
-	estimateCmd := makeComposeEstimateCmd()
+	estimateCmd := makeEstimateCmd()
 	RootCmd.AddCommand(estimateCmd)
 
 	// Debug Command

--- a/src/cmd/cli/command/compose.go
+++ b/src/cmd/cli/command/compose.go
@@ -531,12 +531,12 @@ func makeComposeEstimateCmd() *cobra.Command {
 			region, _ := cmd.Flags().GetString("region")
 			os.Setenv("DEFANG_JSON", "1") // always show JSON output for estimate
 			loader := configureLoader(cmd)
-			project, err := loader.LoadProject(cmd.Context())
+			project, err := loader.LoadProject(ctx)
 			if err != nil {
 				return err
 			}
 
-			provider, err := getProvider(cmd.Context(), loader)
+			provider, err := getProvider(ctx, loader)
 			if err != nil {
 				return err
 			}

--- a/src/cmd/cli/command/compose.go
+++ b/src/cmd/cli/command/compose.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -593,7 +594,11 @@ func makeComposeEstimateCmd() *cobra.Command {
 				}
 			}
 
-			term.Println("Estimate:")
+			// sort line items by description
+			sort.Slice(lineItems, func(i, j int) bool {
+				return lineItems[i].Description < lineItems[j].Description
+			})
+
 			term.Table(lineItems, []string{"Cost", "Quantity", "Description"})
 			fmt.Printf("Estimated Monthly Cost: $%.2f %s (+ usage)\n", estimate.Subtotal, estimate.Currency)
 			fmt.Printf("Estimate does not include tax or discounts.\n")

--- a/src/cmd/cli/command/compose.go
+++ b/src/cmd/cli/command/compose.go
@@ -587,7 +587,7 @@ func makeComposeEstimateCmd() *cobra.Command {
 					lineItem.Description,
 				)
 			}
-			fmt.Printf("Estimated Total: $%.2f %s (+ usage)\n", estimate.Subtotal, estimate.Currency)
+			fmt.Printf("Estimated Monthly Cost: $%.2f %s (+ usage)\n", estimate.Subtotal, estimate.Currency)
 			fmt.Printf("Estimate does not include tax or discounts.\n")
 
 			return nil

--- a/src/cmd/cli/command/compose.go
+++ b/src/cmd/cli/command/compose.go
@@ -520,6 +520,12 @@ func makeComposeLogsCmd() *cobra.Command {
 	return logsCmd
 }
 
+type EstimateLineItemTableItem struct {
+	Cost        string
+	Quantity    string
+	Description string
+}
+
 func makeComposeEstimateCmd() *cobra.Command {
 	var estimateCmd = &cobra.Command{
 		Use:         "estimate",
@@ -578,15 +584,17 @@ func makeComposeEstimateCmd() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("failed to estimate: %w", err)
 			}
-
-			fmt.Printf("Estimate:\n")
-			for _, lineItem := range estimate.LineItems {
-				fmt.Printf("$%.2f\t%.2f %s\t%s\n",
-					lineItem.Cost,
-					lineItem.Quantity, lineItem.Unit,
-					lineItem.Description,
-				)
+			lineItems := make([]EstimateLineItemTableItem, len(estimate.LineItems))
+			for i, lineItem := range estimate.LineItems {
+				lineItems[i] = EstimateLineItemTableItem{
+					Cost:        fmt.Sprintf("$%.2f", lineItem.Cost),
+					Quantity:    fmt.Sprintf("%.2f %s", lineItem.Quantity, lineItem.Unit),
+					Description: lineItem.Description,
+				}
 			}
+
+			term.Println("Estimate:")
+			term.Table(lineItems, []string{"Cost", "Quantity", "Description"})
 			fmt.Printf("Estimated Monthly Cost: $%.2f %s (+ usage)\n", estimate.Subtotal, estimate.Currency)
 			fmt.Printf("Estimate does not include tax or discounts.\n")
 

--- a/src/cmd/cli/command/compose.go
+++ b/src/cmd/cli/command/compose.go
@@ -588,7 +588,7 @@ func makeComposeEstimateCmd() *cobra.Command {
 			lineItems := make([]EstimateLineItemTableItem, len(estimate.LineItems))
 			for i, lineItem := range estimate.LineItems {
 				lineItems[i] = EstimateLineItemTableItem{
-					Cost:        fmt.Sprintf("$%.2f", lineItem.Cost),
+					Cost:        lineItem.Cost.String(),
 					Quantity:    fmt.Sprintf("%.2f %s", lineItem.Quantity, lineItem.Unit),
 					Description: lineItem.Description,
 				}
@@ -600,7 +600,7 @@ func makeComposeEstimateCmd() *cobra.Command {
 			})
 
 			term.Table(lineItems, []string{"Cost", "Quantity", "Description"})
-			fmt.Printf("Estimated Monthly Cost: $%.2f %s (+ usage)\n", estimate.Subtotal, estimate.Currency)
+			fmt.Printf("Estimated Monthly Cost: %s (+ usage)\n", estimate.Subtotal.String())
 			fmt.Printf("Estimate does not include tax or discounts.\n")
 
 			return nil

--- a/src/cmd/cli/command/compose.go
+++ b/src/cmd/cli/command/compose.go
@@ -553,7 +553,6 @@ services:
 	composeCmd.AddCommand(makeComposeStartCmd())
 	composeCmd.AddCommand(makeComposeRestartCmd())
 	composeCmd.AddCommand(makeComposeStopCmd())
-	composeCmd.AddCommand(makeComposeEstimateCmd())
 
 	return composeCmd
 }

--- a/src/cmd/cli/command/estimate.go
+++ b/src/cmd/cli/command/estimate.go
@@ -1,0 +1,140 @@
+package command
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/DefangLabs/defang/src/pkg"
+	"github.com/DefangLabs/defang/src/pkg/cli"
+	cliClient "github.com/DefangLabs/defang/src/pkg/cli/client"
+	"github.com/DefangLabs/defang/src/pkg/cli/compose"
+	"github.com/DefangLabs/defang/src/pkg/logs"
+	"github.com/DefangLabs/defang/src/pkg/money"
+	"github.com/DefangLabs/defang/src/pkg/term"
+	defangv1 "github.com/DefangLabs/defang/src/protos/io/defang/v1"
+	"github.com/spf13/cobra"
+)
+
+func makeComposeEstimateCmd() *cobra.Command {
+	var estimateCmd = &cobra.Command{
+		Use:         "estimate",
+		Args:        cobra.NoArgs,
+		Annotations: authNeededAnnotation,
+		Short:       "Estimate the cost of deploying the current project",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			region, _ := cmd.Flags().GetString("region")
+
+			loader := configureLoader(cmd)
+			project, err := loader.LoadProject(ctx)
+			if err != nil {
+				return err
+			}
+
+			provider, err := getProvider(ctx, loader)
+			if err != nil {
+				return err
+			}
+
+			err = canIUseProvider(ctx, provider, project.Name)
+			if err != nil {
+				return err
+			}
+
+			return RunEstimate(ctx, project, provider, region, mode.Value())
+		},
+	}
+
+	estimateCmd.Flags().VarP(&mode, "mode", "m", fmt.Sprintf("deployment mode; one of %v", allModes()))
+	estimateCmd.Flags().StringP("region", "r", pkg.Getenv("AWS_REGION", "us-west-2"), "which cloud region to estimate")
+	return estimateCmd
+}
+
+func RunEstimate(ctx context.Context, project *compose.Project, provider cliClient.Provider, region string, mode defangv1.DeploymentMode) error {
+	os.Setenv("DEFANG_JSON", "1") // always show JSON output for estimate
+	since := time.Now()
+
+	term.Info("Generating deployment preview")
+	resp, project, err := cli.ComposeUp(ctx, project, client, provider, compose.UploadModePreview, mode)
+	if err != nil {
+		return err
+	}
+
+	var pulumiPreviewLogLines []string
+	options := cli.TailOptions{
+		Deployment: resp.Etag,
+		Since:      since,
+		LogType:    logs.LogTypeBuild,
+		Verbose:    true,
+	}
+
+	err = cli.TailAndWaitForCD(ctx, project.Name, provider, options, func(entry *defangv1.LogEntry, options *cli.TailOptions) error {
+		pulumiPreviewLogLines = append(pulumiPreviewLogLines, entry.GetMessage())
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("failed to tail and wait for cd: %w", err)
+	}
+
+	preview := strings.Join(pulumiPreviewLogLines, "\n")
+
+	term.Debugf("Preview output: %s\n", preview)
+
+	term.Info("Preparing estimate")
+	estimate, err := client.Estimate(ctx, &defangv1.EstimateRequest{
+		Provider:      providerID.EnumValue(),
+		Region:        region,
+		PulumiPreview: []byte(preview),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to estimate: %w", err)
+	}
+
+	term.Debugf("Estimate: %+v", estimate)
+
+	subtotal := (*money.Money)(estimate.Subtotal)
+
+	tableItems := prepareEstimateLineItemTableItems(estimate.LineItems)
+	term.Table(tableItems, []string{"Cost", "Quantity", "Description"})
+	fmt.Printf("Estimated Monthly Cost: %s (+ usage)\n", subtotal.String())
+	fmt.Printf("Estimate does not include taxes or Discount Programs.\n")
+
+	return nil
+}
+
+type EstimateLineItemTableItem struct {
+	Cost        string
+	Quantity    string
+	Description string
+}
+
+func prepareEstimateLineItemTableItems(lineItems []*defangv1.EstimateLineItem) []EstimateLineItemTableItem {
+	tableItems := make([]EstimateLineItemTableItem, len(lineItems))
+	for i, lineItem := range lineItems {
+		cost := (*money.Money)(lineItem.Cost)
+		var quantityStr string
+		if lineItem.Quantity == float32(int(lineItem.Quantity)) {
+			quantityStr = strconv.Itoa(int(lineItem.Quantity))
+		} else {
+			quantityStr = fmt.Sprintf("%.2f", lineItem.Quantity)
+		}
+
+		tableItems[i] = EstimateLineItemTableItem{
+			Cost:        cost.String(),
+			Quantity:    fmt.Sprintf("%s %s", quantityStr, lineItem.Unit),
+			Description: lineItem.Description,
+		}
+	}
+
+	// sort line items by description
+	sort.Slice(tableItems, func(i, j int) bool {
+		return tableItems[i].Description < tableItems[j].Description
+	})
+
+	return tableItems
+}

--- a/src/cmd/cli/command/estimate.go
+++ b/src/cmd/cli/command/estimate.go
@@ -20,7 +20,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func makeComposeEstimateCmd() *cobra.Command {
+func makeEstimateCmd() *cobra.Command {
 	var estimateCmd = &cobra.Command{
 		Use:         "estimate",
 		Args:        cobra.NoArgs,

--- a/src/cmd/cli/command/estimate_test.go
+++ b/src/cmd/cli/command/estimate_test.go
@@ -1,0 +1,144 @@
+package command
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/DefangLabs/defang/src/pkg/term"
+	_type "github.com/DefangLabs/defang/src/protos/google/type"
+	defangv1 "github.com/DefangLabs/defang/src/protos/io/defang/v1"
+	"github.com/andreyvit/diff"
+)
+
+func TestPrintEstimate(t *testing.T) {
+	// Test with a sample estimate
+	estimate := &defangv1.EstimateResponse{
+		Subtotal: &_type.Money{
+			CurrencyCode: "USD",
+			Units:        118,
+			Nanos:        550_000_000,
+		},
+		LineItems: []*defangv1.EstimateLineItem{
+			{
+				Description: "AWSELB USW2-LoadBalancerUsage",
+				Unit:        "Hours",
+				Quantity:    730,
+				Cost: &_type.Money{
+					CurrencyCode: "USD",
+					Units:        16,
+					Nanos:        430_000_000,
+				},
+			},
+			{
+				Description: "AmazonEC2 USW2-NatGateway-Hours",
+				Unit:        "Hours",
+				Quantity:    730,
+				Cost: &_type.Money{
+					CurrencyCode: "USD",
+					Units:        32,
+					Nanos:        850_000_000,
+				},
+			},
+			{
+				Description: "AmazonECS USW2-Fargate-EphemeralStorage-GB-Hours (20 GB * 730 hours)",
+				Unit:        "GB-Hours",
+				Quantity:    14600,
+				Cost: &_type.Money{
+					CurrencyCode: "USD",
+					Units:        1,
+					Nanos:        620_000_000,
+				},
+			},
+			{
+				Description: "AmazonECS USW2-Fargate-GB-Hours (2 GB * 730 hours)",
+				Unit:        "GB-Hours",
+				Quantity:    1460,
+				Cost: &_type.Money{
+					CurrencyCode: "USD",
+					Units:        6,
+					Nanos:        490_000_000,
+				},
+			},
+			{
+				Description: "AmazonECS USW2-Fargate-GB-Hours-SpotDiscount (Estimated @ 70%)",
+				Unit:        "GB-Hours",
+				Quantity:    1460,
+				Cost: &_type.Money{
+					CurrencyCode: "USD",
+					Units:        -4,
+					Nanos:        -540_000_000,
+				},
+			},
+			{
+				Description: "AmazonECS USW2-Fargate-vCPU-Hours:perCPU (1.00 vCPU * 730 hours)",
+				Unit:        "vCPU-Hours",
+				Quantity:    730,
+				Cost: &_type.Money{
+					CurrencyCode: "USD",
+					Units:        29,
+					Nanos:        550_000_000,
+				},
+			},
+			{
+				Description: "AmazonECS USW2-Fargate-vCPU-Hours:perCPU-SpotDiscount (Estimated @ 70%)",
+				Unit:        "GB-Hours",
+				Quantity:    730,
+				Cost: &_type.Money{
+					CurrencyCode: "USD",
+					Units:        -20,
+					Nanos:        -690_000_000,
+				},
+			},
+			{
+				Description: "AmazonElastiCache USW2-NodeUsage:cache.t3.medium",
+				Unit:        "%Utilized/mo",
+				Quantity:    730,
+				Cost: &_type.Money{
+					CurrencyCode: "USD",
+					Units:        49,
+					Nanos:        640_000_000,
+				},
+			},
+			{
+				Description: "AmazonRDS USW2-InstanceUsage:db.t3.medium",
+				Unit:        "%Utilized/mo",
+				Quantity:    100,
+				Cost: &_type.Money{
+					CurrencyCode: "USD",
+					Units:        7,
+					Nanos:        200_000_000,
+				},
+			},
+		},
+	}
+
+	stdout, _ := term.SetupTestTerm(t)
+	PrintEstimate(estimate)
+
+	expectedOutput := `
+Cost     Quantity          Description
+$16.43   730 Hours         AWSELB USW2-LoadBalancerUsage
+$32.85   730 Hours         AmazonEC2 USW2-NatGateway-Hours
+$1.62    14600 GB-Hours    AmazonECS USW2-Fargate-EphemeralStorage-GB-Hours (20 GB * 730 hours)
+$6.49    1460 GB-Hours     AmazonECS USW2-Fargate-GB-Hours (2 GB * 730 hours)
+-$4.54   1460 GB-Hours     AmazonECS USW2-Fargate-GB-Hours-SpotDiscount (Estimated @ 70%)
+$29.55   730 vCPU-Hours    AmazonECS USW2-Fargate-vCPU-Hours:perCPU (1.00 vCPU * 730 hours)
+-$20.69  730 GB-Hours      AmazonECS USW2-Fargate-vCPU-Hours:perCPU-SpotDiscount (Estimated @ 70%)
+$49.64   730 %Utilized/mo  AmazonElastiCache USW2-NodeUsage:cache.t3.medium
+$7.20    100 %Utilized/mo  AmazonRDS USW2-InstanceUsage:db.t3.medium
+Estimated Monthly Cost: $118.55 (+ usage)
+Estimate does not include taxes or Discount Programs.
+`
+
+	outputLines := strings.Split(term.StripAnsi(stdout.String()), "\n")
+	// for each line remove trailing spaces
+	for i, line := range outputLines {
+		outputLines[i] = strings.TrimRight(line, " ")
+	}
+
+	actualOutput := strings.Join(outputLines, "\n")
+
+	if actualOutput != expectedOutput {
+		t.Errorf("Expected output did not match actual output. diff:\n%s", diff.LineDiff(expectedOutput, actualOutput))
+	}
+}

--- a/src/go.mod
+++ b/src/go.mod
@@ -17,6 +17,7 @@ require (
 	cloud.google.com/go/storage v1.50.0
 	github.com/AlecAivazis/survey/v2 v2.3.7
 	github.com/DefangLabs/secret-detector v0.0.0-20250108223530-c2b44d4c1f8f
+	github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883
 	github.com/aws/aws-sdk-go-v2 v1.32.6
 	github.com/aws/aws-sdk-go-v2/config v1.26.6
 	github.com/aws/aws-sdk-go-v2/service/cloudformation v1.42.6
@@ -97,6 +98,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/rivo/uniseg v0.4.2 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
+	github.com/sergi/go-diff v1.3.1 // indirect
 	github.com/spiffe/go-spiffe/v2 v2.5.0 // indirect
 	github.com/xhit/go-str2duration/v2 v2.1.0 // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
@@ -110,7 +112,6 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20250422160041-2d3770c4ea7f // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250414145226-207652e42e2e // indirect
 	gopkg.in/ini.v1 v1.66.2 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
 )
 
 require (

--- a/src/go.sum
+++ b/src/go.sum
@@ -50,6 +50,8 @@ github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERo
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2 h1:+vx7roKuyA63nhn5WAunQHLTznkw5W8b1Xc0dNjp83s=
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2/go.mod h1:HBCaDeC1lPdgDeDbhX8XFpy1jqjK0IBG8W5K+xYqA0w=
+github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883 h1:bvNMNQO63//z+xNgfBlViaCIJKLlCJ6/fmUseuG0wVQ=
+github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/aws/aws-sdk-go-v2 v1.32.6 h1:7BokKRgRPuGmKkFMhEg/jSul+tB9VvXhcViILtfG8b4=
 github.com/aws/aws-sdk-go-v2 v1.32.6/go.mod h1:P5WJBrYqqbWVaOxgH0X/FYYD47/nooaPOZPlQdmiN2U=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.6.2 h1:x6xsQXGSmW6frevwDA+vi/wqhp1ct18mVXYN08/93to=
@@ -213,8 +215,11 @@ github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNU
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
+github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69Aj6K7nkY=
@@ -271,6 +276,8 @@ github.com/ross96D/cancelreader v0.2.6 h1:XLPWassoMWRTlHvEoVKS3z0N0a7jHcIupGU0U1
 github.com/ross96D/cancelreader v0.2.6/go.mod h1:sSs12d88ds2FFb9aOsKYyhTJCJDQDOll6gpyILZwIzc=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/sergi/go-diff v1.3.1 h1:xkr+Oxo4BOQKmkn/B9eMK0g5Kg/983T9DqqPHwYqD+8=
+github.com/sergi/go-diff v1.3.1/go.mod h1:aMJSSKb2lpPvRNec0+w3fl7LP9IOFzdc9Pa4NFbPK1I=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/spf13/pflag v1.0.6 h1:jFzHGLGAlb3ruxLB8MhbI6A8+AQX/2eW4qeyNZXNp2o=
@@ -279,6 +286,7 @@ github.com/spiffe/go-spiffe/v2 v2.5.0 h1:N2I01KCUkv1FAjZXJMwh95KK1ZIQLYbPfhaxw8W
 github.com/spiffe/go-spiffe/v2 v2.5.0/go.mod h1:P+NxobPc6wXhVtINNtFjNWGBTreew1GBUCwT2wPmb7g=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
@@ -402,10 +410,12 @@ google.golang.org/grpc v1.72.0/go.mod h1:wH5Aktxcg25y1I3w7H69nHfXdOG3UiadoBtjh3i
 google.golang.org/protobuf v1.36.6 h1:z1NpPI8ku2WgiWnf+t9wTPsn6eP1L7ksHUlkfLvd9xY=
 google.golang.org/protobuf v1.36.6/go.mod h1:jduwjTPXsFjZGTmRluh+L6NjiWu7pchiJ2/5YcXBHnY=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/ini.v1 v1.66.2 h1:XfR1dOYubytKy4Shzc2LHrrGhU0lDCfDGG1yLPmpgsI=
 gopkg.in/ini.v1 v1.66.2/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=

--- a/src/pkg/cli/bootstrap.go
+++ b/src/pkg/cli/bootstrap.go
@@ -35,10 +35,10 @@ func BootstrapCommand(ctx context.Context, projectName string, verbose bool, p c
 		LogType:    logs.LogTypeBuild,
 		Verbose:    verbose,
 	}
-	return tailAndWaitForCD(ctx, projectName, p, options, LogEntryPrintHandler)
+	return TailAndWaitForCD(ctx, projectName, p, options, LogEntryPrintHandler)
 }
 
-func tailAndWaitForCD(ctx context.Context, projectName string, provider client.Provider, tailOptions TailOptions, handler LogEntryHandler) error {
+func TailAndWaitForCD(ctx context.Context, projectName string, provider client.Provider, tailOptions TailOptions, handler LogEntryHandler) error {
 	ctx, cancelTail := context.WithCancelCause(ctx)
 	defer cancelTail(nil) // to cancel tail and clean-up context
 

--- a/src/pkg/cli/bootstrap.go
+++ b/src/pkg/cli/bootstrap.go
@@ -45,7 +45,7 @@ func tailAndWaitForCD(ctx context.Context, projectName string, provider client.P
 
 	// blocking call to tail
 	var tailErr error
-	if err := tail(ctx, provider, projectName, tailOptions); err != nil {
+	if err := streamLogs(ctx, provider, projectName, tailOptions, LogEntryPrintHandler); err != nil {
 		term.Debug("Tail stopped with", err, errors.Unwrap(err))
 		if !errors.Is(err, context.Canceled) {
 			tailErr = err

--- a/src/pkg/cli/client/grpc.go
+++ b/src/pkg/cli/client/grpc.go
@@ -169,3 +169,7 @@ func (g GrpcClient) SetOptions(ctx context.Context, req *defangv1.SetOptionsRequ
 	_, err := g.client.SetOptions(ctx, connect.NewRequest(req))
 	return err
 }
+
+func (g GrpcClient) Estimate(ctx context.Context, req *defangv1.EstimateRequest) (*defangv1.EstimateResponse, error) {
+	return getMsg(g.client.Estimate(ctx, connect.NewRequest(req)))
+}

--- a/src/pkg/cli/preview.go
+++ b/src/pkg/cli/preview.go
@@ -15,5 +15,6 @@ func Preview(ctx context.Context, project *compose.Project, fabric cliClient.Fab
 		return err
 	}
 
-	return tailAndWaitForCD(ctx, project.Name, provider, TailOptions{Deployment: resp.Etag, LogType: logs.LogTypeBuild, Verbose: true})
+	options := TailOptions{Deployment: resp.Etag, LogType: logs.LogTypeBuild, Verbose: true}
+	return tailAndWaitForCD(ctx, project.Name, provider, options, LogEntryPrintHandler)
 }

--- a/src/pkg/cli/preview.go
+++ b/src/pkg/cli/preview.go
@@ -16,5 +16,5 @@ func Preview(ctx context.Context, project *compose.Project, fabric cliClient.Fab
 	}
 
 	options := TailOptions{Deployment: resp.Etag, LogType: logs.LogTypeBuild, Verbose: true}
-	return tailAndWaitForCD(ctx, project.Name, provider, options, LogEntryPrintHandler)
+	return TailAndWaitForCD(ctx, project.Name, provider, options, LogEntryPrintHandler)
 }

--- a/src/pkg/cli/tail.go
+++ b/src/pkg/cli/tail.go
@@ -195,7 +195,7 @@ func Tail(ctx context.Context, provider client.Provider, projectName string, opt
 		return ErrDryRun
 	}
 
-	return tail(ctx, provider, projectName, options)
+	return streamLogs(ctx, provider, projectName, options, LogEntryPrintHandler)
 }
 
 func isTransientError(err error) bool {
@@ -207,7 +207,9 @@ func isTransientError(err error) bool {
 		errors.Is(err, io.ErrUnexpectedEOF)
 }
 
-func tail(ctx context.Context, provider client.Provider, projectName string, options TailOptions) error {
+type LogEntryHandler func(*defangv1.LogEntry, *TailOptions) error
+
+func streamLogs(ctx context.Context, provider client.Provider, projectName string, options TailOptions, handler LogEntryHandler) error {
 	var sinceTs, untilTs *timestamppb.Timestamp
 	if pkg.IsValidTime(options.Since) {
 		sinceTs = timestamppb.New(options.Since)
@@ -336,9 +338,21 @@ func tail(ctx context.Context, provider client.Provider, projectName string, opt
 		}
 
 		for _, e := range msg.Entries {
-			service := valueOrDefault(e.Service, msg.Service)
-			host := valueOrDefault(e.Host, msg.Host)
-			etag := valueOrDefault(e.Etag, msg.Etag)
+			// Replace service progress messages with our own spinner
+			if doSpinner && isProgressDot(e.Message) {
+				continue
+			}
+			ts := e.Timestamp.AsTime()
+			// Skip duplicate logs (e.g. after reconnecting we might get the same log once more)
+			if skipDuplicate && ts.Equal(options.Since) {
+				skipDuplicate = false
+				continue
+			}
+			e.Service = valueOrDefault(e.Service, msg.Service)
+			e.Host = valueOrDefault(e.Host, msg.Host)
+			e.Etag = valueOrDefault(e.Etag, msg.Etag)
+			host := e.Host
+			service := e.Service
 
 			// HACK: skip noisy CI/CD logs (except errors)
 			isInternal := service == "cd" || service == "kaniko" || service == "fabric" || host == "kaniko" || host == "fabric" || host == "ecs" || host == "cloudbuild" || host == "pulumi"
@@ -348,81 +362,79 @@ func tail(ctx context.Context, provider client.Provider, projectName string, opt
 					cancel() // TODO: stuck on defer Close() if we don't do this
 					return nil
 				}
-				continue
+				return nil
 			}
 
-			ts := e.Timestamp.AsTime()
-			// Skip duplicate logs (e.g. after reconnecting we might get the same log once more)
-			if skipDuplicate && ts.Equal(options.Since) {
-				skipDuplicate = false
-				continue
-			}
 			if ts.After(options.Since) {
 				options.Since = ts
 			}
-
-			if options.Raw {
-				if e.Stderr {
-					term.Error(e.Message)
-				} else {
-					term.Println(e.Message)
-				}
-				continue
+			err := handler(e, &options)
+			if err != nil {
+				term.Debug("Ending tail loop", err)
+				cancel() // TODO: stuck on defer Close() if we don't do this
 			}
-
-			// Replace service progress messages with our own spinner
-			if doSpinner && isProgressDot(e.Message) {
-				continue
-			}
-
-			tsString := ts.Local().Format(RFC3339Milli)
-			tsColor := termenv.ANSIBrightBlack
-			if term.HasDarkBackground() {
-				tsColor = termenv.ANSIWhite
-			}
-			if e.Stderr {
-				tsColor = termenv.ANSIBrightRed
-			}
-			var prefixLen int
-			trimmed := strings.TrimRight(e.Message, "\t\r\n ")
-			buf := term.NewMessageBuilder(term.StdoutCanColor())
-			for i, line := range strings.Split(trimmed, "\n") {
-				if i == 0 {
-					prefixLen, _ = buf.Printc(tsColor, tsString, " ")
-					if options.Deployment == "" {
-						l, _ := buf.Printc(termenv.ANSIYellow, etag, " ")
-						prefixLen += l
-					}
-					if len(options.Services) != 1 {
-						l, _ := buf.Printc(termenv.ANSIGreen, service, " ")
-						prefixLen += l
-					}
-					if options.Verbose {
-						l, _ := buf.Printc(termenv.ANSIMagenta, host, " ")
-						prefixLen += l
-					}
-				} else {
-					buf.WriteString(strings.Repeat(" ", prefixLen))
-				}
-				if term.StdoutCanColor() {
-					if !strings.Contains(line, "\033[") {
-						line = colorKeyRegex.ReplaceAllString(line, replaceString) // add some color
-					}
-				} else {
-					line = term.StripAnsi(line)
-				}
-				buf.WriteString(line)
-				buf.WriteRune('\n')
-
-				// Detect end logging event
-				if options.EndEventDetectFunc != nil && options.EndEventDetectFunc([]string{service}, host, line) {
-					cancel() // TODO: stuck on defer Close() if we don't do this
-					return nil
-				}
-			}
-			term.Print(buf.String())
 		}
 	}
+}
+
+func LogEntryPrintHandler(e *defangv1.LogEntry, options *TailOptions) error {
+	if options.Raw {
+		if e.Stderr {
+			term.Error(e.Message)
+		} else {
+			term.Println(e.Message)
+		}
+		return nil
+	}
+
+	ts := e.Timestamp.AsTime()
+	tsString := ts.Local().Format(RFC3339Milli)
+	tsColor := termenv.ANSIBrightBlack
+	if term.HasDarkBackground() {
+		tsColor = termenv.ANSIWhite
+	}
+	if e.Stderr {
+		tsColor = termenv.ANSIBrightRed
+	}
+	var prefixLen int
+	trimmed := strings.TrimRight(e.Message, "\t\r\n ")
+	buf := term.NewMessageBuilder(term.StdoutCanColor())
+	for i, line := range strings.Split(trimmed, "\n") {
+		if i == 0 {
+			prefixLen, _ = buf.Printc(tsColor, tsString, " ")
+			if options.Deployment == "" {
+				l, _ := buf.Printc(termenv.ANSIYellow, e.Etag, " ")
+				prefixLen += l
+			}
+			if len(options.Services) != 1 {
+				l, _ := buf.Printc(termenv.ANSIGreen, e.Service, " ")
+				prefixLen += l
+			}
+			if options.Verbose {
+				l, _ := buf.Printc(termenv.ANSIMagenta, e.Host, " ")
+				prefixLen += l
+			}
+		} else {
+			buf.WriteString(strings.Repeat(" ", prefixLen))
+		}
+		if term.StdoutCanColor() {
+			if !strings.Contains(line, "\033[") {
+				line = colorKeyRegex.ReplaceAllString(line, replaceString) // add some color
+			}
+		} else {
+			line = term.StripAnsi(line)
+		}
+		buf.WriteString(line)
+		buf.WriteRune('\n')
+
+		// Detect end logging event
+		if options.EndEventDetectFunc != nil && options.EndEventDetectFunc([]string{e.Service}, e.Host, line) {
+			return errors.New("end event detected")
+		}
+	}
+	term.Print(buf.String())
+
+	return nil
 }
 
 func valueOrDefault(value, def string) string {

--- a/src/pkg/money/money.go
+++ b/src/pkg/money/money.go
@@ -1,0 +1,55 @@
+package money
+
+import (
+	"fmt"
+	"math"
+	"strings"
+
+	google "github.com/DefangLabs/defang/src/protos/google/type"
+)
+
+type Money google.Money
+
+// Currency symbol map (expand as needed)
+var currencySymbols = map[string]string{
+	"USD": "$",
+	"EUR": "€",
+	"GBP": "£",
+	"JPY": "¥",
+	// Add more as needed
+}
+
+func NewMoney(amount float64, currency string) *Money {
+	units := int64(amount)
+	nanos := int32(math.Round((amount - float64(units)) * 1e9))
+
+	// Fix signs: if nanos and units mismatch, adjust accordingly
+	if amount < 0 && nanos > 0 {
+		units--
+		nanos = nanos - 1e9
+	}
+	if amount > 0 && nanos < 0 {
+		units++
+		nanos = nanos + 1e9
+	}
+
+	return &Money{
+		CurrencyCode: currency,
+		Units:        units,
+		Nanos:        nanos,
+	}
+}
+
+func (m *Money) String() string {
+	symbol, ok := currencySymbols[strings.ToUpper(m.CurrencyCode)]
+	if !ok {
+		symbol = m.CurrencyCode + " "
+	}
+
+	// Combine units and nanos
+	total := float64(m.Units) + float64(m.Nanos)/1e9
+	if total < 0 {
+		return fmt.Sprintf("-%s%.2f", symbol, -total)
+	}
+	return fmt.Sprintf("%s%.2f", symbol, total)
+}

--- a/src/pkg/money/money_test.go
+++ b/src/pkg/money/money_test.go
@@ -1,0 +1,25 @@
+package money
+
+import (
+	"testing"
+)
+
+func TestMoney(t *testing.T) {
+	tests := []struct {
+		amount   float64
+		currency string
+		expected string
+	}{
+		{1.23, "USD", "$1.23"},
+		{1.23, "GBP", "£1.23"},
+		{0, "USD", "$0.00"},
+		{-1.23, "USD", "-$1.23"},
+	}
+
+	for _, test := range tests {
+		m := NewMoney(test.amount, test.currency)
+		if m.String() != test.expected {
+			t.Errorf("Expected %s but got %s", test.expected, m.String())
+		}
+	}
+}


### PR DESCRIPTION
## Description

Add a new command `defang estimate` which does the following:
1. Load the project from the current working directory, or from `-f`
2. Run `pulumi preview` in JSON format mode in a cd task in the user's cloud account and keep a buffer of the json-formatted pulumi preview operation log lines. (Note: this requires the user to provide their cloud account credentials. In a followup, we will remove this requirement and enable the possibility to run previews in our cloud accounts.)
3. Pass the json-formatted pulumi operations to fabric as a byte array so that fabric can estimate the AWS workload

## Linked Issues

* https://github.com/DefangLabs/defang/pull/1173
* https://github.com/DefangLabs/defang-mvp/pull/1768
* https://github.com/DefangLabs/defang-mvp/pull/1770

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

