### PR TITLE
Fix provider fixup: adjust DNS once

### DIFF
--- a/src/pkg/cli/compose/fixup.go
+++ b/src/pkg/cli/compose/fixup.go
@@ -47,7 +47,7 @@ func FixupServices(ctx context.Context, provider client.Provider, project *types
 		}
 
 		if svccfg.Provider != nil && svccfg.Provider.Type == "model" && svccfg.Image == "" && svccfg.Build == nil {
-			fixupModelProvider(&svccfg, provider, project)
+			fixupModelProvider(&svccfg, project)
 		}
 
 		if _, llm := svccfg.Extensions["x-defang-llm"]; llm {
@@ -214,14 +214,14 @@ func fixupRedisService(svccfg *types.ServiceConfig, provider client.Provider) er
 	return nil
 }
 
-func fixupModelProvider(svccfg *types.ServiceConfig, provider client.Provider, project *types.Project) {
+func fixupModelProvider(svccfg *types.ServiceConfig, project *types.Project) {
 	// Declare a private network for the model provider
 	const modelProviderNetwork = "model_provider_private"
 
 	// Local Docker sets [SERVICE]_URL and [SERVICE]_MODEL environment variables on the dependent services
 	envName := strings.ToUpper(svccfg.Name) // TODO: handle characters that are not allowed in env vars, like '-'
 	urlEnv := envName + "_URL"
-	urlVal := "http://" + provider.ServiceDNS(NormalizeServiceName(svccfg.Name)) + "/api/v1/"
+	urlVal := "http://" + svccfg.Name + "/api/v1/"
 	modelEnv := envName + "_MODEL"
 	modelVal := svccfg.Provider.Options["model"]
 

--- a/src/testdata/provider/compose.yaml.warnings
+++ b/src/testdata/provider/compose.yaml.warnings
@@ -1,2 +1,3 @@
  ! service "ai_runner": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors
  ! service "chat": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors
+ ! service "chat": service name was adjusted: environment variable "AI_RUNNER_URL" assigned value "http://mock-ai-runner/api/v1/"


### PR DESCRIPTION
## Description

In #1190 I moved the Docker `provider:` handling to be before the DNS fixup, but the existing provider code would already add the user's tenant ID to the service names (for Playground), so by moving that fixup code up, the DNS service name replacement happened twice. This broke the `managed-llm-provider` sample.

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

