### PR TITLE
Drop UID/GID based on HOME perms

### DIFF
--- a/src/cmd/cli/main.go
+++ b/src/cmd/cli/main.go
@@ -23,6 +23,11 @@ func main() {
 		}
 	}()
 
+	// To avoid creating files as root, we set the UID and GID to the "current" HOME user
+	if homeDir, err := os.UserHomeDir(); err == nil {
+		setUidGidFromFile(homeDir)
+	}
+
 	// Handle Ctrl+C so we can exit gracefully
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
 

--- a/src/cmd/cli/setuidgid_other.go
+++ b/src/cmd/cli/setuidgid_other.go
@@ -1,0 +1,19 @@
+//go:build !windows
+
+package main
+
+import (
+	"os"
+	"syscall"
+)
+
+func setUidGidFromFile(path string) error {
+	// Find out the owner of the given path
+	stat, err := os.Stat(path)
+	if err != nil {
+		return err
+	}
+	statt := stat.Sys().(*syscall.Stat_t)
+	syscall.Setgid(int(statt.Gid))
+	return syscall.Setuid(int(statt.Uid))
+}

--- a/src/cmd/cli/setuidgid_other.go
+++ b/src/cmd/cli/setuidgid_other.go
@@ -13,7 +13,9 @@ func setUidGidFromFile(path string) error {
 	if err != nil {
 		return err
 	}
-	statt := stat.Sys().(*syscall.Stat_t)
-	syscall.Setgid(int(statt.Gid))
-	return syscall.Setuid(int(statt.Uid))
+	if statt, ok := stat.Sys().(*syscall.Stat_t); ok {
+		syscall.Setgid(int(statt.Gid))
+		return syscall.Setuid(int(statt.Uid))
+	}
+	return nil
 }

--- a/src/cmd/cli/setuidgid_windows.go
+++ b/src/cmd/cli/setuidgid_windows.go
@@ -1,0 +1,8 @@
+//go:build windows
+
+package main
+
+func setUidGidFromFile(path string) error {
+	// Windows does not support changing file ownership
+	return nil
+}

--- a/src/pkg/cli/client/state.go
+++ b/src/pkg/cli/client/state.go
@@ -4,21 +4,10 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
-	"runtime"
 	"time"
 
-	"github.com/DefangLabs/defang/src/pkg"
 	"github.com/google/uuid"
 )
-
-func userStateDir() (string, error) {
-	if runtime.GOOS == "windows" {
-		return os.UserCacheDir()
-	} else {
-		home, err := os.UserHomeDir()
-		return pkg.Getenv("XDG_STATE_HOME", filepath.Join(home, ".local/state")), err
-	}
-}
 
 var (
 	stateDir, _ = userStateDir()
@@ -48,7 +37,7 @@ func (state State) write(path string) error {
 		return err
 	} else {
 		os.MkdirAll(StateDir, 0700)
-		return os.WriteFile(path, bytes, 0644)
+		return os.WriteFile(path, bytes, 0600)
 	}
 }
 

--- a/src/pkg/cli/client/state_other.go
+++ b/src/pkg/cli/client/state_other.go
@@ -1,0 +1,16 @@
+//go:build !windows
+
+package client
+
+import (
+	"os"
+	"path/filepath"
+)
+
+func userStateDir() (string, error) {
+	if stateHome := os.Getenv("XDG_STATE_HOME"); stateHome != "" {
+		return stateHome, nil
+	}
+	home, err := os.UserHomeDir()
+	return filepath.Join(home, ".local", "state"), err
+}

--- a/src/pkg/cli/client/state_windows.go
+++ b/src/pkg/cli/client/state_windows.go
@@ -1,0 +1,11 @@
+//go:build windows
+
+package client
+
+import (
+	"os"
+)
+
+func userStateDir() (string, error) {
+	return os.UserCacheDir() // %LocalAppData%
+}

