### PR TITLE
Normalize compose commands when generating for heroku migration

### DIFF
--- a/src/pkg/migrate/migrate_test.go
+++ b/src/pkg/migrate/migrate_test.go
@@ -472,6 +472,40 @@ services:
 `,
 			expectingError: false,
 		},
+		{
+			name: "string command",
+			input: `
+services:
+  web:
+    build: .
+    command: npm start
+`,
+			expected: `services:
+    web:
+        build: .
+        command:
+            - npm start
+`,
+			expectingError: false,
+		},
+		{
+			name: "array command",
+			input: `
+services:
+  web:
+    build: .
+    command:
+      - npm
+      - start
+`,
+			expected: `services:
+    web:
+        build: .
+        command:
+            - npm start
+`,
+			expectingError: false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Description

Railpack uses `bash -c` as the entrypoint for the images it builds (See https://github.com/railwayapp/railpack/blob/84e99a95d4ab127366267af24d25cfa921d4c75e/buildkit/convert.go#L79)

This causes an issue if the compose service command is written as an array, for example:
```
services:
  web:
    command:
      - npm
      - start
```
And because `compose-go` normalizes string commands to arrays in memory, for example:
```
services:
  web:
    command: npm start
```
This ☝️ gets converted into the first example.

Both of these command declarations cause problems, because if the entrypoint is `bash -c`, then the command which will ultimately get executed is `bash -c npm start`. When this gets executed, bash will drop all but the first argument and will only run `npm` in a subprocess:

For example:
```
bash -c npm install
npm <command>

Usage:

npm install        install all the dependencies in your project
# etc...
```

In order to work around this snag for heroku migration, we have chosen to normalize all commands into the following form:
```
services:
  web:
    command:
      - npm start
```

This ensures that the ultimate command is `bash -c 'npm start'` which will behave as expected.

We may ultimately move this change to read time when deploying with defang if railpacks is being used.

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

