### PR TITLE
Update vscode insider alias to match CLI name

### DIFF
--- a/src/pkg/mcp/setup.go
+++ b/src/pkg/mcp/setup.go
@@ -55,7 +55,7 @@ const (
 	MCPClientVSCode         MCPClient = "vscode"
 	MCPClientCode           MCPClient = "code"
 	MCPClientVSCodeInsiders MCPClient = "vscode-insiders"
-	MCPClientInsiders       MCPClient = "insiders"
+	MCPClientInsiders       MCPClient = "code-insiders"
 	MCPClientClaude         MCPClient = "claude"
 	MCPClientWindsurf       MCPClient = "windsurf"
 	MCPClientCascade        MCPClient = "cascade"


### PR DESCRIPTION
## Description

Changed `insiders` ---> `code-insiders` to match the terminal binary name.

<!-- Concise description of what this PR is tackling. -->

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

