### PR TITLE
add tail scope to github actions workflows

### DIFF
--- a/src/pkg/cli/login.go
+++ b/src/pkg/cli/login.go
@@ -130,7 +130,7 @@ func NonInteractiveGitHubLogin(ctx context.Context, client client.FabricClient, 
 	term.Debug("Got GitHub Actions id-token")
 	resp, err := client.Token(ctx, &defangv1.TokenRequest{
 		Assertion: idToken,
-		Scope:     []string{"admin", "read", "delete"}, // no "tail" scope
+		Scope:     []string{"admin", "read", "delete", "tail"},
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
## Description

Adding the `tail` scope to the noninteractive github login token scope so that we can support estimates in CI. We may roll this back in the future and make this opt-in

## Linked Issues

Depends on https://github.com/DefangLabs/defang-mvp/pull/1947

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

