### PR TITLE
Use destroy API call for playground compose down

### DIFF
--- a/src/pkg/cli/client/playground.go
+++ b/src/pkg/cli/client/playground.go
@@ -81,21 +81,7 @@ func (g *PlaygroundProvider) BootstrapCommand(ctx context.Context, req Bootstrap
 	return "", errors.New("the CD command is not valid for the Defang playground; did you forget --provider?")
 }
 func (g *PlaygroundProvider) Destroy(ctx context.Context, req *defangv1.DestroyRequest) (types.ETag, error) {
-	// Get all the services in the project and delete them all at once
-	servicesList, err := g.GetServices(ctx, &defangv1.GetServicesRequest{Project: req.Project})
-	if err != nil {
-		return "", err
-	}
-	if len(servicesList.Services) == 0 {
-		return "", errors.New("no services found")
-	}
-	var names []string
-	for _, service := range servicesList.Services {
-		names = append(names, service.Service.Name)
-	}
-
-	// FIXME: use Destroy rpc instead of Delete rpc; https://github.com/DefangLabs/defang/issues/1231
-	resp, err := g.Delete(ctx, &defangv1.DeleteRequest{Project: req.Project, Names: names})
+	resp, err := getMsg(g.GetController().Destroy(ctx, connect.NewRequest(req)))
 	if err != nil {
 		return "", err
 	}
@@ -131,7 +117,7 @@ func (g *PlaygroundProvider) AccountInfo(ctx context.Context) (*AccountInfo, err
 	return &AccountInfo{
 		Provider:  ProviderDefang,
 		AccountID: g.GetTenantName().String(),
-		Region:    "us-west-2", // Hardcoded for now for prod1
+		Region:    "us-west-2", // Hardcoded for now for prod1 TODO: Probably should be the current tenant shard?
 	}, nil
 }
 

--- a/src/pkg/cli/destroy_test.go
+++ b/src/pkg/cli/destroy_test.go
@@ -23,7 +23,13 @@ func (grpcDestroyMockHandler) WhoAmI(context.Context, *connect.Request[emptypb.E
 
 func (grpcDestroyMockHandler) Delete(context.Context, *connect.Request[defangv1.DeleteRequest]) (*connect.Response[defangv1.DeleteResponse], error) {
 	return connect.NewResponse(&defangv1.DeleteResponse{
-		Etag: "test-etag",
+		Etag: "test-delete-etag",
+	}), nil
+}
+
+func (grpcDestroyMockHandler) Destroy(context.Context, *connect.Request[defangv1.DestroyRequest]) (*connect.Response[defangv1.DestroyResponse], error) {
+	return connect.NewResponse(&defangv1.DestroyResponse{
+		Etag: "test-destroy-etag",
 	}), nil
 }
 
@@ -55,7 +61,7 @@ func TestDestroy(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if etag != "test-etag" {
-		t.Fatalf("expected etag %q, got %q", "test-etag", etag)
+	if etag != "test-destroy-etag" {
+		t.Fatalf("expected etag %q, got %q", "test-destroy-etag", etag)
 	}
 }


### PR DESCRIPTION
## Description
To be consistent with portal

## Linked Issues
fixes: [Use destroy API call for playground compose down](https://github.com/DefangLabs/defang/commit/1c1a4a7fc5a4f1857b60f71eac6a53f0145e67fa)

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

