### PR TITLE
do not wait for local pulumi, just like when using a remote task

### DIFF
--- a/src/pkg/cli/client/byoc/common.go
+++ b/src/pkg/cli/client/byoc/common.go
@@ -51,7 +51,8 @@ func runLocalCommand(ctx context.Context, dir string, env []string, cmd ...strin
 	command.Env = env
 	command.Stdout = os.Stdout
 	command.Stderr = os.Stderr
-	return command.Run()
+	// Start the process and do not wait for it to finish
+	return command.Start()
 }
 
 func DebugPulumi(ctx context.Context, env []string, cmd ...string) error {

--- a/src/pkg/cli/client/byoc/common.go
+++ b/src/pkg/cli/client/byoc/common.go
@@ -73,8 +73,7 @@ func DebugPulumi(ctx context.Context, env []string, cmd ...string) error {
 	if err := runLocalCommand(ctx, dir, env, localCmd...); err != nil {
 		return err
 	}
-	// We always return an error to stop the CLI from "tailing" the cloud logs
-	return errors.New("local pulumi command succeeded; stopping")
+	return nil
 }
 
 func GetPrivateDomain(projectName string) string {


### PR DESCRIPTION
## Description

Trying to get logs back from kaniko and release tasks when using local pulumi. 

This doesn't work yet. I see this in the logs even after a `defang compose down` and `defang cd cancel`
```
2025-08-28T10:47:04.199-07:00 cd pulumi Running update...
2025-08-28T10:47:04.625-07:00 cd pulumi  ** Update failed; executing forced refresh...
2025-08-28T10:47:04.625-07:00 cd pulumi Refreshing stack...
2025-08-28T10:47:05.289-07:00 cd pulumi  ** error: the stack is currently locked by 1 lock(s). Either wait for the other process(es) to end or delete the lock file with `defang cd cancel --org=jordanstephens --project-name=vast-badlands`.
 - AWS error: context canceled
```

I haven't figured out why—I'm running pulumi locally, and it shouldn't be running in ECS.

Here is the full output from my last attempt of `compose up` right after a successful `compose down`:
https://gist.github.com/jordanstephens/f754d9faa41e549460d259c2f3673b20

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

