### PR TITLE
Need .zip for GCP cloudbuild railpack

### DIFF
--- a/src/pkg/cli/compose/context.go
+++ b/src/pkg/cli/compose/context.go
@@ -226,6 +226,9 @@ func getRemoteBuildContext(ctx context.Context, provider client.Provider, projec
 
 func uploadArchive(ctx context.Context, provider client.Provider, project string, body io.Reader, contentType ArchiveType, digest string) (string, error) {
 	// Upload the archive to the fabric controller storage;; TODO: use a streaming API
+	if contentType == ArchiveTypeZip {
+		digest = digest + ".zip" // We need to add the .zip extension for GCP cloudbuild to be valid
+	}
 	ureq := &defangv1.UploadURLRequest{Digest: digest, Project: project}
 	res, err := provider.CreateUploadURL(ctx, ureq)
 	if err != nil {

--- a/src/pkg/cli/compose/context.go
+++ b/src/pkg/cli/compose/context.go
@@ -74,10 +74,17 @@ defang.exe
 .defang`
 )
 
-type ArchiveType string
+type ArchiveType struct {
+	MimeType  MimeType
+	Extension string
+}
 
-const ArchiveTypeZip ArchiveType = "application/zip"
-const ArchiveTypeGzip ArchiveType = "application/gzip"
+type MimeType string
+
+var (
+	ArchiveTypeZip  = ArchiveType{MimeType: "application/zip", Extension: ".zip"}
+	ArchiveTypeGzip = ArchiveType{MimeType: "application/gzip", Extension: ".tar.gz"}
+)
 
 type WriterFactory interface {
 	CreateHeader(info fs.FileInfo, slashPath string) (io.Writer, error)
@@ -226,8 +233,10 @@ func getRemoteBuildContext(ctx context.Context, provider client.Provider, projec
 
 func uploadArchive(ctx context.Context, provider client.Provider, project string, body io.Reader, contentType ArchiveType, digest string) (string, error) {
 	// Upload the archive to the fabric controller storage;; TODO: use a streaming API
-	if contentType == ArchiveTypeZip {
-		digest = digest + ".zip" // We need to add the .zip extension for GCP cloudbuild to be valid
+	if contentType.MimeType == ArchiveTypeZip.MimeType {
+		digest = digest + ArchiveTypeZip.Extension
+	} else {
+		digest = digest + ArchiveTypeGzip.Extension
 	}
 	ureq := &defangv1.UploadURLRequest{Digest: digest, Project: project}
 	res, err := provider.CreateUploadURL(ctx, ureq)
@@ -236,7 +245,7 @@ func uploadArchive(ctx context.Context, provider client.Provider, project string
 	}
 
 	// Do an HTTP PUT to the generated URL
-	resp, err := http.Put(ctx, res.Url, string(contentType), body)
+	resp, err := http.Put(ctx, res.Url, string(contentType.MimeType), body)
 	if err != nil {
 		return "", err
 	}

--- a/src/pkg/cli/compose/context_test.go
+++ b/src/pkg/cli/compose/context_test.go
@@ -49,41 +49,72 @@ func TestUploadArchive(t *testing.T) {
 		if !strings.HasPrefix(r.URL.Path, path) {
 			t.Errorf("Expected prefix %v, got %v", path, r.URL.Path)
 		}
-		if !(r.Header.Get("Content-Type") == string(ArchiveTypeGzip) || r.Header.Get("Content-Type") == string(ArchiveTypeZip)) {
+		if !(r.Header.Get("Content-Type") == string(ArchiveTypeGzip.MimeType) || r.Header.Get("Content-Type") == string(ArchiveTypeZip.MimeType)) {
 			t.Errorf("Expected Content-Type: application/gzip or application/zip, got %v", r.Header.Get("Content-Type"))
 		}
 		w.WriteHeader(200)
 	}))
 	defer server.Close()
 
-	t.Run("upload with digest", func(t *testing.T) {
+	t.Run("upload tar with digest", func(t *testing.T) {
 		url, err := uploadArchive(context.Background(), client.MockProvider{UploadUrl: server.URL + path}, "testproj", &bytes.Buffer{}, ArchiveTypeGzip, digest)
 		if err != nil {
 			t.Fatalf("uploadArchive() failed: %v", err)
 		}
-		const expectedPath = path + digest
+		var expectedPath = path + digest + ArchiveTypeGzip.Extension
 		if url != server.URL+expectedPath {
 			t.Errorf("Expected %v, got %v", server.URL+expectedPath, url)
 		}
-
-		t.Run("upload with zip", func(t *testing.T) {
-			url, err := uploadArchive(context.Background(), client.MockProvider{UploadUrl: server.URL + path}, "testproj", &bytes.Buffer{}, ArchiveTypeZip, "")
-			if err != nil {
-				t.Fatalf("uploadContent() failed: %v", err)
-			}
-			if url != server.URL+path {
-				t.Errorf("Expected %v, got %v", server.URL+path, url)
-			}
-		})
 	})
 
-	t.Run("force upload without digest", func(t *testing.T) {
+	t.Run("upload zip with digest", func(t *testing.T) {
+		url, err := uploadArchive(context.Background(), client.MockProvider{UploadUrl: server.URL + path}, "testproj", &bytes.Buffer{}, ArchiveTypeZip, digest)
+		if err != nil {
+			t.Fatalf("uploadArchive() failed: %v", err)
+		}
+		var expectedPath = path + digest + ArchiveTypeZip.Extension
+		if url != server.URL+expectedPath {
+			t.Errorf("Expected %v, got %v", server.URL+expectedPath, url)
+		}
+	})
+
+	t.Run("upload with zip", func(t *testing.T) {
+		url, err := uploadArchive(context.Background(), client.MockProvider{UploadUrl: server.URL + path}, "testproj", &bytes.Buffer{}, ArchiveTypeZip, "")
+		if err != nil {
+			t.Fatalf("uploadContent() failed: %v", err)
+		}
+		if url != server.URL+path+ArchiveTypeZip.Extension {
+			t.Errorf("Expected %v, got %v", server.URL+path+ArchiveTypeZip.Extension, url)
+		}
+	})
+
+	t.Run("upload with tar", func(t *testing.T) {
+		url, err := uploadArchive(context.Background(), client.MockProvider{UploadUrl: server.URL + path}, "testproj", &bytes.Buffer{}, ArchiveTypeGzip, "")
+		if err != nil {
+			t.Fatalf("uploadContent() failed: %v", err)
+		}
+		if url != server.URL+path+ArchiveTypeGzip.Extension {
+			t.Errorf("Expected %v, got %v", server.URL+path+ArchiveTypeGzip.Extension, url)
+		}
+	})
+
+	t.Run("force upload tar without digest", func(t *testing.T) {
 		url, err := uploadArchive(context.Background(), client.MockProvider{UploadUrl: server.URL + path}, "testproj", &bytes.Buffer{}, ArchiveTypeGzip, "")
 		if err != nil {
 			t.Fatalf("uploadArchive() failed: %v", err)
 		}
-		if url != server.URL+path {
-			t.Errorf("Expected %v, got %v", server.URL+path, url)
+		if url != server.URL+path+ArchiveTypeGzip.Extension {
+			t.Errorf("Expected %v, got %v", server.URL+path+ArchiveTypeGzip.Extension, url)
+		}
+	})
+
+	t.Run("force upload zip without digest", func(t *testing.T) {
+		url, err := uploadArchive(context.Background(), client.MockProvider{UploadUrl: server.URL + path}, "testproj", &bytes.Buffer{}, ArchiveTypeZip, "")
+		if err != nil {
+			t.Fatalf("uploadArchive() failed: %v", err)
+		}
+		if url != server.URL+path+ArchiveTypeZip.Extension {
+			t.Errorf("Expected %v, got %v", server.URL+path+ArchiveTypeZip.Extension, url)
 		}
 	})
 }


### PR DESCRIPTION
## Description

We added both .zip and tar.gz extension to the end of the archive URL. We need to support .zip extension because GCP cloudbuild would reject it.  

Going to do a manual test first.

<!-- Concise description of what this PR is tackling. -->

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

