### PR TITLE
Fix explict access token issuance

### DIFF
--- a/src/pkg/cli/token.go
+++ b/src/pkg/cli/token.go
@@ -9,6 +9,7 @@ import (
 	"github.com/DefangLabs/defang/src/pkg/scope"
 	"github.com/DefangLabs/defang/src/pkg/term"
 	"github.com/DefangLabs/defang/src/pkg/types"
+	defangv1 "github.com/DefangLabs/defang/src/protos/io/defang/v1"
 )
 
 func Token(ctx context.Context, client client.FabricClient, tenant types.TenantName, dur time.Duration, scope scope.Scope) error {
@@ -26,7 +27,18 @@ func Token(ctx context.Context, client client.FabricClient, tenant types.TenantN
 		return err
 	}
 
+	// Translate the OpenAuth token to our own Defang Fabric token
+	resp, err := client.Token(ctx, &defangv1.TokenRequest{
+		Tenant:    string(tenant),
+		Scope:     []string{string(scope)},
+		Assertion: at,
+		ExpiresIn: uint32(dur.Seconds()),
+	})
+	if err != nil {
+		return err
+	}
+
 	term.Printc(term.BrightCyan, "Scoped access token: ")
-	term.Println(at)
+	term.Println(resp.AccessToken)
 	return nil
 }


### PR DESCRIPTION
## Description

This fixes a regression introduced by moving to OpenAuth: the OpenAuth JWT cannot have custom expiry, but for using the Defang CLI in a CI (non-GitHub), we need to store a `DEFANG_ACCESS_TOKEN` in the CI secrets, so the default 24h is very inconvenient. 

Longer term we should support the OpenAuth refresh token, if its expiry can be customized and >24hrs.

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

