### PR TITLE
Always run estimate previews on defang provider

### DIFF
--- a/src/cmd/cli/command/estimate.go
+++ b/src/cmd/cli/command/estimate.go
@@ -33,7 +33,7 @@ func makeEstimateCmd() *cobra.Command {
 			loader := configureLoader(cmd)
 			project, err := loader.LoadProject(ctx)
 			if err != nil {
-				return fmt.Errorf("failed to load project: %w", err)
+				return err
 			}
 
 			estimate, err := RunEstimate(ctx, project, providerID, region, mode.Value())
@@ -58,7 +58,7 @@ func RunEstimate(ctx context.Context, project *compose.Project, provider cliClie
 	term.Info("Generating deployment preview")
 	preview, err := GeneratePreview(ctx, project, defangProvider, mode)
 	if err != nil {
-		return nil, fmt.Errorf("failed to generate preview: %w", err)
+		return nil, err
 	}
 	term.Debugf("Preview output: %s\n", preview)
 
@@ -70,7 +70,7 @@ func RunEstimate(ctx context.Context, project *compose.Project, provider cliClie
 		PulumiPreview: []byte(preview),
 	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to estimate: %w", err)
+		return nil, err
 	}
 	return estimate, nil
 }


### PR DESCRIPTION
## Description

In order to avoid requiring cloud credentials to generate an estimate, we will now run the deployment preview on the defang provider (playground). This should also help reduce latency as we already have a cd task running and we won't have to wait for it to spin up.

There is a little subtlety here, because we handle the `-P, --provider` flag passed by the user differently in this case than we do in other commands. Instead of running the preview on the specified provider, we will always run the preview on the Defang provider, and we will always generate the estimate with fabric, but we will still use the passed provider name to determine the deployment and estimation target.

## Linked Issues

https://github.com/DefangLabs/defang-mvp/pull/1836

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

