### PR TITLE
nil check for EndEventDetectFunc

### DIFF
--- a/src/pkg/cli/tail.go
+++ b/src/pkg/cli/tail.go
@@ -344,9 +344,11 @@ func streamLogs(ctx context.Context, provider client.Provider, projectName strin
 			isInternal := service == "cd" || service == "kaniko" || service == "fabric" || host == "kaniko" || host == "fabric" || host == "ecs" || host == "cloudbuild" || host == "pulumi"
 			onlyErrors := !options.Verbose && isInternal
 			if onlyErrors && !e.Stderr {
-				if err := options.EndEventDetectFunc(e); err != nil {
-					cancel() // TODO: stuck on defer Close() if we don't do this
-					return err
+				if options.EndEventDetectFunc != nil {
+					if err := options.EndEventDetectFunc(e); err != nil {
+						cancel() // TODO: stuck on defer Close() if we don't do this
+						return err
+					}
 				}
 				continue
 			}


### PR DESCRIPTION
## Description
To prevent panic when there is no end event detection:
```
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x22c2ff1]

goroutine 1 [running]:
main.main.func1()
	github.com/DefangLabs/defang/src/cmd/cli/main.go:22 +0x145
panic({0x288d1e0?, 0x4e95fc0?})
	runtime/panic.go:791 +0x132
github.com/DefangLabs/defang/src/pkg/cli.streamLogs({0x360e068, 0xc000613e50}, {0x362b958, 0xc0004a4a80}, {0x0, 0x0}, {0x0, {0xc000102747, 0x20}, {0x0, ...}, ...}, ...)
	github.com/DefangLabs/defang/src/pkg/cli/tail.go:347 +0x12b1
github.com/DefangLabs/defang/src/pkg/cli.TailAndWaitForCD({0x360e228?, 0xc0004a6300?}, {0x0, 0x0}, {0x362b958, 0xc0004a4a80}, {0x0, {0xc000102747, 0x20}, {0x0, ...}, ...}, ...)
	github.com/DefangLabs/defang/src/pkg/cli/bootstrap.go:54 +0x1d6
github.com/DefangLabs/defang/src/pkg/cli.BootstrapCommand({0x360e228, 0xc0004a6300}, {0x0, 0x0}, 0x0, {0x362b958, 0xc0004a4a80}, {0x31d358b, 0x4})
	github.com/DefangLabs/defang/src/pkg/cli/bootstrap.go:38 +0x2b0
github.com/DefangLabs/defang/src/cmd/cli/command.init.func18(0x4f2bba0, {0xc000970230?, 0x0?, 0x5?})
	github.com/DefangLabs/defang/src/cmd/cli/command/cd.go:173 +0x10f
github.com/spf13/cobra.(*Command).execute(0x4f2bba0, {0xc0009701e0, 0x5, 0x5})
	github.com/spf13/cobra@v1.8.0/command.go:1015 +0xa94
github.com/spf13/cobra.(*Command).ExecuteC(0x4f2[87](https://github.com/DefangLabs/defang-mvp/actions/runs/15591194460/job/43912135469#step:7:88)60)
	github.com/spf13/cobra@v1.8.0/command.go:1148 +0x40c
github.com/spf13/cobra.(*Command).Execute(...)
	github.com/spf13/cobra@v1.8.0/command.go:1071
github.com/spf13/cobra.(*Command).ExecuteContext(...)
	github.com/spf13/cobra@v1.8.0/command.go:1064
github.com/DefangLabs/defang/src/cmd/cli/command.Execute({0x360e228, 0xc0004a6300})
	github.com/DefangLabs/defang/src/cmd/cli/command/commands.go:80 +0xd1
main.main()
	github.com/DefangLabs/defang/src/cmd/cli/main.go:36 +0x145
```

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

