### PR TITLE
Makefile fix and only run src/README.md sync on change

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,5 +22,5 @@ src/README.md: README.md
 	awk '/^## Getting started/{p=1} (/^## /||/^### /){if(p&&!/^## Getting started/){exit}} p' README.md >> src/README.md; \
 	awk '/^## Support/{p=1} (/^## /||/^### /){if(p&&!/^## Support/){exit}} p' README.md >> src/README.md; \
 	awk '/^## Environment Variables/{p=1} (/^## /||/^### /){if(p&&!/^## Environment Variables/){exit}} p' README.md >> src/README.md; \
-	echo 'src/README.md was updated because root README.md changed. Please add src/README.md to your commit.';
+	@echo 'src/README.md was updated because root README.md changed. Please add src/README.md to your commit.';
 	@false


### PR DESCRIPTION
Makefile update
-  the src/README.md will only be updated on root README.md change
- fix the sync using the wrong header text to sync

## Linked Issues
fixes #1374

## Checklist

- [X] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

