### PR TITLE
update nightly tag to "nightly" rather than "devel"

### DIFF
--- a/src/.goreleaser.yml
+++ b/src/.goreleaser.yml
@@ -150,7 +150,7 @@ announce:
     enabled: true
 
 nightly:
-  tag_name: devel
+  tag_name: nightly
   publish_release: true
   keep_single_release: true
   version_template: "{{ incpatch .Version }}-{{ .ShortCommit }}-nightly"


### PR DESCRIPTION
## Description

The current tag for nightly builds is "devel", rename to "nightly" to be better descriptive.

## Linked Issues

fixes #1312 

## Checklist

- [X] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

