### PR TITLE
Fix error for config set to clean account

### DIFF
--- a/src/cmd/cli/command/commands_test.go
+++ b/src/cmd/cli/command/commands_test.go
@@ -255,7 +255,7 @@ func TestGetProvider(t *testing.T) {
 	}
 	mockClient.SetClient(mockCtrl)
 	client = &mockClient
-	loader := cliClient.MockLoader{Project: &compose.Project{Name: "empty"}}
+	loader := cliClient.MockLoader{Project: compose.Project{Name: "empty"}}
 	oldRootCmd := RootCmd
 	t.Cleanup(func() {
 		RootCmd = oldRootCmd

--- a/src/pkg/cli/client/byoc/baseclient.go
+++ b/src/pkg/cli/client/byoc/baseclient.go
@@ -100,14 +100,14 @@ func (b *ByocBaseClient) RemoteProjectName(ctx context.Context) (string, error) 
 	// Get the list of projects from remote
 	projectNames, err := b.projectBackend.BootstrapList(ctx)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("no cloud projects found: %w", err)
 	}
 	for i, name := range projectNames {
 		projectNames[i] = strings.Split(name, "/")[0] // Remove the stack name
 	}
 
 	if len(projectNames) == 0 {
-		return "", errors.New("no projects found")
+		return "", errors.New("no cloud projects found")
 	}
 
 	if len(projectNames) > 1 {

--- a/src/pkg/cli/client/mock.go
+++ b/src/pkg/cli/client/mock.go
@@ -135,13 +135,14 @@ func (m MockFabricClient) ListDeployments(ctx context.Context, req *defangv1.Lis
 }
 
 type MockLoader struct {
-	Project *composeTypes.Project
+	Project composeTypes.Project
+	Error   error
 }
 
 func (m MockLoader) LoadProject(ctx context.Context) (*composeTypes.Project, error) {
-	return m.Project, nil
+	return &m.Project, m.Error
 }
 
 func (m MockLoader) LoadProjectName(ctx context.Context) (string, error) {
-	return m.Project.Name, nil
+	return m.Project.Name, m.Error
 }

--- a/src/pkg/cli/client/playground.go
+++ b/src/pkg/cli/client/playground.go
@@ -116,9 +116,9 @@ func (g PlaygroundProvider) RemoteProjectName(ctx context.Context) (string, erro
 		return "", err
 	}
 	if resp.Project == "" {
-		return "", errors.New("no projects found")
+		return "", errors.New("no Playground projects found")
 	}
-	term.Debug("Using default playground project: ", resp.Project)
+	term.Debug("Using default Playground project: ", resp.Project)
 	return resp.Project, nil
 }
 

--- a/src/pkg/cli/client/projectName.go
+++ b/src/pkg/cli/client/projectName.go
@@ -2,22 +2,25 @@ package client
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/DefangLabs/defang/src/pkg/term"
 )
 
 func LoadProjectNameWithFallback(ctx context.Context, loader Loader, provider Provider) (string, error) {
+	var loadErr error
 	if loader != nil {
 		projectName, err := loader.LoadProjectName(ctx)
 		if err == nil {
 			return projectName, nil
 		}
 		term.Debug("Failed to load local project:", err)
+		loadErr = err
 	}
 	term.Debug("Trying to get the remote project name from the provider")
 	projectName, err := provider.RemoteProjectName(ctx)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("%w and %w", loadErr, err)
 	}
 	return projectName, nil
 }

--- a/src/pkg/cli/client/projectName_test.go
+++ b/src/pkg/cli/client/projectName_test.go
@@ -1,0 +1,62 @@
+package client
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	composeTypes "github.com/compose-spec/compose-go/v2/types"
+)
+
+func TestLoadProjectNameWithFallback(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("with project", func(t *testing.T) {
+		loader := MockLoader{Project: composeTypes.Project{Name: "test-project"}}
+		projectName, err := LoadProjectNameWithFallback(ctx, loader, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if projectName != "test-project" {
+			t.Fatalf("expected project name 'test-project', got %q", projectName)
+		}
+	})
+
+	t.Run("no local project, no fallback", func(t *testing.T) {
+		loader := MockLoader{Error: errors.New("no local project")}
+		provider := mockRemoteProjectName{
+			Error: errors.New("no remote project"),
+		}
+		projectName, err := LoadProjectNameWithFallback(ctx, loader, provider)
+		if err == nil {
+			t.Fatalf("expected error, got project name %q", projectName)
+		}
+		if expected, got := "no local project and no remote project", err.Error(); expected != got {
+			t.Fatalf("expected error message %q, got %q", expected, got)
+		}
+	})
+
+	t.Run("no local project, with fallback", func(t *testing.T) {
+		loader := MockLoader{Error: errors.New("no local project")}
+		provider := mockRemoteProjectName{
+			ProjectName: "test-project",
+		}
+		projectName, err := LoadProjectNameWithFallback(ctx, loader, provider)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if projectName != "test-project" {
+			t.Fatalf("expected project name 'test-project', got %q", projectName)
+		}
+	})
+}
+
+type mockRemoteProjectName struct {
+	Provider
+	ProjectName string
+	Error       error
+}
+
+func (m mockRemoteProjectName) RemoteProjectName(context.Context) (string, error) {
+	return m.ProjectName, m.Error
+}


### PR DESCRIPTION
## Description

When doing `defang config set` to a clean account (and outside of a project dir), the error was not clear:

> Error: StackNotFoundException: Stack with id defang-cd does not exist

This happens because secret/config names are scoped per project, but when we're outside a project, we try to fetch the (single) deployed project from the cloud, which (on AWS) requires an S3 bucket from the CloudFormation stack.

This PR fixes this, by including any previous (loading) error as well:

> Error: no --project-name specified and no compose.yaml file found and no cloud projects found: StackNotFoundException: Stack with id defang-cd does not exist

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

