### PR TITLE
Allow gcp estimate preview provider

### DIFF
--- a/src/cmd/cli/command/estimate.go
+++ b/src/cmd/cli/command/estimate.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/DefangLabs/defang/src/pkg"
 	"github.com/DefangLabs/defang/src/pkg/cli"
+	cliClient "github.com/DefangLabs/defang/src/pkg/cli/client"
 	"github.com/DefangLabs/defang/src/pkg/term"
 	defangv1 "github.com/DefangLabs/defang/src/protos/io/defang/v1"
 	"github.com/spf13/cobra"
@@ -26,15 +27,7 @@ func makeEstimateCmd() *cobra.Command {
 				return err
 			}
 
-			previewProvider, err := newProvider(cmd.Context(), loader)
-			if err != nil {
-				return err
-			}
-
-			err = canIUseProvider(cmd.Context(), previewProvider, project.Name)
-			if err != nil {
-				return err
-			}
+			var previewProvider cliClient.Provider = &cliClient.PlaygroundProvider{FabricClient: client}
 
 			// default to development mode if not specified; TODO: when mode is not specified, show an interactive prompt
 			if mode.Value() == defangv1.DeploymentMode_MODE_UNSPECIFIED {


### PR DESCRIPTION
## Description

Running `defang estimate -P gcp` should run the preview in a gcp account if gcp credentials are available.

## Linked Issues

* https://github.com/DefangLabs/defang-mvp/pull/1915

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

