### PR TITLE
fix: no 'overridden by config' warning for X=${X}

### DIFF
--- a/src/pkg/cli/client/mock.go
+++ b/src/pkg/cli/client/mock.go
@@ -18,11 +18,11 @@ func (m MockProvider) CreateUploadURL(ctx context.Context, req *defangv1.UploadU
 }
 
 func (m MockProvider) ListConfig(ctx context.Context, req *defangv1.ListConfigsRequest) (*defangv1.Secrets, error) {
-	return &defangv1.Secrets{Names: []string{"VAR1"}}, nil
+	return &defangv1.Secrets{Names: []string{"CONFIG1", "CONFIG2", "dummy", "ENV1", "SENSITIVE_DATA", "VAR1"}}, nil
 }
 
 func (m MockProvider) ServiceDNS(service string) string {
-	return service
+	return "mock-" + service
 }
 
 // MockServerStream mocks a ServerStream.

--- a/src/pkg/cli/compose/loader.go
+++ b/src/pkg/cli/compose/loader.go
@@ -156,14 +156,14 @@ func (c *Loader) NewProjectOptions() (*cli.ProjectOptions, error) {
 					if hasSubstitution(templ, key) {
 						// We don't (yet) support substitution patterns during deployment
 						if inEnv {
-							term.Warnf("Environment variable %q is not used; add it to `.env` if needed", key)
+							term.Warnf("Environment variable %q is ignored; add it to `.env` if needed", key)
 						} else {
 							term.Debugf("Unresolved environment variable %q", key)
 						}
 						return "", false
 					}
 					if inEnv {
-						term.Warnf("Environment variable %q is not used; add it to `.env` or it may be resolved from config during deployment", key)
+						term.Warnf("Environment variable %q is ignored; add it to `.env` or it may be resolved from config during deployment", key)
 					} else {
 						term.Debugf("Environment variable %q was not resolved locally. It may be resolved from config during deployment", key)
 					}

--- a/src/pkg/cli/compose/validation_test.go
+++ b/src/pkg/cli/compose/validation_test.go
@@ -16,22 +16,6 @@ import (
 	composeTypes "github.com/compose-spec/compose-go/v2/types"
 )
 
-type validationMockProvider struct {
-	client.Provider
-	configs []string
-}
-
-func (m validationMockProvider) ListConfig(ctx context.Context, req *defangv1.ListConfigsRequest) (*defangv1.Secrets, error) {
-	return &defangv1.Secrets{
-		Names:   m.configs,
-		Project: "mock-project",
-	}, nil
-}
-
-func (m validationMockProvider) ServiceDNS(name string) string {
-	return "mock-" + name
-}
-
 func TestValidationAndConvert(t *testing.T) {
 	oldTerm := term.DefaultTerm
 	t.Cleanup(func() {
@@ -40,9 +24,7 @@ func TestValidationAndConvert(t *testing.T) {
 
 	t.Setenv("NODE_ENV", "if-you-see-this-env-was-used") // for interpolate/compose.yaml; should be ignored
 
-	mockClient := validationMockProvider{
-		configs: []string{"CONFIG1", "CONFIG2", "dummy", "ENV1", "SENSITIVE_DATA"},
-	}
+	mockClient := client.MockProvider{}
 	listConfigNamesFunc := func(ctx context.Context) ([]string, error) {
 		configs, err := mockClient.ListConfig(ctx, &defangv1.ListConfigsRequest{})
 		if err != nil {

--- a/src/testdata/configoverride/compose.yaml.warnings
+++ b/src/testdata/configoverride/compose.yaml.warnings
@@ -1,1 +1,2 @@
+ ! service "service1": environment variable(s) ["VAR1"] overridden by config
  ! service "service1": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors

--- a/src/testdata/fixupenv/compose.yaml.fixup
+++ b/src/testdata/fixupenv/compose.yaml.fixup
@@ -18,7 +18,7 @@
     "command": null,
     "entrypoint": null,
     "environment": {
-      "CONFIG1": "http://mistral:8000"
+      "CONFIG1": null
     },
     "image": "service:latest",
     "networks": {
@@ -30,7 +30,7 @@
       "context": ".",
       "dockerfile": "Dockerfile",
       "args": {
-        "API_URL": "http://mistral:8000"
+        "API_URL": "http://mock-mistral:8000"
       }
     },
     "command": null,
@@ -59,7 +59,7 @@
     "command": null,
     "entrypoint": null,
     "environment": {
-      "API_URL": "http://mistral:8000",
+      "API_URL": "http://mock-mistral:8000",
       "SENSITIVE_DATA": null
     },
     "image": "ui:latest",

--- a/src/testdata/interpolate/compose.yaml
+++ b/src/testdata/interpolate/compose.yaml
@@ -11,3 +11,4 @@ services:
       - NOP_BRACED=abc$${def} # FIXME: this should not get resolved in CD
       - NODE_ENV=${NODE_ENV}
       - PORT=${PORT:-8080}
+      - VAR1=${VAR1} # from config

--- a/src/testdata/interpolate/compose.yaml.fixup
+++ b/src/testdata/interpolate/compose.yaml.fixup
@@ -10,6 +10,7 @@
       "NOP": "abc$def",
       "NOP_BRACED": "abc${def}",
       "PORT": "8080",
+      "VAR1": "${VAR1}",
       "interpolate": "value"
     },
     "image": "alpine",

--- a/src/testdata/interpolate/compose.yaml.golden
+++ b/src/testdata/interpolate/compose.yaml.golden
@@ -9,6 +9,7 @@ services:
       NOP: abc$def
       NOP_BRACED: abc${def}
       PORT: "8080"
+      VAR1: ${VAR1}
       interpolate: value
     image: alpine
     networks:

--- a/src/testdata/interpolate/compose.yaml.warnings
+++ b/src/testdata/interpolate/compose.yaml.warnings
@@ -1,4 +1,4 @@
- ! Environment variable "NODE_ENV" is not used; add it to `.env` if needed
- ! Environment variable "NODE_ENV" is not used; add it to `.env` or it may be resolved from config during deployment
+ ! Environment variable "NODE_ENV" is ignored; add it to `.env` if needed
+ ! Environment variable "NODE_ENV" is ignored; add it to `.env` or it may be resolved from config during deployment
  ! service "interpolate": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors
 missing configs ["NODE_ENV" "POSTGRES_PASSWORD" "def"] (https://docs.defang.io/docs/concepts/configuration)

--- a/src/testdata/models/compose.yaml.fixup
+++ b/src/testdata/models/compose.yaml.fixup
@@ -22,7 +22,7 @@
     "entrypoint": null,
     "environment": {
       "AI_MODEL_MODEL": "ai/model",
-      "AI_MODEL_URL": "http://ai-model/api/v1/"
+      "AI_MODEL_URL": "http://mock-ai-model/api/v1/"
     },
     "image": "app",
     "models": {
@@ -55,7 +55,7 @@
     "command": null,
     "entrypoint": null,
     "environment": {
-      "MODEL_URL": "http://my-model/api/v1/",
+      "MODEL_URL": "http://mock-my-model/api/v1/",
       "MY_MODEL_MODEL": "ai/model"
     },
     "image": "app",

--- a/src/testdata/mongo/compose.yaml.fixup
+++ b/src/testdata/mongo/compose.yaml.fixup
@@ -32,7 +32,7 @@
       "ME_CONFIG_BASICAUTH": "false",
       "ME_CONFIG_MONGODB_ADMINPASSWORD": "example!",
       "ME_CONFIG_MONGODB_ADMINUSERNAME": "root",
-      "ME_CONFIG_MONGODB_URL": "mongodb://root:example!@mongo:27017/"
+      "ME_CONFIG_MONGODB_URL": "mongodb://root:example!@mock-mongo:27017/"
     },
     "image": "mongo-express",
     "networks": {

--- a/src/testdata/provider/compose.yaml.fixup
+++ b/src/testdata/provider/compose.yaml.fixup
@@ -29,7 +29,7 @@
     "entrypoint": null,
     "environment": {
       "AI_RUNNER_MODEL": "ai/smollm2",
-      "AI_RUNNER_URL": "http://ai-runner/api/v1/"
+      "AI_RUNNER_URL": "http://mock-ai-runner/api/v1/"
     },
     "image": "my-chat-app",
     "networks": {

--- a/src/testdata/testproj/compose.yaml.fixup
+++ b/src/testdata/testproj/compose.yaml.fixup
@@ -4,7 +4,7 @@
       "context": ".",
       "dockerfile": "Dockerfile",
       "args": {
-        "DNS": "dfnx"
+        "DNS": "mock-dfnx"
       },
       "target": "testproj"
     },


### PR DESCRIPTION
## Description

Having a "eponymous" env var would trigger a warning:

```yaml
services:
  interpolate:
    image: blah
    environment:
      VAR1: ${VAR1}
```

```
 ! service "interpolate": environment variable(s) ["VAR1"] overridden by config
```
…which was what was intended all along, so this warning doesn't add anything.

In addition to that change, the code used a difference mock provider for validation (`.warnings` file) and fixup testing (`.fixup` file), which was confusing, so now using a single mock.

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

