### PR TITLE
fix for vscode mcp setup - location of settings changed with latest vcode

### DIFF
--- a/src/cmd/cli/command/commands.go
+++ b/src/cmd/cli/command/commands.go
@@ -22,6 +22,7 @@ import (
 	"github.com/DefangLabs/defang/src/pkg/cli/compose"
 	"github.com/DefangLabs/defang/src/pkg/clouds/aws"
 	"github.com/DefangLabs/defang/src/pkg/logs"
+	"github.com/DefangLabs/defang/src/pkg/mcp"
 	"github.com/DefangLabs/defang/src/pkg/scope"
 	"github.com/DefangLabs/defang/src/pkg/term"
 	"github.com/DefangLabs/defang/src/pkg/track"
@@ -294,7 +295,7 @@ func SetupCommands(ctx context.Context, version string) {
 	// MCP Command
 	mcpCmd.AddCommand(mcpSetupCmd)
 	mcpCmd.AddCommand(mcpServerCmd)
-	mcpSetupCmd.Flags().String("client", "", "MCP setup client (supports: claude, windsurf, cursor, vscode)")
+	mcpSetupCmd.Flags().String("client", "", fmt.Sprintf("MCP setup client %v", mcp.ValidClients))
 	mcpServerCmd.Flags().Int("auth-server", 0, "auth server port")
 	mcpSetupCmd.MarkFlagRequired("client")
 	RootCmd.AddCommand(mcpCmd)

--- a/src/cmd/cli/command/mcp.go
+++ b/src/cmd/cli/command/mcp.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/DefangLabs/defang/src/pkg/cli"
 	cliClient "github.com/DefangLabs/defang/src/pkg/cli/client"
@@ -110,8 +109,7 @@ var mcpSetupCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		term.Debug("Setting up MCP client")
 		client, _ := cmd.Flags().GetString("client")
-		client = strings.ToLower(client)
-		term.Debug("Client: ", client)
+		term.Debugf("MCP Client: %q", client)
 		if err := mcp.SetupClient(client); err != nil {
 			return err
 		}

--- a/src/pkg/mcp/setup.go
+++ b/src/pkg/mcp/setup.go
@@ -87,7 +87,7 @@ func ParseMCPClient(clientStr string) (MCPClient, error) {
 	clientStr = strings.ToLower(clientStr)
 	client := MCPClient(clientStr)
 	if !slices.Contains(ValidClients, client) {
-		return "", fmt.Errorf("invalid MCP client: %q. Valid MCP clients are: %v", client, ValidClients)
+		return "", fmt.Errorf("invalid MCP client: %q. Valid MCP clients are %v", clientStr, ValidClients)
 	}
 	return client, nil
 }
@@ -329,11 +329,10 @@ func handleStandardConfig(configPath string) error {
 	return nil
 }
 
-func SetupClient(clientValue string) error {
-	client, err := ParseMCPClient(clientValue)
+func SetupClient(clientStr string) error {
+	client, err := ParseMCPClient(clientStr)
 	if err != nil {
-		// cast the client string to MCPClient
-		return fmt.Errorf("invalid MCP client: %q. Valid MCP clients are: %v", client, ValidClients)
+		return err
 	}
 
 	track.Evt("MCP Setup Client: ", track.P("client", client))

--- a/src/pkg/mcp/setup.go
+++ b/src/pkg/mcp/setup.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -240,48 +241,26 @@ func handleVSCodeConfig(configPath string) error {
 			existingData = make(map[string]interface{})
 		}
 
-		// Check if mcp section exists
-		mcpData, ok := existingData["mcp"]
+		// Check if "servers" section exists
+		serversSection, ok := existingData["servers"]
 		if !ok {
-			// Create new mcp section
-			existingData["mcp"] = map[string]interface{}{
-				"servers": map[string]interface{}{
-					"defang": config,
-				},
-			}
+			// Create new "servers" section
+			existingData["servers"] = map[string]interface{}{}
+			serversSection = existingData["servers"]
+		}
+
+		// get
+		if mcpMap, ok := serversSection.(map[string]interface{}); ok {
+			mcpMap["defang"] = config
+			existingData["servers"] = mcpMap
 		} else {
-			// Update existing mcp section
-			mcpMap, ok := mcpData.(map[string]interface{})
-			if !ok {
-				mcpMap = make(map[string]interface{})
-			}
-
-			serversData, ok := mcpMap["servers"]
-			if !ok {
-				mcpMap["servers"] = map[string]interface{}{
-					"defang": config,
-				}
-			} else {
-				serversMap, ok := serversData.(map[string]interface{})
-				if !ok {
-					serversMap = make(map[string]interface{})
-				}
-
-				// Add or update the Defang MCP server config
-				serversMap["defang"] = config
-
-				mcpMap["servers"] = serversMap
-			}
-
-			existingData["mcp"] = mcpMap
+			return errors.New("failed to assert 'servers' section as map[string]interface{}")
 		}
 	} else {
 		// File doesn't exist, create a new config with minimal settings
 		existingData = map[string]interface{}{
-			"mcp": map[string]interface{}{
-				"servers": map[string]interface{}{
-					"defang": config,
-				},
+			"servers": map[string]interface{}{
+				"defang": config,
 			},
 		}
 	}

--- a/src/pkg/mcp/setup.go
+++ b/src/pkg/mcp/setup.go
@@ -249,7 +249,6 @@ func handleVSCodeConfig(configPath string) error {
 			serversSection = existingData["servers"]
 		}
 
-		// get
 		if mcpMap, ok := serversSection.(map[string]interface{}); ok {
 			mcpMap["defang"] = config
 			existingData["servers"] = mcpMap


### PR DESCRIPTION
## Description

The mcp.json used by vscode/insiders has changed format on how to declare servers. This fix address the change in format.

## Linked Issues

fixes #1317 

## Checklist

- [X] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

