### PR TITLE
always open IdP login screen

### DIFF
--- a/src/pkg/auth/auth.go
+++ b/src/pkg/auth/auth.go
@@ -176,9 +176,6 @@ func StartAuthCodeFlow(ctx context.Context, mcpFlow LoginFlow) (AuthCodeFlow, er
 	opts := []AuthorizeOption{
 		WithPkce(),
 	}
-	if !mcpFlow {
-		opts = append(opts, WithProvider("github"))
-	}
 	ar, err := openAuthClient.Authorize(redirectUri, CodeResponseType, opts...)
 	if err != nil {
 		return AuthCodeFlow{}, err


### PR DESCRIPTION
## Description

We are enabling GitLab support for user login. When authenticating, users will need to select which authenticator they used to create their Defang account.

## Linked Issues

addresses https://github.com/DefangLabs/defang-mvp/issues/651

## Checklist

- [X] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

