### PR TITLE
uppercase table headers

### DIFF
--- a/src/cmd/cli/command/deploymentinfo_test.go
+++ b/src/cmd/cli/command/deploymentinfo_test.go
@@ -66,7 +66,7 @@ func TestPrintServiceStatesAndEndpointsAndDomainname(t *testing.T) {
 				},
 			},
 			expectedLines: []string{
-				"Deployment  Name      Status         Endpoints  DomainName",
+				"DEPLOYMENT  NAME      STATUS         ENDPOINTS  DOMAINNAME",
 				"            service1  NOT_SPECIFIED  N/A        https://example.com",
 				" * Run `defang cert generate` to get a TLS certificate for your service(s)",
 				"",
@@ -92,7 +92,7 @@ func TestPrintServiceStatesAndEndpointsAndDomainname(t *testing.T) {
 				},
 			},
 			expectedLines: []string{
-				"Deployment  Name      Status         Endpoints                                  DomainName",
+				"DEPLOYMENT  NAME      STATUS         ENDPOINTS                                  DOMAINNAME",
 				"            service1  NOT_SPECIFIED  https://example.com, service1.internal:80  https://example.com",
 				" * Run `defang cert generate` to get a TLS certificate for your service(s)",
 				"",
@@ -116,7 +116,7 @@ func TestPrintServiceStatesAndEndpointsAndDomainname(t *testing.T) {
 				},
 			},
 			expectedLines: []string{
-				"Deployment  Name      Status         Endpoints",
+				"DEPLOYMENT  NAME      STATUS         ENDPOINTS",
 				"            service1  NOT_SPECIFIED  https://service1",
 				"",
 			},

--- a/src/cmd/cli/command/estimate_test.go
+++ b/src/cmd/cli/command/estimate_test.go
@@ -135,7 +135,7 @@ updates, so there may be small windows of downtime during redeployment.
 Services will be exposed directly to the public internet for easy debugging.
 This mode emphasizes affordability over availability.
 
-Cost     Quantity          Service  Description
+COST     QUANTITY          SERVICE  DESCRIPTION
 $1.62    14600 GB-Hours    app      AmazonECS USW2-Fargate-EphemeralStorage-GB-Hours (20 GB * 730 hours)
 $6.49    1460 GB-Hours     app      AmazonECS USW2-Fargate-GB-Hours (2 GB * 730 hours)
 -$4.54   1460 GB-Hours     app      AmazonECS USW2-Fargate-GB-Hours-SpotDiscount (Estimated @ 70%)

--- a/src/pkg/cli/configList_test.go
+++ b/src/pkg/cli/configList_test.go
@@ -77,7 +77,7 @@ func TestConfigList(t *testing.T) {
 			t.Fatalf("ConfigList() error = %v", err)
 		}
 
-		expectedOutput := "\x1b[1m\nName\x1b[0m" + `
+		expectedOutput := "\x1b[1m\nNAME\x1b[0m" + `
 foo
 bar
 `

--- a/src/pkg/cli/deploymentsList_test.go
+++ b/src/pkg/cli/deploymentsList_test.go
@@ -79,7 +79,7 @@ func TestDeploymentsList(t *testing.T) {
 		if err != nil {
 			t.Fatalf("DeploymentsList() error = %v", err)
 		}
-		expectedOutput := "\x1b[1m\nProjectName  Provider  AccountId   Region     Deployment  DeployedAt\x1b[0m" + `
+		expectedOutput := "\x1b[1m\nPROJECTNAME  PROVIDER  ACCOUNTID   REGION     DEPLOYMENT  DEPLOYEDAT\x1b[0m" + `
 test         defang    1234567890  us-test-2  a1b2c3      ` + time.Time{}.Local().Format(time.RFC3339) + "\n"
 
 		receivedLines := strings.Split(stdout.String(), "\n")

--- a/src/pkg/cli/estimate.go
+++ b/src/pkg/cli/estimate.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/DefangLabs/defang/src/pkg/cli/client"
-	cliClient "github.com/DefangLabs/defang/src/pkg/cli/client"
 	"github.com/DefangLabs/defang/src/pkg/cli/compose"
 	"github.com/DefangLabs/defang/src/pkg/logs"
 	"github.com/DefangLabs/defang/src/pkg/money"
@@ -20,7 +19,7 @@ import (
 	defangv1 "github.com/DefangLabs/defang/src/protos/io/defang/v1"
 )
 
