### PR TITLE
fix AWS byoc compose down does not stop due to missing etag

### DIFF
--- a/src/pkg/cli/client/byoc/aws/byoc.go
+++ b/src/pkg/cli/client/byoc/aws/byoc.go
@@ -686,7 +686,6 @@ func (b *ByocAws) QueryLogs(ctx context.Context, req *defangv1.TailRequest) (cli
 		tailStream, err = b.driver.TailTaskID(ctx, etag)
 		if err == nil {
 			b.cdTaskArn, err = b.driver.GetTaskArn(etag)
-			etag = "" // no need to filter by etag
 		}
 	} else {
 		var service string


### PR DESCRIPTION
## Description
In the recent update to fix cli end condition, we had a small regression for aws byoc, which compose down does not terminate as the [end condition check checks for etag](https://github.com/DefangLabs/defang/pull/1234/files#diff-551b321584f650e3341ed3b36221e8e19c88f18487f0aba1ada34f66d3cc8607R403), but it was [removed from the tail api call](https://github.com/DefangLabs/defang/blob/main/src/pkg/cli/client/byoc/aws/byoc.go#L689). Keeping the etag (ecs task id) for cd actually works well for this case since it would be [added to the event by the byoc server stream](https://github.com/DefangLabs/defang/blob/main/src/pkg/cli/client/byoc/aws/stream.go#L86).

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [X] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

