### PR TITLE
Call debugger on composeUp errors

### DIFF
--- a/src/pkg/cli/client/byoc/baseclient.go
+++ b/src/pkg/cli/client/byoc/baseclient.go
@@ -207,7 +207,7 @@ func topologicalSort(nodes map[string]*Node) []*defangv1.ServiceInfo {
 // This function was based on update function from Fabric controller and slightly modified to work with BYOC
 func (b *ByocBaseClient) update(ctx context.Context, projectName, delegateDomain string, service composeTypes.ServiceConfig) (*defangv1.ServiceInfo, error) {
 	if err := compose.ValidateService(&service); err != nil {
-		return nil, fmt.Errorf("service %q: %w", service.Name, err)
+		return nil, err // caller prepends service name
 	}
 
 	pkg.Ensure(projectName != "", "ProjectName not set")
@@ -257,7 +257,7 @@ func (b *ByocBaseClient) update(ctx context.Context, projectName, delegateDomain
 
 	if siUpdater, ok := b.projectBackend.(ServiceInfoUpdater); ok {
 		if err := siUpdater.UpdateServiceInfo(ctx, si, projectName, delegateDomain, service); err != nil {
-			return nil, fmt.Errorf("service %q: %w", service.Name, err)
+			return nil, err // caller prepends service name
 		}
 	}
 

--- a/src/pkg/cli/compose/context_test.go
+++ b/src/pkg/cli/compose/context_test.go
@@ -222,7 +222,7 @@ func TestGetDockerIgnorePatterns(t *testing.T) {
 			dockerfile:        "Dockerfile",
 			ignoreFileName:    "",
 			ignoreFileContent: defaultDockerIgnore,
-			expectedFileName:  ".dockerignore",
+			expectedFileName:  "",
 		},
 		{
 			name:              "No dockerfile, but dockerignore exists",
@@ -236,7 +236,7 @@ func TestGetDockerIgnorePatterns(t *testing.T) {
 			dockerfile:        "",
 			ignoreFileName:    "",
 			ignoreFileContent: defaultDockerIgnore,
-			expectedFileName:  ".dockerignore",
+			expectedFileName:  "",
 		},
 	}
 

--- a/src/pkg/cli/debug.go
+++ b/src/pkg/cli/debug.go
@@ -25,8 +25,6 @@ import (
 const maxFiles = 20
 
 var (
-	ErrDebugSkipped = errors.New("debug skipped")
-
 	errFileLimitReached = errors.New("file limit reached")
 	patterns            = []string{"*.js", "*.ts", "*.py", "*.go", "requirements.txt", "package.json", "go.mod"} // TODO: add patterns for other languages
 )
@@ -86,7 +84,7 @@ func interactiveDebug(ctx context.Context, client client.FabricClient, debugConf
 		return err
 	} else if !aiDebug {
 		track.Evt("Debug Prompt Skipped", P("etag", debugConfig.Deployment), P("loadErr", clientErr))
-		return ErrDebugSkipped
+		return err
 	}
 
 	track.Evt("Debug Prompt Accepted", P("etag", debugConfig.Deployment), P("loadErr", clientErr))


### PR DESCRIPTION
## Description

Use AI debugger to handle common "compose up" errors (like IAM permissions). For example, when you get the AssumeRole error:

> =================
> Debugging Summary
> \=================
> The log shows an AWS IAM permission error when trying to access Route 53 DNS services. The application is attempting to assume an IAM role (dnsadmin-39a19c3) but lacks the necessary permissions to do so.
> -------------------
> Issue #1
> -------------------
> The error occurs because the service is trying to use a DNS role (arn:aws:iam::258338292852:role/dnsadmin-39a19c3) that it doesn’t have permission to assume. This is likely because either the role doesn’t exist or the service doesn’t have the correct permissions to assume it. If DNS configuration is not needed, you can remove the x-defang-dns-role configuration from the compose file.

## Linked Issues

Fixes https://github.com/DefangLabs/defang-mvp/issues/1630

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

