### PR TITLE
Retry compose up after recoverable errors

### DIFF
--- a/src/pkg/cli/compose/validation.go
+++ b/src/pkg/cli/compose/validation.go
@@ -23,6 +23,10 @@ type ListConfigNamesFunc func(context.Context) ([]string, error)
 
 type ErrMissingConfig []string
 
+func (e ErrMissingConfig) Names() []string {
+	return ([]string)(e)
+}
+
 func (e ErrMissingConfig) Error() string {
 	return fmt.Sprintf("missing configs %q (https://docs.defang.io/docs/concepts/configuration)", ([]string)(e))
 }

--- a/src/pkg/mcp/tools/common.go
+++ b/src/pkg/mcp/tools/common.go
@@ -3,6 +3,7 @@ package tools
 import (
 	"crypto/rand"
 	"encoding/base64"
+	"errors"
 	"regexp"
 	"strings"
 
@@ -53,7 +54,8 @@ func HandleTermsOfServiceError(err error) *mcp.CallToolResult {
 }
 
 func HandleConfigError(err error) *mcp.CallToolResult {
-	if strings.Contains(err.Error(), "missing configs") {
+	var missingConfigErr *compose.ErrMissingConfig
+	if errors.As(err, &missingConfigErr) {
 		mcpResult := mcp.NewToolResultErrorFromErr("The operation failed due to missing configs not being set. Please use the Defang tool called set_config to set the variable.", err)
 		term.Debugf("MCP output error: %v", mcpResult)
 		return mcpResult


### PR DESCRIPTION
## Description

Retry compose up after interactively handling recoverable errors: `missing config` or `maximum number of projects`.

I haven't tested this yet

## Linked Issues

Closes #1360

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

