### PR TITLE
Restore ability to run estimate previews on AWS

### DIFF
--- a/src/cmd/cli/command/estimate.go
+++ b/src/cmd/cli/command/estimate.go
@@ -6,6 +6,7 @@ import (
 	"github.com/DefangLabs/defang/src/pkg"
 	"github.com/DefangLabs/defang/src/pkg/cli"
 	cliClient "github.com/DefangLabs/defang/src/pkg/cli/client"
+	"github.com/DefangLabs/defang/src/pkg/cli/client/byoc/aws"
 	"github.com/DefangLabs/defang/src/pkg/term"
 	"github.com/spf13/cobra"
 )
@@ -26,7 +27,12 @@ func makeEstimateCmd() *cobra.Command {
 				return err
 			}
 
-			providerID = cliClient.ProviderAWS // Default to AWS
+			var previewProvider cliClient.Provider
+			if awsInEnv() && providerID == cliClient.ProviderAWS {
+				previewProvider = aws.NewByocProvider(ctx, client.GetTenantName())
+			} else {
+				previewProvider = &cliClient.PlaygroundProvider{FabricClient: client}
+			}
 			// TODO: bring this back when GCP is supported
 			// if providerID == cliClient.ProviderAuto || providerID == cliClient.ProviderDefang {
 			// 	if _, err := interactiveSelectProvider([]cliClient.ProviderID{cliClient.ProviderAWS, cliClient.ProviderGCP}); err != nil {
@@ -34,7 +40,7 @@ func makeEstimateCmd() *cobra.Command {
 			// 	}
 			// }
 
-			estimate, err := cli.RunEstimate(ctx, project, client, providerID, region, mode.Value())
+			estimate, err := cli.RunEstimate(ctx, project, client, previewProvider, providerID, region, mode.Value())
 			if err != nil {
 				return fmt.Errorf("failed to run estimate: %w", err)
 			}

--- a/src/pkg/cli/compose/serviceNameReplacer.go
+++ b/src/pkg/cli/compose/serviceNameReplacer.go
@@ -63,7 +63,7 @@ func (s *ServiceNameReplacer) ReplaceServiceNameWithDNS(serviceName string, key,
 	if val != value {
 		term.Warnf("service %q: service name was adjusted: %s %q assigned value %q", serviceName, fixupTarget, key, val)
 	} else if s.ingressServiceNameRegex != nil && s.ingressServiceNameRegex.MatchString(value) {
-		term.Warnf("service %q: service name in the %s %q was not adjusted; only references to other services with port mode set to 'host' will be fixed-up", serviceName, fixupTarget, key)
+		term.Debugf("service %q: service name in the %s %q was not adjusted; only references to other services with port mode set to 'host' will be fixed-up", serviceName, fixupTarget, key)
 	}
 
 	return val

--- a/src/pkg/cli/estimate.go
+++ b/src/pkg/cli/estimate.go
@@ -20,10 +20,9 @@ import (
 	defangv1 "github.com/DefangLabs/defang/src/protos/io/defang/v1"
 )
 
-func RunEstimate(ctx context.Context, project *compose.Project, client cliClient.FabricClient, provider cliClient.ProviderID, region string, mode defangv1.DeploymentMode) (*defangv1.EstimateResponse, error) {
-	defangProvider := &cliClient.PlaygroundProvider{FabricClient: client}
+func RunEstimate(ctx context.Context, project *compose.Project, client cliClient.FabricClient, previewProvider cliClient.Provider, estimateProvider cliClient.ProviderID, region string, mode defangv1.DeploymentMode) (*defangv1.EstimateResponse, error) {
 	term.Info("Generating deployment preview")
-	preview, err := GeneratePreview(ctx, project, client, defangProvider, mode)
+	preview, err := GeneratePreview(ctx, project, client, previewProvider, mode)
 	if err != nil {
 		return nil, err
 	}
@@ -31,7 +30,7 @@ func RunEstimate(ctx context.Context, project *compose.Project, client cliClient
 	term.Info("Preparing estimate")
 
 	estimate, err := client.Estimate(ctx, &defangv1.EstimateRequest{
-		Provider:      provider.Value(),
+		Provider:      estimateProvider.Value(),
 		Region:        region,
 		PulumiPreview: []byte(preview),
 	})

--- a/src/pkg/mcp/tools/estimate.go
+++ b/src/pkg/mcp/tools/estimate.go
@@ -58,10 +58,11 @@ func setupEstimateTool(s *server.MCPServer, cluster string) {
 			return mcp.NewToolResultErrorFromErr("Could not connect", err), nil
 		}
 
+		defangProvider := &cliClient.PlaygroundProvider{FabricClient: client}
 		providerID := cliClient.ProviderAWS // Default to AWS
 
 		term.Debug("Function invoked: cli.RunEstimate")
-		estimate, err := cli.RunEstimate(ctx, project, client, providerID, "us-west-2", defangv1.DeploymentMode_DEVELOPMENT)
+		estimate, err := cli.RunEstimate(ctx, project, client, defangProvider, providerID, "us-west-2", defangv1.DeploymentMode_DEVELOPMENT)
 		if err != nil {
 			return mcp.NewToolResultErrorFromErr("Failed to run estimate", err), nil
 		}

--- a/src/testdata/fixupenv/compose.yaml.warnings
+++ b/src/testdata/fixupenv/compose.yaml.warnings
@@ -8,5 +8,4 @@
  ! service "ui": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors
  ! service "ui": service name was adjusted: environment variable "API_URL" assigned value "http://mock-mistral:8000"
  ! service "use-ingress-service": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors
- ! service "use-ingress-service": service name in the environment variable "DB_URL" was not adjusted; only references to other services with port mode set to 'host' will be fixed-up
  * Packaging the project files for fixup-args at .


### PR DESCRIPTION
## Description

If we explicitly pass `-Paws` with aws in the environment. run the preview in your own cloud account

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