-func RunEstimate(ctx context.Context, project *compose.Project, client cliClient.FabricClient, previewProvider cliClient.Provider, estimateProviderID cliClient.ProviderID, region string, mode defangv1.DeploymentMode) (*defangv1.EstimateResponse, error) {
+func RunEstimate(ctx context.Context, project *compose.Project, client client.FabricClient, previewProvider client.Provider, estimateProviderID client.ProviderID, region string, mode defangv1.DeploymentMode) (*defangv1.EstimateResponse, error) {
 	term.Debugf("Running estimate for project %s in region %s with mode %s", project.Name, region, mode)
 	preview, err := GeneratePreview(ctx, project, client, previewProvider, estimateProviderID, mode, region)
 	if err != nil {
@@ -40,7 +39,7 @@ func RunEstimate(ctx context.Context, project *compose.Project, client cliClient
 	return estimate, nil
 }
 
-func GeneratePreview(ctx context.Context, project *compose.Project, client client.FabricClient, previewProvider cliClient.Provider, estimateProviderID cliClient.ProviderID, mode defangv1.DeploymentMode, region string) (string, error) {
+func GeneratePreview(ctx context.Context, project *compose.Project, client client.FabricClient, previewProvider client.Provider, estimateProviderID client.ProviderID, mode defangv1.DeploymentMode, region string) (string, error) {
 	os.Setenv("DEFANG_JSON", "1") // HACK: always show JSON output for estimate
 	since := time.Now()
 
@@ -111,16 +110,17 @@ func PrintEstimate(mode defangv1.DeploymentMode, estimate *defangv1.EstimateResp
 	subtotal := (*money.Money)(estimate.Subtotal)
 	tableItems := prepareEstimateLineItemTableItems(estimate.LineItems)
 	term.Println("")
-	if mode == defangv1.DeploymentMode_DEVELOPMENT || mode == defangv1.DeploymentMode_MODE_UNSPECIFIED {
+	switch mode {
+	case defangv1.DeploymentMode_DEVELOPMENT, defangv1.DeploymentMode_MODE_UNSPECIFIED:
 		term.Println("Estimate for Deployment Mode: AFFORDABLE")
 		term.Println(affordableModeEstimateSummary)
-	} else if mode == defangv1.DeploymentMode_STAGING {
+	case defangv1.DeploymentMode_STAGING:
 		term.Println("Estimate for Deployment Mode: BALANCED")
 		term.Println(balancedModeEstimateSummary)
-	} else if mode == defangv1.DeploymentMode_PRODUCTION {
+	case defangv1.DeploymentMode_PRODUCTION:
 		term.Println("Estimate for Deployment Mode: HIGH_AVAILABILITY")
 		term.Println(highAvailabilityModeEstimateSummary)
-	} else {
+	default:
 		term.Printf("Estimate for %s Mode\n", mode.String())
 	}
 

--- a/src/pkg/cli/getServices_test.go
+++ b/src/pkg/cli/getServices_test.go
@@ -85,7 +85,7 @@ func TestGetServices(t *testing.T) {
 		if err != nil {
 			t.Fatalf("GetServices() error = %v", err)
 		}
-		expectedOutput := "\x1b[1m\nService  Deployment  PublicFqdn                 PrivateFqdn  Status\x1b[0m" + `
+		expectedOutput := "\x1b[1m\nSERVICE  DEPLOYMENT  PUBLICFQDN                 PRIVATEFQDN  STATUS\x1b[0m" + `
 foo      a1b2c3      test-foo.prod1.defang.dev               UNKNOWN
 `
 

--- a/src/pkg/term/table.go
+++ b/src/pkg/term/table.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"strings"
 	"text/tabwriter"
 )
 
@@ -35,7 +36,7 @@ func (t *Term) Table(slice interface{}, attributes ...string) error {
 		if i > 0 {
 			prefix = "\t"
 		}
-		_, err = fmt.Fprint(w, prefix, attr)
+		_, err = fmt.Fprint(w, prefix, strings.ToUpper(attr))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
## Description

I've seen many CLIs (like `docker`) that use UPPERCASE table headers, which is nice when we don't have an ANSI-capable terminal.

```
SERVICE      DEPLOYMENT    PUBLICFQDN                                     PRIVATEFQDN                  STATUS
redis        leozagfrmcdq                                                 redis.docs-chatbot.internal  PROVISIONING
llm          leozagfrmcdq                                                 llm.docs-chatbot.internal    PROVISIONING
app          leozagfrmcdq  app.docs-chatbot.commit111.defang.app                                       PROVISIONING
discord-bot  leozagfrmcdq  discord-bot.docs-chatbot.commit111.defang.app                               PROVISIONING
```

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

