### PR TITLE
Use Pulumi Version from Fabric

### DIFF
--- a/src/pkg/cli/client/byoc/aws/byoc.go
+++ b/src/pkg/cli/client/byoc/aws/byoc.go
@@ -42,10 +42,6 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-var (
-	PulumiVersion = pkg.Getenv("DEFANG_PULUMI_VERSION", "3.148.0")
-)
-
 type StsProviderAPI interface {
 	GetCallerIdentity(ctx context.Context, params *sts.GetCallerIdentityInput, optFns ...func(*sts.Options)) (*sts.GetCallerIdentityOutput, error)
 	AssumeRole(ctx context.Context, params *sts.AssumeRoleInput, optFns ...func(*sts.Options)) (*sts.AssumeRoleOutput, error)
@@ -148,7 +144,7 @@ func (b *ByocAws) setUpCD(ctx context.Context) error {
 	containers := []types.Container{
 		{
 			// FIXME: get the Pulumi image or version from Fabric: https://github.com/DefangLabs/defang/issues/1027
-			Image:     "public.ecr.aws/pulumi/pulumi-nodejs:" + PulumiVersion,
+			Image:     "public.ecr.aws/pulumi/pulumi-nodejs:" + b.PulumiVersion,
 			Name:      ecs.CdContainerName,
 			Cpus:      2.0,
 			Memory:    2048_000_000, // 2G

--- a/src/pkg/cli/client/byoc/baseclient.go
+++ b/src/pkg/cli/client/byoc/baseclient.go
@@ -38,9 +38,10 @@ type HasStackSupport interface {
 }
 
 type CanIUseConfig struct {
-	CDImage      string
-	AllowScaling bool
-	AllowGPU     bool
+	AllowGPU      bool
+	AllowScaling  bool
+	CDImage       string
+	PulumiVersion string
 }
 
 type ByocBaseClient struct {
@@ -90,6 +91,7 @@ func (b *ByocBaseClient) SetCanIUseConfig(quotas *defangv1.CanIUseResponse) {
 	b.CDImage = pkg.Getenv("DEFANG_CD_IMAGE", quotas.CdImage)
 	b.AllowScaling = quotas.AllowScaling
 	b.AllowGPU = quotas.Gpu
+	b.PulumiVersion = pkg.Getenv("DEFANG_PULUMI_VERSION", quotas.PulumiVersion)
 }
 
 func (b *ByocBaseClient) ServiceDNS(name string) string {

--- a/src/pkg/cli/client/byoc/gcp/byoc.go
+++ b/src/pkg/cli/client/byoc/gcp/byoc.go
@@ -47,7 +47,6 @@ const (
 
 var (
 	DefaultCDTags = map[string]string{"created-by": "defang"}
-	PulumiVersion = pkg.Getenv("DEFANG_PULUMI_VERSION", "3.136.1")
 
 	//TODO: Create cd role with more fine-grained permissions
 	// cdPermissions = []string{


### PR DESCRIPTION
## Description

This is in preparation for #1191 so we can update Pulumi without having to update the CLI.

```
$ curl -HAuthorization:"bearer $(cat ~/.local/state/defang/$DEFANG_FABRIC)"  -Hcontent-type:application/json https://$DEFANG_FABRIC/io.defang.v1.FabricController/CanIUse -d'{"provider":4}'
{"cdImage":"532501343364.dkr.ecr.us-west-2.amazonaws.com/cd:public-gcp-v0.6.0-576-gf5b76e67", "gpu":true, "allowScaling":true, "pulumiVersion":"3.148.0"}%    
```

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

