### PR TITLE
added support for mcp estimate deployment modes

### DIFF
--- a/src/cmd/cli/command/estimate.go
+++ b/src/cmd/cli/command/estimate.go
@@ -58,7 +58,7 @@ func makeEstimateCmd() *cobra.Command {
 		},
 	}
 
-	estimateCmd.Flags().VarP(&mode, "mode", "m", fmt.Sprintf("deployment mode; one of %v", []string{"affordable", "balanced", "high_availability"}))
+	estimateCmd.Flags().VarP(&mode, "mode", "m", fmt.Sprintf("deployment mode; one of %v", allModes()))
 	estimateCmd.Flags().StringP("region", "r", pkg.Getenv("AWS_REGION", "us-west-2"), "which cloud region to estimate")
 	return estimateCmd
 }

--- a/src/cmd/cli/command/mode.go
+++ b/src/cmd/cli/command/mode.go
@@ -16,7 +16,7 @@ func (b Mode) String() string {
 	return strings.ToLower(defangv1.DeploymentMode_name[int32(b)])
 }
 
-func NewMode(s string) (Mode, error) {
+func (b *Mode) Set(s string) error {
 	upper := strings.ToUpper(s)
 	mode, ok := defangv1.DeploymentMode_value[upper]
 	if !ok {
@@ -29,19 +29,10 @@ func NewMode(s string) (Mode, error) {
 		case "HA":
 			mode = int32(defangv1.DeploymentMode_PRODUCTION)
 		default:
-			return 0, fmt.Errorf("invalid mode: %s, not one of %v", s, allModes())
+			return fmt.Errorf("invalid mode: %s, not one of %v", s, allModes())
 		}
 	}
-	return Mode(mode), nil
-}
-
-func (b *Mode) Set(s string) error {
-	mode, err := NewMode(s)
-	if err != nil {
-		return fmt.Errorf("failed to set mode: %w", err)
-	}
-	*b = mode
-
+	*b = Mode(mode)
 	return nil
 }
 

--- a/src/cmd/cli/command/mode.go
+++ b/src/cmd/cli/command/mode.go
@@ -2,7 +2,6 @@ package command
 
 import (
 	"fmt"
-	"slices"
 	"strings"
 
 	defangv1 "github.com/DefangLabs/defang/src/protos/io/defang/v1"
@@ -17,7 +16,7 @@ func (b Mode) String() string {
 	return strings.ToLower(defangv1.DeploymentMode_name[int32(b)])
 }
 
-func (b *Mode) Set(s string) error {
+func NewMode(s string) (Mode, error) {
 	upper := strings.ToUpper(s)
 	mode, ok := defangv1.DeploymentMode_value[upper]
 	if !ok {
@@ -30,10 +29,19 @@ func (b *Mode) Set(s string) error {
 		case "HA":
 			mode = int32(defangv1.DeploymentMode_PRODUCTION)
 		default:
-			return fmt.Errorf("invalid mode: %s, not one of %v", s, allModes())
+			return 0, fmt.Errorf("invalid mode: %s, not one of %v", s, allModes())
 		}
 	}
-	*b = Mode(mode)
+	return Mode(mode), nil
+}
+
+func (b *Mode) Set(s string) error {
+	mode, err := NewMode(s)
+	if err != nil {
+		return fmt.Errorf("failed to set mode: %w", err)
+	}
+	*b = mode
+
 	return nil
 }
 
@@ -46,13 +54,5 @@ func (b Mode) Value() defangv1.DeploymentMode {
 }
 
 func allModes() []string {
-	modes := make([]string, 0, len(defangv1.DeploymentMode_name)-1)
-	for i, mode := range defangv1.DeploymentMode_name {
-		if i == 0 {
-			continue
-		}
-		modes = append(modes, strings.ToLower(mode))
-	}
-	slices.Sort(modes) // TODO: sort by enum value instead of string
-	return modes
+	return []string{"affordable", "balanced", "high_availability"}
 }

--- a/src/pkg/mcp/tools/estimate.go
+++ b/src/pkg/mcp/tools/estimate.go
@@ -27,9 +27,9 @@ func setupEstimateTool(s *server.MCPServer, cluster string) {
 		),
 
 		mcp.WithString("deployment_mode",
-			mcp.Description("The deployment mode for the estimate. Options are AFFORDABLE, BALANCED or HIGH_AVAILABILITY."),
+			mcp.Description("The deployment mode for the estimate. Options are AFFORDABLE, BALANCED or HIGH AVAILABILITY."),
 			mcp.DefaultString("AFFORDABLE"),
-			mcp.Enum("AFFORDABLE", "BALANCED", "HIGH_AVAILABILITY"),
+			mcp.Enum("AFFORDABLE", "BALANCED", "HIGH AVAILABILITY"),
 		),
 	)
 	term.Debug("Estimate tool created")
@@ -62,7 +62,7 @@ func setupEstimateTool(s *server.MCPServer, cluster string) {
 			mode = defangv1.DeploymentMode_DEVELOPMENT
 		case "BALANCED":
 			mode = defangv1.DeploymentMode_STAGING
-		case "HIGH_AVAILABILITY":
+		case "HIGH AVAILABILITY":
 			mode = defangv1.DeploymentMode_PRODUCTION
 		default:
 			term.Warn("Unknown deployment mode provided, defaulting to AFFORDABLE")

--- a/src/pkg/mcp/tools/estimate.go
+++ b/src/pkg/mcp/tools/estimate.go
@@ -56,17 +56,13 @@ func setupEstimateTool(s *server.MCPServer, cluster string) {
 		// This logic is replicated from src/cmd/cli/command/mode.go
 		// I couldn't figure out how to import it without circular dependencies
 		modeString = strings.ToUpper(modeString)
-		mode := defangv1.DeploymentMode_DEVELOPMENT // Default to DEVELOPMENT
+		var mode defangv1.DeploymentMode
 		switch modeString {
 		case "AFFORDABLE":
-		case "DEVELOPMENT":
 			mode = defangv1.DeploymentMode_DEVELOPMENT
 		case "BALANCED":
-		case "STAGING":
 			mode = defangv1.DeploymentMode_STAGING
-		case "PRODUCTION":
 		case "HIGH_AVAILABILITY":
-		case "HA":
 			mode = defangv1.DeploymentMode_PRODUCTION
 		default:
 			term.Warn("Unknown deployment mode provided, defaulting to AFFORDABLE")


### PR DESCRIPTION
## Description
Added support for MCP deployment modes (dev and prod)

<!-- Concise description of what this PR is tackling. -->

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

