### PR TITLE
Handle GCP transient errors and retry for waiting for service states and cd task when there is transient error

### DIFF
--- a/src/pkg/cli/bootstrap.go
+++ b/src/pkg/cli/bootstrap.go
@@ -44,7 +44,7 @@ func TailAndWaitForCD(ctx context.Context, projectName string, provider client.P
 
 	var cdErr error
 	go func() {
-		cdErr = client.WaitForCdTaskExit(ctx, provider)
+		cdErr = WaitForCdTaskExit(ctx, provider)
 		pkg.SleepWithContext(ctx, 2*time.Second) // a delay before cancelling tail to make sure we got the last logs
 		cancelTail(cdErr)
 	}()

--- a/src/pkg/cli/tailAndMonitor.go
+++ b/src/pkg/cli/tailAndMonitor.go
@@ -43,17 +43,32 @@ func TailAndMonitor(ctx context.Context, project *compose.Project, provider clie
 	go func() {
 		defer wg.Done()
 		// block on waiting for services to reach target state
-		serviceStates, svcErr = WaitServiceState(svcStatusCtx, provider, targetServiceState, project.Name, tailOptions.Deployment, computeServices)
+		for {
+			serviceStates, svcErr = WaitServiceState(svcStatusCtx, provider, targetServiceState, project.Name, tailOptions.Deployment, computeServices)
+			if svcErr != nil && isTransientError(svcErr) {
+				term.Debug("WaitServiceState failed with transient error, retrying:", svcErr)
+				continue
+			}
+			break
+		}
+		term.Debug("WaitServiceState stopped with", svcErr)
 	}()
 
 	go func() {
 		defer wg.Done()
 		// block on waiting for cdTask to complete
-		if err := client.WaitForCdTaskExit(ctx, provider); err != nil {
+		for {
+			err := client.WaitForCdTaskExit(ctx, provider)
+			if err != nil && isTransientError(err) {
+				term.Debug("WaitForCdTaskExit failed with transient error, retrying:", err)
+				continue
+			}
 			cdErr = err
 			// When CD fails, stop WaitServiceState
 			cancelSvcStatus(cdErr)
+			break
 		}
+		term.Debug("WaitForCdTaskExit stopped with", cdErr)
 	}()
 
 	errMonitoringDone := errors.New("monitoring done") // pseudo error to signal that monitoring is done

--- a/src/pkg/cli/tailAndMonitor.go
+++ b/src/pkg/cli/tailAndMonitor.go
@@ -44,7 +44,6 @@ func TailAndMonitor(ctx context.Context, project *compose.Project, provider clie
 		defer wg.Done()
 		// block on waiting for services to reach target state
 		serviceStates, svcErr = WaitServiceState(svcStatusCtx, provider, targetServiceState, project.Name, tailOptions.Deployment, computeServices)
-		term.Debug("WaitServiceState stopped with", svcErr)
 	}()
 
 	go func() {
@@ -55,7 +54,6 @@ func TailAndMonitor(ctx context.Context, project *compose.Project, provider clie
 			// When CD fails, stop WaitServiceState
 			cancelSvcStatus(cdErr)
 		}
-		term.Debug("WaitForCdTaskExit stopped with", cdErr)
 	}()
 
 	errMonitoringDone := errors.New("monitoring done") // pseudo error to signal that monitoring is done

--- a/src/pkg/cli/waitForCdTaskExit.go
+++ b/src/pkg/cli/waitForCdTaskExit.go
@@ -1,15 +1,17 @@
-package client
+package cli
 
 import (
 	"context"
 	"errors"
 	"io"
 	"time"
+
+	"github.com/DefangLabs/defang/src/pkg/cli/client"
 )
 
 var pollDuration = 2 * time.Second
 
-func WaitForCdTaskExit(ctx context.Context, provider Provider) error {
+func WaitForCdTaskExit(ctx context.Context, provider client.Provider) error {
 	ticker := time.NewTicker(pollDuration)
 	defer ticker.Stop()
 
@@ -20,6 +22,12 @@ func WaitForCdTaskExit(ctx context.Context, provider Provider) error {
 				if errors.Is(err, io.EOF) {
 					// EOF indicates that the task has completed successfully
 					return nil
+				} else if isTransientError(err) {
+					// If it's a transient error, we can retry
+					if err := provider.DelayBeforeRetry(ctx); err != nil {
+						return err
+					}
+					continue
 				}
 				return err
 			}


### PR DESCRIPTION
## Description
Handle GCP transient errors and retry for waiting for service states and cd task when there is transient error

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