--- a/src/pkg/cli/login.go
+++ b/src/pkg/cli/login.go
@@ -74,12 +74,12 @@ func (g OpenAuthService) serveAuthServer(ctx context.Context, fabric string, aut
 
 var authService AuthService = OpenAuthService{}
 
-func saveAccessToken(fabric, at string) error {
+func saveAccessToken(fabric, token string) error {
 	tokenFile := getTokenFile(fabric)
 	term.Debug("Saving access token to", tokenFile)
 	os.MkdirAll(client.StateDir, 0700)
-	if err := os.WriteFile(tokenFile, []byte(at), 0600); err != nil {
-		return err
+	if err := os.WriteFile(tokenFile, []byte(token), 0600); err != nil {
+		return fmt.Errorf("failed to save access token: %w", err)
 	}
 	return nil
 }

--- a/src/pkg/cli/login_test.go
+++ b/src/pkg/cli/login_test.go
@@ -54,16 +54,16 @@ func (g mockGitHubAuthService) serveAuthServer(ctx context.Context, fabric strin
 }
 
 func TestInteractiveLogin(t *testing.T) {
-	tempGithubAuthService := authService
+	prevGithubAuthService := authService
 	accessToken := "test-token"
 	fabric := "test.defang.dev"
 	// use a temp dir for the token file
-	tempStateDir := client.StateDir
+	prevStateDir := client.StateDir
 	client.StateDir = filepath.Join(t.TempDir(), "defang")
 
 	t.Cleanup(func() {
-		authService = tempGithubAuthService
-		client.StateDir = tempStateDir
+		authService = prevGithubAuthService
+		client.StateDir = prevStateDir
 	})
 
 	tokenFile := getTokenFile(fabric)
@@ -114,11 +114,11 @@ func TestNonInteractiveLogin(t *testing.T) {
 			t.Skip("ACTIONS_ID_TOKEN_REQUEST_URL not set")
 		}
 
-		// use a temp dir for the token file
-		temp := client.StateDir
+		// use a prevStateDir dir for the token file
+		prevStateDir := client.StateDir
 		client.StateDir = filepath.Join(t.TempDir(), "defang")
 
-		t.Cleanup(func() { client.StateDir = temp })
+		t.Cleanup(func() { client.StateDir = prevStateDir })
 
 		err := NonInteractiveLogin(ctx, mockClient, fabric)
 		if err != nil {

--- a/src/pkg/mcp/resources/resources.go
+++ b/src/pkg/mcp/resources/resources.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/DefangLabs/defang/src/pkg/cli/client"
 	"github.com/DefangLabs/defang/src/pkg/term"
@@ -23,8 +24,8 @@ func SetupResources(s *server.MCPServer) {
 	setupSamplePrompt(s)
 }
 
-var knowledgeBasePath = client.StateDir + "/knowledge_base.json"
-var samplesExamplesPath = client.StateDir + "/samples_examples.json"
+var knowledgeBasePath = filepath.Join(client.StateDir, "knowledge_base.json")
+var samplesExamplesPath = filepath.Join(client.StateDir, "samples_examples.json")
 
 // setupDocumentationResource configures and adds the documentation resource to the MCP server
 func setupDocumentationResource(s *server.MCPServer) {

--- a/src/pkg/mcp/setup.go
+++ b/src/pkg/mcp/setup.go
@@ -66,8 +66,8 @@ var ValidClients = append(
 	ValidVSCodeClients...,
 )
 
-// IsValidClient checks if the provided client is in the list of valid clients
-func IsValidClient(client string) bool {
+// isValidClient checks if the provided client is in the list of valid clients
+func isValidClient(client string) bool {
 	return slices.Contains(ValidClients, client)
 }
 
@@ -246,8 +246,8 @@ func handleVSCodeConfig(configPath string) error {
 
 func SetupClient(client string) error {
 	// Validate client
-	if !IsValidClient(client) {
-		return fmt.Errorf("invalid MCP client: %s. Valid MCP clients are: %s", client, strings.Join(ValidClients, ", "))
+	if !isValidClient(client) {
+		return fmt.Errorf("invalid MCP client: %q. Valid MCP clients are: %v", client, ValidClients)
 	}
 
 	// Get the config path for the client


### PR DESCRIPTION
## Description

Set the process's UID and GID based off of the ownership of `$HOME`. This ensures we don't create token/log files with permissions that the user can't access, for example when `defang` is run as `root` through `sudo`.

## Linked Issues

Fixes #1176 


<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

