### PR TITLE
fix(cd): hide node warnings

### DIFF
--- a/src/pkg/cli/client/byoc/aws/byoc.go
+++ b/src/pkg/cli/client/byoc/aws/byoc.go
@@ -387,6 +387,7 @@ func (b *ByocAws) environment(projectName string) (map[string]string, error) {
 		"DEFANG_ORG":                 b.TenantName,
 		"DEFANG_PREFIX":              byoc.DefangPrefix,
 		"DEFANG_STATE_URL":           defangStateUrl,
+		"NODE_NO_WARNINGS":           "1",
 		"NPM_CONFIG_UPDATE_NOTIFIER": "false",
 		"PRIVATE_DOMAIN":             byoc.GetPrivateDomain(projectName),
 		"PROJECT":                    projectName,                 // may be empty

--- a/src/pkg/cli/client/byoc/do/byoc.go
+++ b/src/pkg/cli/client/byoc/do/byoc.go
@@ -677,6 +677,10 @@ func (b *ByocDo) environment(projectName, delegateDomain string) ([]*godo.AppVar
 			Value: b.PulumiStack,
 		},
 		{
+			Key:   "NODE_NO_WARNINGS",
+			Value: "1",
+		},
+		{
 			Key:   "NPM_CONFIG_UPDATE_NOTIFIER",
 			Value: "false",
 		},


### PR DESCRIPTION
## Description

This sets the NodeJS flag to hide warnings. See https://nodejs.org/api/cli.html#node_no_warnings1

## Linked Issues

fixes #1272

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

