### PR TITLE
revert: use DEFANG_EDITOR instead of EDITOR

### DIFF
--- a/src/cmd/cli/command/commands.go
+++ b/src/cmd/cli/command/commands.go
@@ -514,7 +514,7 @@ var certGenerateCmd = &cobra.Command{
 
 func afterGenerate(ctx context.Context, result setup.SetupResult) {
 	term.Info("Code generated successfully in folder", result.Folder)
-	editor := pkg.Getenv("EDITOR", "code")
+	editor := pkg.Getenv("DEFANG_EDITOR", "code") // TODO: should we use EDITOR env var instead? But won't handle terminal editors like vim
 	cmdd := exec.Command(editor, result.Folder)
 	err := cmdd.Start()
 	if err != nil {


### PR DESCRIPTION
## Description

Running common editors like `vim` as a new process won't work, because they'd start in the background without TTY.

No doc change since README wasn't changed in #1354 https://github.com/DefangLabs/defang/blob/b402051980254b00d9f53f16eba8b04d917f0e13/README.md#L128 

## Linked Issues

Regression from #1354 

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

