### PR TITLE
Close the tailer in gcp server stream Close() method

### DIFF
--- a/src/pkg/cli/client/byoc/gcp/stream.go
+++ b/src/pkg/cli/client/byoc/gcp/stream.go
@@ -60,7 +60,8 @@ func NewServerStream[T any](ctx context.Context, gcp *gcp.Gcp, parse LogParser[T
 }
 
 func (s *ServerStream[T]) Close() error {
-	s.cancel() // TODO: investigate if we need to close the tailer
+	s.cancel()
+	s.tailer.Close() // Close the grpc connection
 	return nil
 }
 


### PR DESCRIPTION
## Description
So the grpc stream is properly closed

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

