### PR TITLE
add role to allow creation of firestore database

### DIFF
--- a/src/pkg/cli/client/byoc/gcp/byoc.go
+++ b/src/pkg/cli/client/byoc/gcp/byoc.go
@@ -175,6 +175,7 @@ func (b *ByocGcp) setUpCD(ctx context.Context) error {
 		"roles/redis.admin",                     // For creating redis instances/clusters
 		"roles/certificatemanager.owner",        // For creating certificates
 		"roles/serviceusage.serviceUsageAdmin",  // For allowing cd to Enable APIs
+		"roles/datastore.owner",                 // For creating firestore database
 	}); err != nil {
 		return err
 	}


### PR DESCRIPTION
## Description

Add  permission for creating firestore databases

## Linked Issues

[1932](https://github.com/DefangLabs/defang-mvp/issues/1932)

## Checklist

- [X] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

