### PR TITLE
Disable Pulumi copilot

### DIFF
--- a/src/pkg/cli/client/byoc/aws/byoc.go
+++ b/src/pkg/cli/client/byoc/aws/byoc.go
@@ -414,6 +414,7 @@ func (b *ByocAws) environment(projectName string) (map[string]string, error) {
 		"PROJECT":                    projectName,                 // may be empty
 		pulumiBackendKey:             pulumiBackendValue,          // TODO: make secret
 		"PULUMI_CONFIG_PASSPHRASE":   byoc.PulumiConfigPassphrase, // TODO: make secret
+		"PULUMI_COPILOT":             "false",
 		"PULUMI_SKIP_UPDATE_CHECK":   "true",
 		"STACK":                      b.PulumiStack,
 	}

--- a/src/pkg/cli/client/byoc/do/byoc.go
+++ b/src/pkg/cli/client/byoc/do/byoc.go
@@ -702,6 +702,10 @@ func (b *ByocDo) environment(projectName, delegateDomain string) ([]*godo.AppVar
 			Value: "false",
 		},
 		{
+			Key:   "PULUMI_COPILOT",
+			Value: "false",
+		},
+		{
 			Key:   "PULUMI_SKIP_UPDATE_CHECK",
 			Value: "true",
 		},

--- a/src/pkg/cli/client/byoc/gcp/byoc.go
+++ b/src/pkg/cli/client/byoc/gcp/byoc.go
@@ -355,8 +355,10 @@ func (b *ByocGcp) runCdCommand(ctx context.Context, cmd cdCommand) (string, erro
 		"PROJECT":                  cmd.Project,
 		pulumiBackendKey:           pulumiBackendValue,          // TODO: make secret
 		"PULUMI_CONFIG_PASSPHRASE": byoc.PulumiConfigPassphrase, // TODO: make secret
+		"PULUMI_COPILOT":           "false",
+		"PULUMI_SKIP_UPDATE_CHECK": "true",
 		"REGION":                   b.driver.Region,
-		"STACK":                    "beta",
+		"STACK":                    b.PulumiStack,
 	}
 
 	if !term.StdoutCanColor() {


### PR DESCRIPTION
## Description

New Pulumi CLI appears to print a note about their Copilot. Not sure whether this gets triggered only when using Pulumi Cloud, but it's potentially confusing so let's disable it. Env var was listed on https://www.pulumi.com/docs/iac/cli/environment-variables/ 


## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

