### PR TITLE
development mode estimates should ignore NAT gateway 

### DIFF
--- a/src/cmd/cli/command/estimate.go
+++ b/src/cmd/cli/command/estimate.go
@@ -8,6 +8,7 @@ import (
 	cliClient "github.com/DefangLabs/defang/src/pkg/cli/client"
 	"github.com/DefangLabs/defang/src/pkg/cli/client/byoc/aws"
 	"github.com/DefangLabs/defang/src/pkg/term"
+	defangv1 "github.com/DefangLabs/defang/src/protos/io/defang/v1"
 	"github.com/spf13/cobra"
 )
 
@@ -45,6 +46,11 @@ func makeEstimateCmd() *cobra.Command {
 			// 		return err
 			// 	}
 			// }
+
+			// default to development mode if not specified
+			if mode.Value() == defangv1.DeploymentMode_MODE_UNSPECIFIED {
+				mode = Mode(defangv1.DeploymentMode_DEVELOPMENT)
+			}
 
 			estimate, err := cli.RunEstimate(ctx, project, client, previewProvider, providerID, region, mode.Value())
 			if err != nil {


### PR DESCRIPTION
## Description

Development mode cost estimates should not include NAT gateways. Temporary change to not include NAT gateway log entries when sent to the estimation API.

## Linked Issues

None

## Checklist

- [X] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

