### PR TITLE
remove default auth provider

### DIFF
--- a/src/pkg/auth/auth.go
+++ b/src/pkg/auth/auth.go
@@ -82,7 +82,7 @@ func ServeAuthCodeFlowServer(ctx context.Context, authPort int, tenant types.Ten
 	redirectUri := "http://127.0.0.1:" + strconv.Itoa(authPort) + "/auth"
 
 	// Get the authorization URL before setting up the handler
-	ar, err := openAuthClient.Authorize(redirectUri, CodeResponseType, WithPkce(), WithProvider("github"))
+	ar, err := openAuthClient.Authorize(redirectUri, CodeResponseType, WithPkce())
 	if err != nil {
 		return err
 	}
@@ -169,7 +169,7 @@ func StartAuthCodeFlow(ctx context.Context, prompt Prompt) (AuthCodeFlow, error)
 	defer server.Close()
 
 	redirectUri := server.URL + "/auth"
-	ar, err := openAuthClient.Authorize(redirectUri, CodeResponseType, WithPkce(), WithProvider("github"))
+	ar, err := openAuthClient.Authorize(redirectUri, CodeResponseType, WithPkce())
 	if err != nil {
 		return AuthCodeFlow{}, err
 	}


### PR DESCRIPTION
## Description

Remove assumption in CLI that auth will be provided by github. We will move that decision to `auth.defang.io` where the auth providers could be selected from a small list.

## Linked Issues

https://github.com/DefangLabs/portal/pull/207

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

