### PR TITLE
Add lifecycle rule to cd bucket to only keep last 10 deployment as version

### DIFF
--- a/src/pkg/clouds/aws/ecs/cfn/template.go
+++ b/src/pkg/clouds/aws/ecs/cfn/template.go
@@ -84,6 +84,19 @@ func createTemplate(stack string, containers []types.Container, overrides Templa
 		VersioningConfiguration: &s3.Bucket_VersioningConfiguration{
 			Status: "Enabled",
 		},
+		LifecycleConfiguration: &s3.Bucket_LifecycleConfiguration{
+			Rules: []s3.Bucket_Rule{
+				{
+					Status: "Enabled",
+					NoncurrentVersionExpiration: &s3.Bucket_NoncurrentVersionExpiration{
+						// Deletion only happens when both NoncurrentDays and NewerNoncurrentVersions are exceeded
+						// See: https://docs.aws.amazon.com/AmazonS3/latest/userguide/intro-lifecycle-rules.html
+						NoncurrentDays:          10,          // Keep deployments for at least 10 days
+						NewerNoncurrentVersions: ptr.Int(10), // Keep last 10 deployments
+					},
+				},
+			},
+		},
 	}
 
 	// 2. ECS cluster


### PR DESCRIPTION
## Description
To prevent cd bucket to become too big.

Sample life cycle rule:
![Screenshot from 2025-06-16 11-28-56](https://github.com/user-attachments/assets/6e0a1876-a40b-4f97-b65a-80319c0a4a4e)


## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

