### PR TITLE
avoid waiting for release tasks during deployment

### DIFF
--- a/src/pkg/cli/composeUp_test.go
+++ b/src/pkg/cli/composeUp_test.go
@@ -217,6 +217,23 @@ func TestSplitManagedAndUnmanagedServices(t *testing.T) {
 			t.Errorf("Expected 1 unmanaged resource, got %d (%s)", len(unmanaged), unmanaged)
 		}
 	})
+
+	t.Run("release task with restart: 'no'", func(t *testing.T) {
+		project := compose.Services{
+			"service1": compose.ServiceConfig{
+				Restart: "no",
+			},
+		}
+
+		managed, unmanaged := splitManagedAndUnmanagedServices(project)
+		if len(managed) != 1 {
+			t.Errorf("Expected 1 managed resource, got %d (%v)", len(managed), managed)
+		}
+
+		if len(unmanaged) != 0 {
+			t.Errorf("Expected 0 unmanaged resource, got %d (%v)", len(unmanaged), unmanaged)
+		}
+	})
 }
 
 func TestComposeUpStops(t *testing.T) {

--- a/src/pkg/cli/tailAndMonitor.go
+++ b/src/pkg/cli/tailAndMonitor.go
@@ -102,6 +102,12 @@ func TailAndMonitor(ctx context.Context, project *compose.Project, provider clie
 }
 
 func CanMonitorService(service compose.ServiceConfig) bool {
+	// Services with "restart: no" are assumed to be one-off
+	// tasks, so they are not monitored.
+	if service.Restart == "no" {
+		return false
+	}
+
 	if service.Extensions == nil {
 		return true
 	}


### PR DESCRIPTION
## Description

Release tasks will not stay in state `DEPLOYMENT_COMPLETED`, so we should not wait for them.

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

