### PR TITLE
Fix interactive down on max projects

### DIFF
--- a/src/cmd/cli/command/commands.go
+++ b/src/cmd/cli/command/commands.go
@@ -105,8 +105,8 @@ func Execute(ctx context.Context) error {
 			if err != nil {
 				return err
 			}
-			if resp, err := provider.GetServices(ctx, &defangv1.GetServicesRequest{Project: projectName}); err == nil {
-				projectName = resp.Project
+			if resp, err := provider.RemoteProjectName(ctx); err == nil {
+				projectName = resp
 			}
 			printDefangHint("To deactivate a project, do:", "compose down --project-name "+projectName)
 		}

--- a/src/cmd/cli/command/compose.go
+++ b/src/cmd/cli/command/compose.go
@@ -114,11 +114,11 @@ func makeComposeUpCmd() *cobra.Command {
 
 			if err != nil {
 				if !nonInteractive && strings.Contains(err.Error(), "maximum number of projects") {
-					if resp, err2 := provider.GetServices(cmd.Context(), &defangv1.GetServicesRequest{Project: project.Name}); err2 == nil {
+					if projectName, err2 := provider.RemoteProjectName(cmd.Context()); err2 == nil {
 						term.Error("Error:", prettyError(err))
-						if _, err := cli.InteractiveComposeDown(cmd.Context(), provider, resp.Project); err != nil {
+						if _, err := cli.InteractiveComposeDown(cmd.Context(), provider, projectName); err != nil {
 							term.Debug("ComposeDown failed:", err)
-							printDefangHint("To deactivate a project, do:", "compose down --project-name "+resp.Project)
+							printDefangHint("To deactivate a project, do:", "compose down --project-name "+projectName)
 						} else {
 							printDefangHint("To try deployment again, do:", "compose up")
 						}


### PR DESCRIPTION
## Description

Fix regression in `compose up` where we no longer ask for interactive `compose down`.


## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

