### PR TITLE
Fix cli early exit when not running in verbose mode

### DIFF
--- a/src/pkg/cli/tail.go
+++ b/src/pkg/cli/tail.go
@@ -362,7 +362,7 @@ func streamLogs(ctx context.Context, provider client.Provider, projectName strin
 					cancel() // TODO: stuck on defer Close() if we don't do this
 					return nil
 				}
-				return nil
+				continue
 			}
 
 			if ts.After(options.Since) {


### PR DESCRIPTION
## Description
Cli currently exits fast when it is not running in verbose mode. This is due to an early exit condition introduced in [PR #1169 Add defang estimate command](https://github.com/DefangLabs/defang/commit/3b05b03fa7cb7748b9c6cfb6e7da8a8c6bb68234#diff-eaaea9856777a2f5870fca35a2c52aef840f045c6558b3b56def7132d9125e95L351)

## Checklist

- [X] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

