### PR TITLE
Print real service state

### DIFF
--- a/src/cmd/cli/command/compose.go
+++ b/src/cmd/cli/command/compose.go
@@ -151,7 +151,7 @@ func makeComposeUpCmd() *cobra.Command {
 			term.Info("Tailing logs for", tailSource, "; press Ctrl+C to detach:")
 
 			tailOptions := cli.NewTailOptionsForDeploy(deploy, since, verbose)
-			err = cli.TailAndMonitor(ctx, project, provider, time.Duration(waitTimeout)*time.Second, tailOptions)
+			serviceStates, err := cli.TailAndMonitor(ctx, project, provider, time.Duration(waitTimeout)*time.Second, tailOptions)
 			if err != nil {
 				var errDeploymentFailed cliClient.ErrDeploymentFailed
 				if errors.As(err, &errDeploymentFailed) {
@@ -184,7 +184,7 @@ func makeComposeUpCmd() *cobra.Command {
 			}
 
 			for _, service := range deploy.Services {
-				service.State = cli.TargetServiceState
+				service.State = serviceStates[service.Service.Name]
 			}
 
 			// Print the current service states of the deployment

--- a/src/pkg/cli/composeUp_test.go
+++ b/src/pkg/cli/composeUp_test.go
@@ -273,7 +273,7 @@ func TestComposeUpStops(t *testing.T) {
 				timer := time.AfterFunc(time.Second, func() { provider.subscribeStream.Send(tt.svcFailed, tt.subscribeErr) })
 				t.Cleanup(func() { timer.Stop() })
 			}
-			err = TailAndMonitor(ctx, project, provider, -1, TailOptions{Deployment: resp.Etag})
+			_, err = TailAndMonitor(ctx, project, provider, -1, TailOptions{Deployment: resp.Etag})
 			if err != nil {
 				if err.Error() != tt.wantError {
 					t.Errorf("expected error: %v, got: %v", tt.wantError, err)


### PR DESCRIPTION
## Description

After `compose up` we print the state of all services, but this table is fake: it always shows COMPLETED. This is now fixed to show the actual latest states.


## Checklist

- [x] I have performed a self-review of my code
- [x] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

