### PR TITLE
Fix panic when depends_on contains excluded service

### DIFF
--- a/src/pkg/cli/client/byoc/baseclient.go
+++ b/src/pkg/cli/client/byoc/baseclient.go
@@ -186,7 +186,7 @@ func topologicalSort(nodes map[string]*Node) []*defangv1.ServiceInfo {
 
 	var visit func(node *Node)
 	visit = func(node *Node) {
-		if node.Visited {
+		if node == nil || node.Visited {
 			return
 		}
 		node.Visited = true

--- a/src/pkg/cli/client/byoc/baseclient_test.go
+++ b/src/pkg/cli/client/byoc/baseclient_test.go
@@ -23,6 +23,7 @@ func TestTopologicalSort(t *testing.T) {
 			"a": {"b"}, "b": {"c"}, "c": {"d"}, "d": {"e", "j"}, "e": {"f"}, "f": {},
 			"g": {"h"}, "h": {"i"}, "i": {"d"}, "j": {"k"}, "k": {},
 		},
+		{"a": {"b", "c"}, "b": {"c"}}, // Excluded service
 	}
 	for _, tt := range tests {
 		t.Run(fmt.Sprintf("%v", tt), func(t *testing.T) {


### PR DESCRIPTION
## Description

This fixes a panic during sorting of dependencies when a dependent service is excluded (`profiles: […]`).


## Checklist

- [x] I have performed a self-review of my code
- [x] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

