### PR TITLE
Consider Connection Reset and Connection Aborted as transient error

### DIFF
--- a/src/pkg/cli/tail.go
+++ b/src/pkg/cli/tail.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"os"
 	"regexp"
 	"runtime"
@@ -168,6 +169,12 @@ func Tail(ctx context.Context, provider client.Provider, projectName string, opt
 }
 
 func isTransientError(err error) bool {
+	// Networking errors are considered transient errors
+	var netOpErr *net.OpError
+	if errors.As(err, &netOpErr) && netOpErr.Temporary() {
+		return true
+	}
+
 	// TODO: detect ALB timeout (504) or Fabric restart and reconnect automatically
 	code := connect.CodeOf(err)
 	// Reconnect on Error: internal: stream error: stream ID 5; INTERNAL_ERROR; received from peer


### PR DESCRIPTION
## Description
So cli will do a retry when connection reset happens.

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

