### PR TITLE
only support AWS estimates for now

### DIFF
--- a/src/cmd/cli/command/estimate.go
+++ b/src/cmd/cli/command/estimate.go
@@ -26,11 +26,13 @@ func makeEstimateCmd() *cobra.Command {
 				return err
 			}
 
-			if providerID == cliClient.ProviderAuto || providerID == cliClient.ProviderDefang {
-				if _, err := interactiveSelectProvider([]cliClient.ProviderID{cliClient.ProviderAWS, cliClient.ProviderDO, cliClient.ProviderGCP}); err != nil {
-					return err
-				}
-			}
+			providerID = cliClient.ProviderAWS // Default to AWS
+			// TODO: bring this back when GCP is supported
+			// if providerID == cliClient.ProviderAuto || providerID == cliClient.ProviderDefang {
+			// 	if _, err := interactiveSelectProvider([]cliClient.ProviderID{cliClient.ProviderAWS, cliClient.ProviderGCP}); err != nil {
+			// 		return err
+			// 	}
+			// }
 
 			estimate, err := cli.RunEstimate(ctx, project, client, providerID, region, mode.Value())
 			if err != nil {


### PR DESCRIPTION
## Description

Lio added a provider picker when running estimates, and it was a good idea, but we only support AWS at the moment, so let's remove it until we support GCP

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

