### PR TITLE
revert temporary change to CLI to exclude NATGW from development mode

### DIFF
--- a/src/cmd/cli/command/estimate.go
+++ b/src/cmd/cli/command/estimate.go
@@ -46,6 +46,13 @@ func makeEstimateCmd() *cobra.Command {
 				mode = Mode(defangv1.DeploymentMode_DEVELOPMENT)
 			}
 
+			// TODO: bring this back when GCP is supported
+			// if providerID == cliClient.ProviderAuto || providerID == cliClient.ProviderDefang {
+			// 	if _, err := interactiveSelectProvider([]cliClient.ProviderID{cliClient.ProviderAWS, cliClient.ProviderGCP}); err != nil {
+			// 		return err
+			// 	}
+			// }
+
 			estimate, err := cli.RunEstimate(ctx, project, client, previewProvider, providerID, region, mode.Value())
 			if err != nil {
 				return fmt.Errorf("failed to run estimate: %w", err)

--- a/src/pkg/cli/estimate.go
+++ b/src/pkg/cli/estimate.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -20,8 +19,6 @@ import (
 	"github.com/DefangLabs/defang/src/pkg/term"
 	defangv1 "github.com/DefangLabs/defang/src/protos/io/defang/v1"
 )
-
-var natgatewayRegex = regexp.MustCompile(`(?i)natgateway`)
 
 func RunEstimate(ctx context.Context, project *compose.Project, client cliClient.FabricClient, previewProvider cliClient.Provider, estimateProviderID cliClient.ProviderID, region string, mode defangv1.DeploymentMode) (*defangv1.EstimateResponse, error) {
 	term.Debugf("Running estimate for project %s in region %s with mode %s", project.Name, region, mode)
@@ -68,11 +65,7 @@ func GeneratePreview(ctx context.Context, project *compose.Project, client clien
 			return errors.New(entry.Message)
 		}
 		term.Debug(entry.Message)
-
-		if mode != defangv1.DeploymentMode_DEVELOPMENT || !natgatewayRegex.MatchString(entry.Message) {
-			pulumiPreviewLogLines = append(pulumiPreviewLogLines, entry.Message)
-		}
-
+		pulumiPreviewLogLines = append(pulumiPreviewLogLines, entry.Message)
 		return nil
 	})
 	if err != nil && !errors.Is(err, io.EOF) {


### PR DESCRIPTION
## Description

Revert a temporary code change to support NATGW in estimations. Fix on server renders the CLI change unnecessary.

## Linked Issues

None

## Checklist

- [X] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

