### PR TITLE
Improve authentication flow when migrating from heroku

### DIFF
--- a/src/cmd/cli/command/commands.go
+++ b/src/cmd/cli/command/commands.go
@@ -20,6 +20,7 @@ import (
 	"github.com/DefangLabs/defang/src/pkg/cli/client/byoc/gcp"
 	"github.com/DefangLabs/defang/src/pkg/cli/compose"
 	"github.com/DefangLabs/defang/src/pkg/clouds/aws"
+	"github.com/DefangLabs/defang/src/pkg/dryrun"
 	"github.com/DefangLabs/defang/src/pkg/logs"
 	"github.com/DefangLabs/defang/src/pkg/mcp"
 	"github.com/DefangLabs/defang/src/pkg/migrate"
@@ -88,7 +89,7 @@ func Execute(ctx context.Context) error {
 			term.Error("Error:", prettyError(err))
 		}
 
-		if err == cli.ErrDryRun {
+		if err == dryrun.ErrDryRun {
 			return nil
 		}
 
@@ -176,7 +177,7 @@ func SetupCommands(ctx context.Context, version string) {
 	// RootCmd.Flag("provider").NoOptDefVal = "auto" NO this will break the "--provider aws"
 	RootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "verbose logging") // backwards compat: only used by tail
 	RootCmd.PersistentFlags().BoolVar(&doDebug, "debug", pkg.GetenvBool("DEFANG_DEBUG"), "debug logging for troubleshooting the CLI")
-	RootCmd.PersistentFlags().BoolVar(&cli.DoDryRun, "dry-run", false, "dry run (don't actually change anything)")
+	RootCmd.PersistentFlags().BoolVar(&dryrun.DoDryRun, "dry-run", false, "dry run (don't actually change anything)")
 	RootCmd.PersistentFlags().BoolVarP(&nonInteractive, "non-interactive", "T", !hasTty, "disable interactive prompts / no TTY")
 	RootCmd.PersistentFlags().StringP("project-name", "p", "", "project name")
 	RootCmd.PersistentFlags().StringP("cwd", "C", "", "change directory before running the command")

--- a/src/cmd/cli/command/commands.go
+++ b/src/cmd/cli/command/commands.go
@@ -20,6 +20,7 @@ import (
 	"github.com/DefangLabs/defang/src/pkg/cli/client/byoc/gcp"
 	"github.com/DefangLabs/defang/src/pkg/cli/compose"
 	"github.com/DefangLabs/defang/src/pkg/clouds/aws"
+	pcluster "github.com/DefangLabs/defang/src/pkg/cluster"
 	"github.com/DefangLabs/defang/src/pkg/dryrun"
 	"github.com/DefangLabs/defang/src/pkg/login"
 	"github.com/DefangLabs/defang/src/pkg/logs"
@@ -158,7 +159,7 @@ func SetupCommands(ctx context.Context, version string) {
 
 	RootCmd.Version = version
 	RootCmd.PersistentFlags().Var(&colorMode, "color", fmt.Sprintf(`colorize output; one of %v`, allColorModes))
-	RootCmd.PersistentFlags().StringVarP(&cluster, "cluster", "s", cli.DefangFabric, "Defang cluster to connect to")
+	RootCmd.PersistentFlags().StringVarP(&cluster, "cluster", "s", pcluster.DefangFabric, "Defang cluster to connect to")
 	RootCmd.PersistentFlags().MarkHidden("cluster")
 	RootCmd.PersistentFlags().StringVar(&org, "org", os.Getenv("DEFANG_ORG"), "override GitHub organization name (tenant)")
 	RootCmd.PersistentFlags().VarP(&providerID, "provider", "P", fmt.Sprintf(`bring-your-own-cloud provider; one of %v`, cliClient.AllProviders()))

--- a/src/cmd/cli/command/commands.go
+++ b/src/cmd/cli/command/commands.go
@@ -21,6 +21,7 @@ import (
 	"github.com/DefangLabs/defang/src/pkg/cli/compose"
 	"github.com/DefangLabs/defang/src/pkg/clouds/aws"
 	"github.com/DefangLabs/defang/src/pkg/dryrun"
+	"github.com/DefangLabs/defang/src/pkg/login"
 	"github.com/DefangLabs/defang/src/pkg/logs"
 	"github.com/DefangLabs/defang/src/pkg/mcp"
 	"github.com/DefangLabs/defang/src/pkg/migrate"
@@ -401,7 +402,7 @@ var RootCmd = &cobra.Command{
 				term.ResetWarnings() // clear any previous warnings so we don't show them again
 
 				defer func() { track.Cmd(nil, "Login", P("reason", err)) }()
-				if err = cli.InteractiveLogin(cmd.Context(), client, getCluster()); err != nil {
+				if err = login.InteractiveLogin(cmd.Context(), client, getCluster()); err != nil {
 					return err
 				}
 
@@ -420,7 +421,7 @@ var RootCmd = &cobra.Command{
 				term.Warn(prettyError(err))
 
 				defer func() { track.Cmd(nil, "Terms", P("reason", err)) }()
-				if err = cli.InteractiveAgreeToS(cmd.Context(), client); err != nil {
+				if err = login.InteractiveAgreeToS(cmd.Context(), client); err != nil {
 					return err // fatal
 				}
 			}
@@ -438,11 +439,11 @@ var loginCmd = &cobra.Command{
 		trainingOptOut, _ := cmd.Flags().GetBool("training-opt-out")
 
 		if nonInteractive {
-			if err := cli.NonInteractiveGitHubLogin(cmd.Context(), client, getCluster()); err != nil {
+			if err := login.NonInteractiveGitHubLogin(cmd.Context(), client, getCluster()); err != nil {
 				return err
 			}
 		} else {
-			err := cli.InteractiveLogin(cmd.Context(), client, getCluster())
+			err := login.InteractiveLogin(cmd.Context(), client, getCluster())
 			if err != nil {
 				return err
 			}
@@ -999,7 +1000,7 @@ var tosCmd = &cobra.Command{
 		agree, _ := cmd.Flags().GetBool("agree-tos")
 
 		if agree {
-			return cli.NonInteractiveAgreeToS(cmd.Context(), client)
+			return login.NonInteractiveAgreeToS(cmd.Context(), client)
 		}
 
 		if nonInteractive {
@@ -1007,7 +1008,7 @@ var tosCmd = &cobra.Command{
 			return nil
 		}
 
-		return cli.InteractiveAgreeToS(cmd.Context(), client)
+		return login.InteractiveAgreeToS(cmd.Context(), client)
 	},
 }
 

--- a/src/cmd/cli/command/commands.go
+++ b/src/cmd/cli/command/commands.go
@@ -391,44 +391,51 @@ var RootCmd = &cobra.Command{
 			return nil
 		}
 
-		if err = client.CheckLoginAndToS(cmd.Context()); err != nil {
-			if nonInteractive {
-				return err
-			}
-			// Login interactively now; only do this for authorization-related errors
-			if connect.CodeOf(err) == connect.CodeUnauthenticated {
-				term.Debug("Server error:", err)
-				term.Warn("Please log in to continue.")
-				term.ResetWarnings() // clear any previous warnings so we don't show them again
-
-				defer func() { track.Cmd(nil, "Login", P("reason", err)) }()
-				if err = login.InteractiveLogin(cmd.Context(), client, getCluster()); err != nil {
-					return err
-				}
-
-				// Reconnect with the new token
-				if client, err = cli.Connect(cmd.Context(), getCluster()); err != nil {
-					return err
-				}
-
-				if err = client.CheckLoginAndToS(cmd.Context()); err == nil { // recheck (new token = new user)
-					return nil // success
-				}
-			}
-
-			// Check if the user has agreed to the terms of service and show a prompt if needed
-			if connect.CodeOf(err) == connect.CodeFailedPrecondition {
-				term.Warn(prettyError(err))
-
-				defer func() { track.Cmd(nil, "Terms", P("reason", err)) }()
-				if err = login.InteractiveAgreeToS(cmd.Context(), client); err != nil {
-					return err // fatal
-				}
-			}
-		}
+		err = RequireLoginAndToS(cmd.Context())
 
 		return err
 	},
+}
+
+func RequireLoginAndToS(ctx context.Context) error {
+	var err error
+	if err = client.CheckLoginAndToS(ctx); err != nil {
+		if nonInteractive {
+			return err
+		}
+		// Login interactively now; only do this for authorization-related errors
+		if connect.CodeOf(err) == connect.CodeUnauthenticated {
+			term.Debug("Server error:", err)
+			term.Warn("Please log in to continue.")
+			term.ResetWarnings() // clear any previous warnings so we don't show them again
+
+			defer func() { track.Cmd(nil, "Login", P("reason", err)) }()
+			if err = login.InteractiveLogin(ctx, client, getCluster()); err != nil {
+				return err
+			}
+
+			// Reconnect with the new token
+			if client, err = cli.Connect(ctx, getCluster()); err != nil {
+				return err
+			}
+
+			if err = client.CheckLoginAndToS(ctx); err == nil { // recheck (new token = new user)
+				return nil // success
+			}
+		}
+
+		// Check if the user has agreed to the terms of service and show a prompt if needed
+		if connect.CodeOf(err) == connect.CodeFailedPrecondition {
+			term.Warn(prettyError(err))
+
+			defer func() { track.Cmd(nil, "Terms", P("reason", err)) }()
+			if err = login.InteractiveAgreeToS(ctx, client); err != nil {
+				return err // fatal
+			}
+		}
+	}
+
+	return err
 }
 
 var loginCmd = &cobra.Command{

--- a/src/cmd/cli/command/compose.go
+++ b/src/cmd/cli/command/compose.go
@@ -230,7 +230,7 @@ func handleComposeUpErr(ctx context.Context, err error, project *compose.Project
 
 	if strings.Contains(err.Error(), "maximum number of projects") {
 		if projectName, err2 := provider.RemoteProjectName(ctx); err2 == nil {
-			term.Error("Error:", prettyError(err))
+			term.Error("Error:", cliClient.PrettyError(err))
 			if _, err := cli.InteractiveComposeDown(ctx, provider, projectName); err != nil {
 				term.Debug("ComposeDown failed:", err)
 				printDefangHint("To deactivate a project, do:", "compose down --project-name "+projectName)
@@ -243,7 +243,7 @@ func handleComposeUpErr(ctx context.Context, err error, project *compose.Project
 		return err
 	}
 
-	term.Error("Error:", prettyError(err))
+	term.Error("Error:", cliClient.PrettyError(err))
 	track.Evt("Debug Prompted", P("composeErr", err))
 	return cli.InteractiveDebugForClientError(ctx, client, project, err)
 }
@@ -376,7 +376,7 @@ func makeComposeDownCmd() *cobra.Command {
 			if err != nil {
 				if connect.CodeOf(err) == connect.CodeNotFound {
 					// Show a warning (not an error) if the service was not found
-					term.Warn(prettyError(err))
+					term.Warn(cliClient.PrettyError(err))
 					return nil
 				}
 				return err

--- a/src/cmd/cli/command/compose.go
+++ b/src/cmd/cli/command/compose.go
@@ -17,6 +17,7 @@ import (
 	cliClient "github.com/DefangLabs/defang/src/pkg/cli/client"
 	"github.com/DefangLabs/defang/src/pkg/cli/client/byoc"
 	"github.com/DefangLabs/defang/src/pkg/cli/compose"
+	"github.com/DefangLabs/defang/src/pkg/dryrun"
 	"github.com/DefangLabs/defang/src/pkg/logs"
 	"github.com/DefangLabs/defang/src/pkg/term"
 	"github.com/DefangLabs/defang/src/pkg/track"
@@ -464,7 +465,7 @@ func makeComposeConfigCmd() *cobra.Command {
 			}
 
 			_, _, err = cli.ComposeUp(ctx, project, client, provider, compose.UploadModeIgnore, defangv1.DeploymentMode_MODE_UNSPECIFIED)
-			if !errors.Is(err, cli.ErrDryRun) {
+			if !errors.Is(err, dryrun.ErrDryRun) {
 				return err
 			}
 			return nil

--- a/src/cmd/cli/command/deploymentinfo.go
+++ b/src/cmd/cli/command/deploymentinfo.go
@@ -4,8 +4,8 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/DefangLabs/defang/src/pkg/cli"
 	cliClient "github.com/DefangLabs/defang/src/pkg/cli/client"
+	pcluster "github.com/DefangLabs/defang/src/pkg/cluster"
 	"github.com/DefangLabs/defang/src/pkg/term"
 	defangv1 "github.com/DefangLabs/defang/src/protos/io/defang/v1"
 )
@@ -15,7 +15,7 @@ const SERVICE_PORTAL_URL = "https://" + DEFANG_PORTAL_HOST + "/service"
 
 func printPlaygroundPortalServiceURLs(serviceInfos []*defangv1.ServiceInfo) {
 	// We can only show services deployed to the prod1 defang SaaS environment.
-	if providerID == cliClient.ProviderDefang && cluster == cli.DefaultCluster {
+	if providerID == cliClient.ProviderDefang && cluster == pcluster.DefaultCluster {
 		term.Info("Monitor your services' status in the defang portal")
 		for _, serviceInfo := range serviceInfos {
 			term.Println("   -", SERVICE_PORTAL_URL+"/"+serviceInfo.Service.Name)

--- a/src/cmd/cli/command/deploymentinfo_test.go
+++ b/src/cmd/cli/command/deploymentinfo_test.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/DefangLabs/defang/src/pkg/cli"
 	cliClient "github.com/DefangLabs/defang/src/pkg/cli/client"
+	pcluster "github.com/DefangLabs/defang/src/pkg/cluster"
 	"github.com/DefangLabs/defang/src/pkg/term"
 	defangv1 "github.com/DefangLabs/defang/src/protos/io/defang/v1"
 )
@@ -22,7 +22,7 @@ func TestPrintPlaygroundPortalServiceURLs(t *testing.T) {
 	term.DefaultTerm = term.NewTerm(os.Stdin, &stdout, &stderr)
 
 	providerID = cliClient.ProviderDefang
-	cluster = cli.DefaultCluster
+	cluster = pcluster.DefaultCluster
 	printPlaygroundPortalServiceURLs([]*defangv1.ServiceInfo{
 		{
 			Service: &defangv1.Service{Name: "service1"},

--- a/src/cmd/cli/command/mcp.go
+++ b/src/cmd/cli/command/mcp.go
@@ -5,8 +5,8 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/DefangLabs/defang/src/pkg/cli"
 	cliClient "github.com/DefangLabs/defang/src/pkg/cli/client"
+	"github.com/DefangLabs/defang/src/pkg/login"
 	"github.com/DefangLabs/defang/src/pkg/mcp"
 	"github.com/DefangLabs/defang/src/pkg/mcp/resources"
 	"github.com/DefangLabs/defang/src/pkg/mcp/tools"
@@ -84,7 +84,7 @@ set_config - This tool sets or updates configuration variables for a deployed ap
 			term.Debug("Function invoked: cli.InteractiveLoginInsideDocker")
 
 			go func() {
-				if err := cli.InteractiveLoginInsideDocker(cmd.Context(), getCluster(), authPort); err != nil {
+				if err := login.InteractiveLoginInsideDocker(cmd.Context(), getCluster(), authPort); err != nil {
 					term.Error("Failed to start auth server", "error", err)
 				}
 			}()

--- a/src/pkg/cli/agree_tos.go
+++ b/src/pkg/cli/agree_tos.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/DefangLabs/defang/src/pkg/cli/client"
+	"github.com/DefangLabs/defang/src/pkg/dryrun"
 	"github.com/DefangLabs/defang/src/pkg/term"
 	"github.com/DefangLabs/defang/src/pkg/track"
 )
@@ -41,8 +42,8 @@ func InteractiveAgreeToS(ctx context.Context, c client.FabricClient) error {
 }
 
 func NonInteractiveAgreeToS(ctx context.Context, c client.FabricClient) error {
-	if DoDryRun {
-		return ErrDryRun
+	if dryrun.DoDryRun {
+		return dryrun.ErrDryRun
 	}
 
 	// Persist the terms agreement in the state file so that we don't ask again

--- a/src/pkg/cli/bootstrap.go
+++ b/src/pkg/cli/bootstrap.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/DefangLabs/defang/src/pkg"
 	"github.com/DefangLabs/defang/src/pkg/cli/client"
+	"github.com/DefangLabs/defang/src/pkg/dryrun"
 	"github.com/DefangLabs/defang/src/pkg/logs"
 	"github.com/DefangLabs/defang/src/pkg/term"
 )
@@ -19,8 +20,8 @@ func BootstrapCommand(ctx context.Context, projectName string, verbose bool, pro
 	} else {
 		term.Infof("Running CD command %q in project %q", cmd, projectName)
 	}
-	if DoDryRun {
-		return ErrDryRun
+	if dryrun.DoDryRun {
+		return dryrun.ErrDryRun
 	}
 
 	since := time.Now()
@@ -67,8 +68,8 @@ func SplitProjectStack(name string) (projectName string, stackName string) {
 
 func BootstrapLocalList(ctx context.Context, provider client.Provider) error {
 	term.Debug("Running CD list")
-	if DoDryRun {
-		return ErrDryRun
+	if dryrun.DoDryRun {
+		return dryrun.ErrDryRun
 	}
 
 	stacks, err := provider.BootstrapList(ctx)

--- a/src/pkg/cli/client/pretty_error.go
+++ b/src/pkg/cli/client/pretty_error.go
@@ -1,0 +1,41 @@
+package client
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/DefangLabs/defang/src/pkg/term"
+	"github.com/bufbuild/connect-go"
+)
+
+func PrettyError(err error) error {
+	// To avoid printing the internal gRPC error code
+	var cerr *connect.Error
+	if errors.As(err, &cerr) {
+		term.Debug("Server error:", cerr)
+		err = errors.Unwrap(cerr)
+	}
+	if IsNetworkError(err) {
+		return fmt.Errorf("%w; please check network settings and try again", err)
+	}
+	return err
+}
+
+func IsNetworkError(err error) bool {
+	if err == nil {
+		return false
+	}
+	errStr := err.Error()
+	lastColon := strings.LastIndexByte(errStr, ':')
+	switch errStr[lastColon+1:] { // +1 to skip the colon and handle the case where there is no colon
+	case " connection refused",
+		" i/o timeout",
+		" network is unreachable",
+		" no such host",
+		" unexpected EOF",
+		" device or resource busy":
+		return true
+	}
+	return false
+}

--- a/src/pkg/cli/common.go
+++ b/src/pkg/cli/common.go
@@ -2,18 +2,11 @@ package cli
 
 import (
 	"encoding/json"
-	"errors"
 
 	"github.com/DefangLabs/defang/src/pkg/term"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 	"gopkg.in/yaml.v3"
-)
-
-var (
-	DoDryRun = false
-
-	ErrDryRun = errors.New("dry run")
 )
 
 func MarshalPretty(root string, data proto.Message) ([]byte, error) {

--- a/src/pkg/cli/composeDown.go
+++ b/src/pkg/cli/composeDown.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/DefangLabs/defang/src/pkg/cli/client"
+	"github.com/DefangLabs/defang/src/pkg/dryrun"
 	"github.com/DefangLabs/defang/src/pkg/term"
 	"github.com/DefangLabs/defang/src/pkg/track"
 	"github.com/DefangLabs/defang/src/pkg/types"
@@ -17,8 +18,8 @@ import (
 func ComposeDown(ctx context.Context, projectName string, c client.FabricClient, provider client.Provider, names ...string) (types.ETag, error) {
 	term.Debugf("Destroying project %q %q", projectName, names)
 
-	if DoDryRun {
-		return "", ErrDryRun
+	if dryrun.DoDryRun {
+		return "", dryrun.ErrDryRun
 	}
 
 	if len(names) == 0 {

--- a/src/pkg/cli/composeUp.go
+++ b/src/pkg/cli/composeUp.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/DefangLabs/defang/src/pkg/cli/client"
 	"github.com/DefangLabs/defang/src/pkg/cli/compose"
+	"github.com/DefangLabs/defang/src/pkg/dryrun"
 	"github.com/DefangLabs/defang/src/pkg/term"
 	defangv1 "github.com/DefangLabs/defang/src/protos/io/defang/v1"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -23,7 +24,7 @@ func (e ComposeError) Unwrap() error {
 
 // ComposeUp validates a compose project and uploads the services using the client
 func ComposeUp(ctx context.Context, project *compose.Project, fabric client.FabricClient, p client.Provider, upload compose.UploadMode, mode defangv1.DeploymentMode) (*defangv1.DeployResponse, *compose.Project, error) {
-	if DoDryRun {
+	if dryrun.DoDryRun {
 		upload = compose.UploadModeIgnore
 	}
 
@@ -66,7 +67,7 @@ func ComposeUp(ctx context.Context, project *compose.Project, fabric client.Fabr
 
 	if upload == compose.UploadModeIgnore {
 		fmt.Println(string(bytes))
-		return nil, project, ErrDryRun
+		return nil, project, dryrun.ErrDryRun
 	}
 
 	delegateDomain, err := fabric.GetDelegateSubdomainZone(ctx, &defangv1.GetDelegateSubdomainZoneRequest{Project: project.Name})

--- a/src/pkg/cli/configDelete.go
+++ b/src/pkg/cli/configDelete.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/DefangLabs/defang/src/pkg/cli/client"
+	"github.com/DefangLabs/defang/src/pkg/dryrun"
 	"github.com/DefangLabs/defang/src/pkg/term"
 	defangv1 "github.com/DefangLabs/defang/src/protos/io/defang/v1"
 )
@@ -11,8 +12,8 @@ import (
 func ConfigDelete(ctx context.Context, projectName string, provider client.Provider, names ...string) error {
 	term.Debugf("Deleting config %v in project %q", names, projectName)
 
-	if DoDryRun {
-		return ErrDryRun
+	if dryrun.DoDryRun {
+		return dryrun.ErrDryRun
 	}
 
 	return provider.DeleteConfig(ctx, &defangv1.Secrets{Names: names, Project: projectName})

--- a/src/pkg/cli/configDelete_test.go
+++ b/src/pkg/cli/configDelete_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/DefangLabs/defang/src/pkg/cli/client"
+	"github.com/DefangLabs/defang/src/pkg/dryrun"
 	defangv1 "github.com/DefangLabs/defang/src/protos/io/defang/v1"
 )
 
@@ -19,11 +20,11 @@ func TestConfigDelete(t *testing.T) {
 	})
 
 	t.Run("expect error on DryRun", func(t *testing.T) {
-		DoDryRun = true
-		t.Cleanup(func() { DoDryRun = false })
+		dryrun.DoDryRun = true
+		t.Cleanup(func() { dryrun.DoDryRun = false })
 
-		if err := ConfigDelete(ctx, "test", provider, "test_name"); err != ErrDryRun {
-			t.Fatalf("Expected ErrDryRun, got %v", err)
+		if err := ConfigDelete(ctx, "test", provider, "test_name"); err != dryrun.ErrDryRun {
+			t.Fatalf("Expected dryrun.ErrDryRun, got %v", err)
 		}
 	})
 }

--- a/src/pkg/cli/configSet.go
+++ b/src/pkg/cli/configSet.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/DefangLabs/defang/src/pkg/cli/client"
+	"github.com/DefangLabs/defang/src/pkg/dryrun"
 	"github.com/DefangLabs/defang/src/pkg/term"
 	defangv1 "github.com/DefangLabs/defang/src/protos/io/defang/v1"
 )
@@ -11,8 +12,8 @@ import (
 func ConfigSet(ctx context.Context, projectName string, provider client.Provider, name string, value string) error {
 	term.Debugf("Setting config %q in project %q", name, projectName)
 
-	if DoDryRun {
-		return ErrDryRun
+	if dryrun.DoDryRun {
+		return dryrun.ErrDryRun
 	}
 
 	return provider.PutConfig(ctx, &defangv1.PutConfigRequest{Project: projectName, Name: name, Value: value})

--- a/src/pkg/cli/configSet_test.go
+++ b/src/pkg/cli/configSet_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/DefangLabs/defang/src/pkg/cli/client"
+	"github.com/DefangLabs/defang/src/pkg/dryrun"
 	defangv1 "github.com/DefangLabs/defang/src/protos/io/defang/v1"
 )
 
@@ -21,11 +22,11 @@ func TestConfigSet(t *testing.T) {
 	})
 
 	t.Run("expect error on DryRun", func(t *testing.T) {
-		DoDryRun = true
-		t.Cleanup(func() { DoDryRun = false })
+		dryrun.DoDryRun = true
+		t.Cleanup(func() { dryrun.DoDryRun = false })
 		err := ConfigSet(ctx, "test", provider, "test_name", "test_value")
-		if err != ErrDryRun {
-			t.Fatalf("Expected ErrDryRun, got %v", err)
+		if err != dryrun.ErrDryRun {
+			t.Fatalf("Expected dryrun.ErrDryRun, got %v", err)
 		}
 	})
 }

--- a/src/pkg/cli/connect.go
+++ b/src/pkg/cli/connect.go
@@ -7,19 +7,15 @@ import (
 	"github.com/DefangLabs/defang/src/pkg/cli/client/byoc/aws"
 	"github.com/DefangLabs/defang/src/pkg/cli/client/byoc/do"
 	"github.com/DefangLabs/defang/src/pkg/cli/client/byoc/gcp"
-	"github.com/DefangLabs/defang/src/pkg/login"
+	"github.com/DefangLabs/defang/src/pkg/cluster"
 	"github.com/DefangLabs/defang/src/pkg/term"
 	"github.com/DefangLabs/defang/src/pkg/track"
 	"github.com/DefangLabs/defang/src/pkg/types"
 )
 
-const DefaultCluster = login.DefaultCluster
-
-var DefangFabric = login.DefangFabric
-
-func Connect(ctx context.Context, cluster string) (*client.GrpcClient, error) {
-	tenantName, host := login.SplitTenantHost(cluster)
-	accessToken := login.GetExistingToken(cluster)
+func Connect(ctx context.Context, addr string) (*client.GrpcClient, error) {
+	tenantName, host := cluster.SplitTenantHost(addr)
+	accessToken := cluster.GetExistingToken(addr)
 	term.Debug("Using tenant", tenantName, "for cluster", host)
 	grpcClient := client.NewGrpcClient(host, accessToken, tenantName)
 	track.Tracker = grpcClient // Update track client

--- a/src/pkg/cli/connect.go
+++ b/src/pkg/cli/connect.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"context"
-	"strings"
 
 	"github.com/DefangLabs/defang/src/pkg/cli/client"
 	"github.com/DefangLabs/defang/src/pkg/cli/client/byoc/aws"
@@ -35,24 +34,6 @@ func Connect(ctx context.Context, cluster string) (*client.GrpcClient, error) {
 		grpcClient.TenantName = types.TenantName(resp.Tenant)
 	}
 	return grpcClient, err
-}
-
-func IsNetworkError(err error) bool {
-	if err == nil {
-		return false
-	}
-	errStr := err.Error()
-	lastColon := strings.LastIndexByte(errStr, ':')
-	switch errStr[lastColon+1:] { // +1 to skip the colon and handle the case where there is no colon
-	case " connection refused",
-		" i/o timeout",
-		" network is unreachable",
-		" no such host",
-		" unexpected EOF",
-		" device or resource busy":
-		return true
-	}
-	return false
 }
 
 func NewProvider(ctx context.Context, providerID client.ProviderID, fabricClient client.FabricClient) (client.Provider, error) {

--- a/src/pkg/cli/connect_test.go
+++ b/src/pkg/cli/connect_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/DefangLabs/defang/src/pkg/auth"
+	"github.com/DefangLabs/defang/src/pkg/cli/client"
 	defangv1 "github.com/DefangLabs/defang/src/protos/io/defang/v1"
 	"github.com/DefangLabs/defang/src/protos/io/defang/v1/defangv1connect"
 	"github.com/bufbuild/connect-go"
@@ -25,7 +26,7 @@ func TestConnect(t *testing.T) {
 		if expected, actual := "unavailable: dial tcp 1.2.3.4:443: connect: network is unreachable", err.Error(); expected != actual {
 			t.Errorf("expected %v, got: %v", expected, actual)
 		}
-		if !IsNetworkError(err) {
+		if !client.IsNetworkError(err) {
 			t.Errorf("expected network error, got: %v", err)
 		}
 	})
@@ -40,7 +41,7 @@ func TestConnect(t *testing.T) {
 		if expected, actual := `deadline_exceeded: Post "https://240.0.0.1:443/io.defang.v1.FabricController/WhoAmI": dial tcp 240.0.0.1:443: i/o timeout`, err.Error(); expected != actual {
 			t.Errorf("expected %v, got: %v", expected, actual)
 		}
-		if !IsNetworkError(err) {
+		if !client.IsNetworkError(err) {
 			t.Errorf("expected network error, got: %v", err)
 		}
 	})
@@ -51,7 +52,7 @@ func TestConnect(t *testing.T) {
 		if expected, actual := "unavailable: dial tcp 127.0.0.1:1234: connect: connection refused", err.Error(); expected != actual {
 			t.Errorf("expected %v, got: %v", expected, actual)
 		}
-		if !IsNetworkError(err) {
+		if !client.IsNetworkError(err) {
 			t.Errorf("expected network error, got: %v", err)
 		}
 	})
@@ -63,7 +64,7 @@ func TestConnect(t *testing.T) {
 		if actual := err.Error(); !slices.ContainsFunc(suffixes, func(suffix string) bool { return strings.HasSuffix(actual, suffix) }) {
 			t.Errorf("expected error to end with %q, got: %v", suffixes, actual)
 		}
-		if !IsNetworkError(err) {
+		if !client.IsNetworkError(err) {
 			t.Errorf("expected network error, got: %v", err)
 		}
 	})
@@ -77,7 +78,7 @@ func TestConnect(t *testing.T) {
 		if expected, actual := "internal: protocol error: no Grpc-Status trailer: unexpected EOF", err.Error(); expected != actual {
 			t.Errorf("expected %v, got: %v", expected, actual)
 		}
-		if !IsNetworkError(err) {
+		if !client.IsNetworkError(err) {
 			t.Errorf("expected network error, got: %v", err)
 		}
 	})

--- a/src/pkg/cli/debug.go
+++ b/src/pkg/cli/debug.go
@@ -13,6 +13,7 @@ import (
 	"github.com/DefangLabs/defang/src/pkg"
 	"github.com/DefangLabs/defang/src/pkg/cli/client"
 	"github.com/DefangLabs/defang/src/pkg/cli/compose"
+	"github.com/DefangLabs/defang/src/pkg/dryrun"
 	"github.com/DefangLabs/defang/src/pkg/term"
 	"github.com/DefangLabs/defang/src/pkg/track"
 	"github.com/DefangLabs/defang/src/pkg/types"
@@ -120,8 +121,8 @@ func DebugDeployment(ctx context.Context, client client.FabricClient, debugConfi
 
 	files := findMatchingProjectFiles(debugConfig.Project, debugConfig.FailedServices)
 
-	if DoDryRun {
-		return ErrDryRun
+	if dryrun.DoDryRun {
+		return dryrun.ErrDryRun
 	}
 
 	var sinceTs, untilTs *timestamppb.Timestamp
@@ -160,8 +161,8 @@ func debugComposeFileLoadError(ctx context.Context, client client.FabricClient, 
 
 	files := findMatchingProjectFiles(project, nil)
 
-	if DoDryRun {
-		return ErrDryRun
+	if dryrun.DoDryRun {
+		return dryrun.ErrDryRun
 	}
 
 	req := defangv1.DebugRequest{

--- a/src/pkg/cli/delete.go
+++ b/src/pkg/cli/delete.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 
 	"github.com/DefangLabs/defang/src/pkg/cli/client"
+	"github.com/DefangLabs/defang/src/pkg/dryrun"
 	"github.com/DefangLabs/defang/src/pkg/term"
 	"github.com/DefangLabs/defang/src/pkg/types"
 	defangv1 "github.com/DefangLabs/defang/src/protos/io/defang/v1"
@@ -13,8 +14,8 @@ import (
 func Delete(ctx context.Context, projectName string, c client.FabricClient, provider client.Provider, names ...string) (types.ETag, error) {
 	term.Debug("Deleting service", names)
 
-	if DoDryRun {
-		return "", ErrDryRun
+	if dryrun.DoDryRun {
+		return "", dryrun.ErrDryRun
 	}
 
 	delegateDomain, err := c.GetDelegateSubdomainZone(ctx, &defangv1.GetDelegateSubdomainZoneRequest{}) // TODO: pass projectName

--- a/src/pkg/cli/generate.go
+++ b/src/pkg/cli/generate.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 
 	"github.com/DefangLabs/defang/src/pkg/cli/client"
+	"github.com/DefangLabs/defang/src/pkg/dryrun"
 	"github.com/DefangLabs/defang/src/pkg/term"
 	defangv1 "github.com/DefangLabs/defang/src/protos/io/defang/v1"
 )
@@ -21,9 +22,9 @@ type GenerateArgs struct {
 }
 
 func GenerateWithAI(ctx context.Context, client client.FabricClient, args GenerateArgs) ([]string, error) {
-	if DoDryRun {
+	if dryrun.DoDryRun {
 		term.Warn("Dry run, no project files will be generated")
-		return nil, ErrDryRun
+		return nil, dryrun.ErrDryRun
 	}
 
 	response, err := client.GenerateFiles(ctx, &defangv1.GenerateFilesRequest{

--- a/src/pkg/cli/sendMsg.go
+++ b/src/pkg/cli/sendMsg.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 
 	"github.com/DefangLabs/defang/src/pkg/cli/client"
+	"github.com/DefangLabs/defang/src/pkg/dryrun"
 	"github.com/DefangLabs/defang/src/pkg/term"
 	defangv1 "github.com/DefangLabs/defang/src/protos/io/defang/v1"
 	"github.com/google/uuid"
@@ -23,8 +24,8 @@ func SendMsg(ctx context.Context, client client.FabricClient, subject, _type, id
 
 	term.Debug("Sending message to", subject, "with type", _type, "and id", id)
 
-	if DoDryRun {
-		return ErrDryRun
+	if dryrun.DoDryRun {
+		return dryrun.ErrDryRun
 	}
 
 	err := client.Publish(ctx, &defangv1.PublishRequest{Event: &defangv1.Event{

--- a/src/pkg/cli/tail.go
+++ b/src/pkg/cli/tail.go
@@ -156,7 +156,7 @@ func Tail(ctx context.Context, provider client.Provider, projectName string, opt
 				case connect.CodeUnknown:
 					// Ignore unknown (nil) errors
 				default:
-					term.Warn(err) // TODO: use prettyError(…)
+					term.Warn(err) // TODO: use cliClient.PrettyError(…)
 				}
 			}
 		}

--- a/src/pkg/cli/tail.go
+++ b/src/pkg/cli/tail.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/DefangLabs/defang/src/pkg"
 	"github.com/DefangLabs/defang/src/pkg/cli/client"
+	"github.com/DefangLabs/defang/src/pkg/dryrun"
 	"github.com/DefangLabs/defang/src/pkg/logs"
 	"github.com/DefangLabs/defang/src/pkg/spinner"
 	"github.com/DefangLabs/defang/src/pkg/term"
@@ -161,8 +162,8 @@ func Tail(ctx context.Context, provider client.Provider, projectName string, opt
 		}
 	}
 
-	if DoDryRun {
-		return ErrDryRun
+	if dryrun.DoDryRun {
+		return dryrun.ErrDryRun
 	}
 
 	return streamLogs(ctx, provider, projectName, options, logEntryPrintHandler)

--- a/src/pkg/cli/teardown.go
+++ b/src/pkg/cli/teardown.go
@@ -6,11 +6,12 @@ import (
 	"fmt"
 
 	"github.com/DefangLabs/defang/src/pkg/cli/client"
+	"github.com/DefangLabs/defang/src/pkg/dryrun"
 	"github.com/DefangLabs/defang/src/pkg/term"
 )
 
 func TearDown(ctx context.Context, provider client.Provider, force bool) error {
-	if DoDryRun {
+	if dryrun.DoDryRun {
 		return errors.New("dry run")
 	}
 	if !force {

--- a/src/pkg/cli/token.go
+++ b/src/pkg/cli/token.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/DefangLabs/defang/src/pkg/auth"
 	"github.com/DefangLabs/defang/src/pkg/cli/client"
+	"github.com/DefangLabs/defang/src/pkg/dryrun"
 	"github.com/DefangLabs/defang/src/pkg/scope"
 	"github.com/DefangLabs/defang/src/pkg/term"
 	"github.com/DefangLabs/defang/src/pkg/types"
@@ -13,8 +14,8 @@ import (
 )
 
 func Token(ctx context.Context, client client.FabricClient, tenant types.TenantName, dur time.Duration, s scope.Scope) error {
-	if DoDryRun {
-		return ErrDryRun
+	if dryrun.DoDryRun {
+		return dryrun.ErrDryRun
 	}
 
 	code, err := auth.StartAuthCodeFlow(ctx, true)

--- a/src/pkg/cluster/cluster.go
+++ b/src/pkg/cluster/cluster.go
@@ -1,0 +1,66 @@
+package cluster
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/DefangLabs/defang/src/pkg"
+	"github.com/DefangLabs/defang/src/pkg/cli/client"
+	"github.com/DefangLabs/defang/src/pkg/term"
+	"github.com/DefangLabs/defang/src/pkg/types"
+)
+
+const DefaultCluster = "fabric-prod1.defang.dev"
+
+var DefangFabric = pkg.Getenv("DEFANG_FABRIC", DefaultCluster)
+
+func SplitTenantHost(cluster string) (types.TenantName, string) {
+	tenant := types.DEFAULT_TENANT
+	parts := strings.SplitN(cluster, "@", 2)
+	if len(parts) == 2 {
+		tenant, cluster = types.TenantName(parts[0]), parts[1]
+	}
+	if cluster == "" {
+		cluster = DefangFabric
+	}
+	if _, _, err := net.SplitHostPort(cluster); err != nil {
+		cluster = cluster + ":443" // default to https
+	}
+	return tenant, cluster
+}
+
+func GetTokenFile(fabric string) string {
+	if host, _, _ := net.SplitHostPort(fabric); host != "" {
+		fabric = host
+	}
+	return filepath.Join(client.StateDir, fabric)
+}
+
+func GetExistingToken(fabric string) string {
+	var accessToken = os.Getenv("DEFANG_ACCESS_TOKEN")
+
+	if accessToken == "" {
+		tokenFile := GetTokenFile(fabric)
+
+		term.Debug("Reading access token from file", tokenFile)
+		all, _ := os.ReadFile(tokenFile)
+		accessToken = string(all)
+	} else {
+		term.Debug("Using access token from env DEFANG_ACCESS_TOKEN")
+	}
+
+	return accessToken
+}
+
+func SaveAccessToken(fabric, token string) error {
+	tokenFile := GetTokenFile(fabric)
+	term.Debug("Saving access token to", tokenFile)
+	os.MkdirAll(client.StateDir, 0700)
+	if err := os.WriteFile(tokenFile, []byte(token), 0600); err != nil {
+		return fmt.Errorf("failed to save access token: %w", err)
+	}
+	return nil
+}

--- a/src/pkg/cluster/cluster_test.go
+++ b/src/pkg/cluster/cluster_test.go
@@ -1,0 +1,39 @@
+package cluster
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetExistingToken(t *testing.T) {
+	fabric := "test.defang.dev"
+	os.Unsetenv("DEFANG_ACCESS_TOKEN")
+
+	t.Run("Get access token from environmental variable", func(t *testing.T) {
+		expectedToken := "env-token"
+		t.Setenv("DEFANG_ACCESS_TOKEN", expectedToken)
+
+		accessToken := GetExistingToken(fabric)
+		if accessToken != expectedToken {
+			t.Errorf("expected %s, got %s", expectedToken, accessToken)
+		}
+	})
+
+	t.Run("Get access token from file", func(t *testing.T) {
+		expectedToken := "file-token"
+		tokenFile := GetTokenFile(fabric)
+		err := os.WriteFile(tokenFile, []byte(expectedToken), 0600)
+		assert.NoError(t, err)
+
+		t.Cleanup(func() {
+			os.Remove(tokenFile)
+		})
+
+		accessToken := GetExistingToken(fabric)
+		if accessToken != expectedToken {
+			t.Errorf("expected %s, got %s", expectedToken, accessToken)
+		}
+	})
+}

--- a/src/pkg/dryrun/dryrun.go
+++ b/src/pkg/dryrun/dryrun.go
@@ -1,0 +1,9 @@
+package dryrun
+
+import "errors"
+
+var (
+	DoDryRun = false
+
+	ErrDryRun = errors.New("dry run")
+)

--- a/src/pkg/login/agree_tos.go
+++ b/src/pkg/login/agree_tos.go
@@ -1,4 +1,4 @@
-package cli
+package login
 
 import (
 	"context"
@@ -12,6 +12,8 @@ import (
 )
 
 var ErrTermsNotAgreed = errors.New("you must agree to the Defang terms of service to use this tool")
+
+var P = track.P
 
 func InteractiveAgreeToS(ctx context.Context, c client.FabricClient) error {
 	if client.TermsAccepted() {

--- a/src/pkg/login/login.go
+++ b/src/pkg/login/login.go
@@ -4,62 +4,16 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net"
 	"os"
-	"path/filepath"
-	"strings"
 
-	"github.com/DefangLabs/defang/src/pkg"
 	"github.com/DefangLabs/defang/src/pkg/auth"
 	"github.com/DefangLabs/defang/src/pkg/cli/client"
+	"github.com/DefangLabs/defang/src/pkg/cluster"
 	"github.com/DefangLabs/defang/src/pkg/dryrun"
 	"github.com/DefangLabs/defang/src/pkg/github"
 	"github.com/DefangLabs/defang/src/pkg/term"
-	"github.com/DefangLabs/defang/src/pkg/types"
 	defangv1 "github.com/DefangLabs/defang/src/protos/io/defang/v1"
 )
-
-const DefaultCluster = "fabric-prod1.defang.dev"
-
-var DefangFabric = pkg.Getenv("DEFANG_FABRIC", DefaultCluster)
-
-func SplitTenantHost(cluster string) (types.TenantName, string) {
-	tenant := types.DEFAULT_TENANT
-	parts := strings.SplitN(cluster, "@", 2)
-	if len(parts) == 2 {
-		tenant, cluster = types.TenantName(parts[0]), parts[1]
-	}
-	if cluster == "" {
-		cluster = DefangFabric
-	}
-	if _, _, err := net.SplitHostPort(cluster); err != nil {
-		cluster = cluster + ":443" // default to https
-	}
-	return tenant, cluster
-}
-
-func getTokenFile(fabric string) string {
-	if host, _, _ := net.SplitHostPort(fabric); host != "" {
-		fabric = host
-	}
-	return filepath.Join(client.StateDir, fabric)
-}
-
-func GetExistingToken(fabric string) string {
-	var accessToken = os.Getenv("DEFANG_ACCESS_TOKEN")
-
-	if accessToken == "" {
-		tokenFile := getTokenFile(fabric)
-
-		term.Debug("Reading access token from file", tokenFile)
-		all, _ := os.ReadFile(tokenFile)
-		accessToken = string(all)
-	} else {
-		term.Debug("Using access token from env DEFANG_ACCESS_TOKEN")
-	}
-
-	return accessToken
-}
 
 type LoginFlow = auth.LoginFlow
 
@@ -78,17 +32,17 @@ func (g OpenAuthService) login(ctx context.Context, client client.FabricClient, 
 		return "", err
 	}
 
-	tenant, _ := SplitTenantHost(fabric)
+	tenant, _ := cluster.SplitTenantHost(fabric)
 	return auth.ExchangeCodeForToken(ctx, code, tenant, 0) // no scopes = unrestricted
 }
 
 func (g OpenAuthService) serveAuthServer(ctx context.Context, fabric string, authPort int) error {
 	term.Debug("Logging in to", fabric)
 
-	tenant, _ := SplitTenantHost(fabric)
+	tenant, _ := cluster.SplitTenantHost(fabric)
 
 	err := auth.ServeAuthCodeFlowServer(ctx, authPort, tenant, func(token string) {
-		saveAccessToken(fabric, token)
+		cluster.SaveAccessToken(fabric, token)
 	})
 	if err != nil {
 		term.Error("failed to start auth server", "error", err)
@@ -97,16 +51,6 @@ func (g OpenAuthService) serveAuthServer(ctx context.Context, fabric string, aut
 }
 
 var authService AuthService = OpenAuthService{}
-
-func saveAccessToken(fabric, token string) error {
-	tokenFile := getTokenFile(fabric)
-	term.Debug("Saving access token to", tokenFile)
-	os.MkdirAll(client.StateDir, 0700)
-	if err := os.WriteFile(tokenFile, []byte(token), 0600); err != nil {
-		return fmt.Errorf("failed to save access token: %w", err)
-	}
-	return nil
-}
 
 func InteractiveLogin(ctx context.Context, client client.FabricClient, fabric string) error {
 	return interactiveLogin(ctx, client, fabric, auth.CliFlow)
@@ -126,10 +70,10 @@ func interactiveLogin(ctx context.Context, client client.FabricClient, fabric st
 		return err
 	}
 
-	tenant, host := SplitTenantHost(fabric)
+	tenant, host := cluster.SplitTenantHost(fabric)
 	term.Info("Successfully logged in to", host, "("+tenant.String()+" tenant)")
 
-	if err := saveAccessToken(fabric, token); err != nil {
+	if err := cluster.SaveAccessToken(fabric, token); err != nil {
 		term.Warn(err)
 		var pathError *os.PathError
 		if errors.As(err, &pathError) {
@@ -161,5 +105,5 @@ func NonInteractiveGitHubLogin(ctx context.Context, client client.FabricClient, 
 	if err != nil {
 		return err
 	}
-	return saveAccessToken(fabric, resp.AccessToken)
+	return cluster.SaveAccessToken(fabric, resp.AccessToken)
 }

--- a/src/pkg/login/login_test.go
+++ b/src/pkg/login/login_test.go
@@ -1,4 +1,4 @@
-package cli
+package login
 
 import (
 	"context"

--- a/src/pkg/login/login_test.go
+++ b/src/pkg/login/login_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/DefangLabs/defang/src/pkg/cli/client"
+	"github.com/DefangLabs/defang/src/pkg/cluster"
 	defangv1 "github.com/DefangLabs/defang/src/protos/io/defang/v1"
 )
 
@@ -19,7 +20,7 @@ func TestGetExistingToken(t *testing.T) {
 		expectedToken := "env-token"
 		t.Setenv("DEFANG_ACCESS_TOKEN", expectedToken)
 
-		accessToken := GetExistingToken(fabric)
+		accessToken := cluster.GetExistingToken(fabric)
 		if accessToken != expectedToken {
 			t.Errorf("expected %s, got %s", expectedToken, accessToken)
 		}
@@ -27,14 +28,14 @@ func TestGetExistingToken(t *testing.T) {
 
 	t.Run("Get access token from file", func(t *testing.T) {
 		expectedToken := "file-token"
-		tokenFile := getTokenFile(fabric)
+		tokenFile := cluster.GetTokenFile(fabric)
 		os.WriteFile(tokenFile, []byte(expectedToken), 0600)
 
 		t.Cleanup(func() {
 			os.Remove(tokenFile)
 		})
 
-		accessToken := GetExistingToken(fabric)
+		accessToken := cluster.GetExistingToken(fabric)
 		if accessToken != expectedToken {
 			t.Errorf("expected %s, got %s", expectedToken, accessToken)
 		}
@@ -67,7 +68,7 @@ func TestInteractiveLogin(t *testing.T) {
 		client.StateDir = prevStateDir
 	})
 
-	tokenFile := getTokenFile(fabric)
+	tokenFile := cluster.GetTokenFile(fabric)
 
 	t.Run("Expect accessToken to be stored when InteractiveLogin() succeeds", func(t *testing.T) {
 		authService = mockGitHubAuthService{accessToken: accessToken}
@@ -126,7 +127,7 @@ func TestNonInteractiveLogin(t *testing.T) {
 			t.Fatalf("expected no error, got %v", err)
 		}
 
-		tokenFile := getTokenFile(fabric)
+		tokenFile := cluster.GetTokenFile(fabric)
 		savedToken, err := os.ReadFile(tokenFile)
 		if err != nil {
 			t.Fatalf("expected no error, got %v", err)

--- a/src/pkg/mcp/tools/login.go
+++ b/src/pkg/mcp/tools/login.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 
 	"github.com/DefangLabs/defang/src/pkg/cli"
+	"github.com/DefangLabs/defang/src/pkg/login"
 	"github.com/DefangLabs/defang/src/pkg/term"
 	"github.com/DefangLabs/defang/src/pkg/track"
 	"github.com/mark3labs/mcp-go/mcp"
@@ -33,7 +34,7 @@ func setupLoginTool(s *server.MCPServer, cluster string, authPort int) {
 				return mcp.NewToolResultText("Please open this URL in your browser: http://127.0.0.1:" + strconv.Itoa(authPort) + " to login"), nil
 			}
 			term.Debug("Function invoked: cli.InteractiveLoginPrompt")
-			err = cli.InteractiveLoginMCP(ctx, client, cluster)
+			err = login.InteractiveLoginMCP(ctx, client, cluster)
 			if err != nil {
 				return mcp.NewToolResultErrorFromErr("Failed to login", err), nil
 			}

--- a/src/pkg/migrate/heroku.go
+++ b/src/pkg/migrate/heroku.go
@@ -1,6 +1,7 @@
 package migrate
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -206,15 +207,44 @@ func herokuGet[T any](ctx context.Context, h *HerokuClient, url string) (T, erro
 	return data, nil
 }
 
+func authenticateHerokuCLI() error {
+	cmd := exec.Command("heroku", "whoami")
+	output, err := cmd.Output()
+	if err == nil && len(output) > 0 {
+		return nil
+	}
+
+	term.Info("You need to authenticate with the Heroku CLI.")
+	term.Info("If a browser window does not open, run `heroku login` in a separate shell and try again.")
+	cmd = exec.Command("heroku", "login")
+	// cmd needs to receive any keypress on stdin in order to open a browser
+	cmd.Stdin = bytes.NewBuffer([]byte{'\n'})
+	_, err = cmd.Output()
+	if err != nil {
+		term.Debugf("Failed to run `heroku login`: %v", err)
+		return err
+	}
+
+	return nil
+}
+
 func getHerokuAuthTokenFromCLI() (string, error) {
-	if _, err := exec.LookPath("heroku"); err != nil {
+	_, err := exec.LookPath("heroku")
+	if err != nil {
 		return "", fmt.Errorf("Heroku CLI is not installed: %v", err)
 	}
-	term.Debug("Heroku CLI is installed, attempting to create a short-lived authorization token")
+	term.Info("The Heroku CLI is installed, we'll use it to generate a short-lived authorization token")
+	err = authenticateHerokuCLI()
+	if err != nil {
+		term.Debugf("Failed to authenticate Heroku CLI: %v", err)
+		return "", err
+	}
+	term.Debug("Successfully authenticated with Heroku")
+
 	cmd := exec.Command("heroku", "authorizations:create", "--expires-in=300", "--json")
 	output, err := cmd.Output()
 	if err != nil {
-		term.Debugf("Failed to run Heroku CLI: %v", err)
+		term.Debugf("Failed to run `heroku authorizations:create`: %v", err)
 		return "", err
 	}
 

--- a/src/pkg/setup/setup.go
+++ b/src/pkg/setup/setup.go
@@ -11,6 +11,7 @@ import (
 	"github.com/DefangLabs/defang/src/pkg"
 	"github.com/DefangLabs/defang/src/pkg/cli"
 	"github.com/DefangLabs/defang/src/pkg/cli/client"
+	"github.com/DefangLabs/defang/src/pkg/login"
 	"github.com/DefangLabs/defang/src/pkg/migrate"
 	"github.com/DefangLabs/defang/src/pkg/surveyor"
 	"github.com/DefangLabs/defang/src/pkg/term"
@@ -134,7 +135,7 @@ func (s *SetupClient) AIGenerate(ctx context.Context) (SetupResult, error) {
 	}
 	if s.Fabric.CheckLoginAndToS(ctx) != nil {
 		// The user is either not logged in or has not agreed to the terms of service; ask for agreement to the terms now
-		if err := cli.InteractiveAgreeToS(ctx, s.Fabric); err != nil {
+		if err := login.InteractiveAgreeToS(ctx, s.Fabric); err != nil {
 			// This might fail because the user did not log in. This is fine: server won't save the terms agreement, but can proceed with the generation
 			if connect.CodeOf(err) != connect.CodeUnauthenticated {
 				return SetupResult{}, err
@@ -225,7 +226,7 @@ func beforeGenerate(directory string) {
 }
 
 func (s *SetupClient) MigrateFromHeroku(ctx context.Context) (SetupResult, error) {
-	if err := cli.InteractiveLogin(ctx, s.Fabric, s.Cluster); err != nil {
+	if err := login.InteractiveLogin(ctx, s.Fabric, s.Cluster); err != nil {
 		return SetupResult{}, err
 	}
 	var composeFileContents string

--- a/src/pkg/setup/setup.go
+++ b/src/pkg/setup/setup.go
@@ -226,10 +226,10 @@ func beforeGenerate(directory string) {
 }
 
 func (s *SetupClient) MigrateFromHeroku(ctx context.Context) (SetupResult, error) {
-	if err := login.InteractiveLogin(ctx, s.Fabric, s.Cluster); err != nil {
+	err := login.InteractiveRequireLoginAndToS(ctx, s.Fabric, s.Cluster)
+	if err != nil {
 		return SetupResult{}, err
 	}
-	var composeFileContents string
 
 	term.Info("Ok, let's create a compose file for your existing deployment.")
 	composeFileContents, err := migrate.InteractiveSetup(ctx, s.Fabric, s.Surveyor, s.Heroku, "heroku")


### PR DESCRIPTION
## Description

There were two issues related to authentication during the "migrate from heroku" flow:
1. the user was asked to authenticate with defang each time this flow was invoked—regardless of whether or not they had already authenticated
2. the defang cli was unable to use the heroku cli unless the user had run `heroku login` out of band

Both of these issues have been addressed in this PR. However, both required an enormous amount of refactoring to disentangle the package import graph. I tried to make each commit instructive to my journey, but I'm happy to walk through it with anyone if they would like a tour.

The most significant change is that the code to call `CheckLoginAndToS` and interactively handle `CodeFailedPrecondition` and `CodeUnauthenticated` was moved into the `login` package so it could be reused during the heroku flow. This was the one of the primary goals of this PR, and this change motivated most of the additional refactoring.

The following new packages were created
* `src/pkg/login` - to handle login and tos acceptance
* `src/pkg/cluster` - most handles storing state locally within the scope of the current cluster (i dont love this name—open to suggestions)
* `src/pkg/dryrun` - this is a global which is set by a cli flag. It is used it too many places to warrant passing it around, so I kept it a global—i just moved it into a new package so it could be imported in multiple places without import cycles.

Additionally:
* `prettyError` was moved into `src/pkg/cli/client` since it seems to be related to formatting errors originating from code in that package.

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

