### PR TITLE
Use Preview RPC for GCP estimates

### DIFF
--- a/src/cmd/cli/command/estimate.go
+++ b/src/cmd/cli/command/estimate.go
@@ -7,6 +7,7 @@ import (
 	"github.com/DefangLabs/defang/src/pkg/cli"
 	cliClient "github.com/DefangLabs/defang/src/pkg/cli/client"
 	"github.com/DefangLabs/defang/src/pkg/cli/client/byoc/aws"
+	"github.com/DefangLabs/defang/src/pkg/cli/client/byoc/gcp"
 	"github.com/DefangLabs/defang/src/pkg/term"
 	defangv1 "github.com/DefangLabs/defang/src/protos/io/defang/v1"
 	"github.com/spf13/cobra"
@@ -30,12 +31,19 @@ func makeEstimateCmd() *cobra.Command {
 
 			var previewProvider cliClient.Provider = &cliClient.PlaygroundProvider{FabricClient: client}
 			switch providerID {
-			case cliClient.ProviderAuto:
-				providerID = cliClient.ProviderAWS // default to AWS for estimates; TODO: show a picker
-				fallthrough
 			case cliClient.ProviderAWS:
 				if awsInEnv() {
 					previewProvider = aws.NewByocProvider(ctx, client.GetTenantName())
+				}
+			case cliClient.ProviderGCP:
+				if gcpInEnv() {
+					previewProvider = gcp.NewByocProvider(ctx, client.GetTenantName())
+				}
+			case cliClient.ProviderAuto:
+				fallthrough
+			case cliClient.ProviderDefang:
+				if _, err := interactiveSelectProvider([]cliClient.ProviderID{cliClient.ProviderAWS, cliClient.ProviderGCP}); err != nil {
+					return err
 				}
 			default:
 				return fmt.Errorf("unsupported provider %s; must be one of %v", providerID, []cliClient.ProviderID{cliClient.ProviderAWS})
@@ -45,13 +53,6 @@ func makeEstimateCmd() *cobra.Command {
 			if mode.Value() == defangv1.DeploymentMode_MODE_UNSPECIFIED {
 				mode = Mode(defangv1.DeploymentMode_DEVELOPMENT)
 			}
-
-			// TODO: bring this back when GCP is supported
-			// if providerID == cliClient.ProviderAuto || providerID == cliClient.ProviderDefang {
-			// 	if _, err := interactiveSelectProvider([]cliClient.ProviderID{cliClient.ProviderAWS, cliClient.ProviderGCP}); err != nil {
-			// 		return err
-			// 	}
-			// }
 
 			estimate, err := cli.RunEstimate(ctx, project, client, previewProvider, providerID, region, mode.Value())
 			if err != nil {

--- a/src/pkg/cli/client/client.go
+++ b/src/pkg/cli/client/client.go
@@ -29,6 +29,7 @@ type FabricClient interface {
 	GetTenantName() types.TenantName
 	GetVersions(context.Context) (*defangv1.Version, error)
 	ListDeployments(context.Context, *defangv1.ListDeploymentsRequest) (*defangv1.ListDeploymentsResponse, error)
+	Preview(context.Context, *defangv1.PreviewRequest) (*defangv1.PreviewResponse, error)
 	Publish(context.Context, *defangv1.PublishRequest) error
 	PutDeployment(context.Context, *defangv1.PutDeploymentRequest) error
 	RevokeToken(context.Context) error

--- a/src/pkg/cli/client/grpc.go
+++ b/src/pkg/cli/client/grpc.go
@@ -173,3 +173,7 @@ func (g GrpcClient) SetOptions(ctx context.Context, req *defangv1.SetOptionsRequ
 func (g GrpcClient) Estimate(ctx context.Context, req *defangv1.EstimateRequest) (*defangv1.EstimateResponse, error) {
 	return getMsg(g.client.Estimate(ctx, connect.NewRequest(req)))
 }
+
+func (g GrpcClient) Preview(ctx context.Context, req *defangv1.PreviewRequest) (*defangv1.PreviewResponse, error) {
+	return getMsg(g.client.Preview(ctx, connect.NewRequest(req)))
+}


### PR DESCRIPTION
## Description

Up to now, we have implemented preview by using the `Deploy` RPC with a `preview` boolean, but now that we are running GCP and AWS previews on playground, we need to be able to send a property to signal which provider playground should use. We didn't want to add a `provider` property to `DeployRequest`, so we decided it was time to factor out a new `Preview` RPC.

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

