### PR TITLE
Put provider in private network

### DIFF
--- a/src/testdata/provider/compose.yaml.fixup
+++ b/src/testdata/provider/compose.yaml.fixup
@@ -7,7 +7,7 @@
     },
     "image": "defangio/openai-access-gateway",
     "networks": {
-      "default": null
+      "model_provider_private": null
     },
     "ports": [
       {
@@ -32,7 +32,8 @@
     },
     "image": "my-chat-app",
     "networks": {
-      "default": null
+      "default": null,
+      "model_provider_private": null
     }
   }
 }


### PR DESCRIPTION
## Description

Follow up from #1161: add the provider pseudo-service, and any service that depends on it, to a private network. This makes it safe to disable access-gateway auth by setting `OPENAI_API_KEY=""`. 

View diff w/o whitespace.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

