### PR TITLE
Show warning during ctrl-c in up

### DIFF
--- a/src/pkg/cli/tailAndMonitor.go
+++ b/src/pkg/cli/tailAndMonitor.go
@@ -78,11 +78,11 @@ func TailAndMonitor(ctx context.Context, project *compose.Project, provider clie
 		}
 
 		switch {
-		case errors.Is(context.Cause(tailCtx), errMonitoringDone):
-			break // the monitoring stopped the tail; cdErr and/or svcErr will have been set
-
 		case errors.Is(context.Cause(ctx), context.Canceled):
 			term.Warn("Deployment is not finished. Service(s) might not be running.")
+
+		case errors.Is(context.Cause(tailCtx), errMonitoringDone):
+			break // the monitoring stopped the tail; cdErr and/or svcErr will have been set
 
 		case errors.Is(context.Cause(ctx), context.DeadlineExceeded):
 			// Tail was canceled when wait-timeout is reached; show a warning and exit with an error


### PR DESCRIPTION
## Description

 When pressing ctrl-c during "compose up", the callers context (`ctx`) gets canceled, which should show the warning `Deployment is not finished. Service(s) might not be running.` but didn't. It didn't because when the `ctx` gets cancelled, all the go routines get cancelled pretty much at the same time, so we can end up with `errMonitoringDone`, which because of the order of the `case` statements ends up skipping the warning.

## Linked Issues

Probably a small regression in #1074

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

