### PR TITLE
avoid truncating access gateway env

### DIFF
--- a/src/pkg/cli/compose/fixup.go
+++ b/src/pkg/cli/compose/fixup.go
@@ -227,7 +227,12 @@ func fixupModelProvider(svccfg *types.ServiceConfig, project *types.Project) {
 
 	empty := ""
 	// svccfg.Deploy.Resources.Reservations.Limits = &types.Resources{} TODO: avoid memory limits warning
-	svccfg.Environment = types.MappingWithEquals{"OPENAI_API_KEY": &empty} // disable auth; see https://github.com/DefangLabs/openai-access-gateway/pull/5
+	if svccfg.Environment == nil {
+		svccfg.Environment = types.MappingWithEquals{}
+	}
+	if _, exists := svccfg.Environment["OPENAI_API_KEY"]; !exists {
+		svccfg.Environment["OPENAI_API_KEY"] = &empty // disable auth; see https://github.com/DefangLabs/openai-access-gateway/pull/5
+	}
 	// svccfg.HealthCheck = &types.ServiceHealthCheckConfig{} TODO: add healthcheck
 	svccfg.Image = "defangio/openai-access-gateway"
 	svccfg.Networks[modelProviderNetwork] = nil

--- a/src/testdata/provider/compose.yaml
+++ b/src/testdata/provider/compose.yaml
@@ -14,4 +14,6 @@ services:
       type: model
       options:
         model: ai/smollm2
+    environment:
+      DEBUG: "true"
     # x-defang-llm: true

--- a/src/testdata/provider/compose.yaml.fixup
+++ b/src/testdata/provider/compose.yaml.fixup
@@ -3,6 +3,7 @@
     "command": null,
     "entrypoint": null,
     "environment": {
+      "DEBUG": "true",
       "OPENAI_API_KEY": ""
     },
     "image": "defangio/openai-access-gateway",

--- a/src/testdata/provider/compose.yaml.golden
+++ b/src/testdata/provider/compose.yaml.golden
@@ -5,6 +5,8 @@ services:
       type: model
       options:
         model: ai/smollm2
+    environment:
+      DEBUG: "true"
     networks:
       default: null
   chat:


### PR DESCRIPTION
## Description

@raphaeltm was trying to deploy this configuration:

```yaml
llm:
  provider:
    type: model options:
    model: us.amazon.nova-premier-v1:0
  x-defang-llm: true
  environment:
    DEBUG: "true" # this gets replaced by the current CLI version
```

But the previous CLI code was overwriting the environment. This change should allow `DEBUG: "true"` to remain in the env even if we set `OPENAI_API_KEY=""`

This PR will also allow the user to set `OPENAI_API_KEY` to something else

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

