### PR TITLE
fix: Docker build used Go version from go.mod

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -23,7 +23,7 @@
               gnumake
               less
               gnused # force Linux `sed` everywhere
-              go_1_24
+              go_1_24 # must match GO_VERSION in Dockerfile
               golangci-lint
               goreleaser
               nixfmt-rfc-style

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,6 +1,6 @@
 # Build stage
-ARG GOVERSION=1.23
-FROM --platform=${BUILDPLATFORM} golang:${GOVERSION} AS builder
+ARG GO_VERSION=1.24
+FROM --platform=${BUILDPLATFORM} golang:${GO_VERSION} AS builder
 
 # These two are automatically set by docker buildx
 ARG TARGETARCH

--- a/src/Makefile
+++ b/src/Makefile
@@ -6,6 +6,7 @@ PROTOS := protos/io/defang/v1/fabric.pb.go protos/io/defang/v1/defangv1connect/f
 BINARY_NAME:=defang
 GOFLAGS:=-ldflags "-X main.version=$(VERSION)"
 GOSRC := $(shell find . -name '*.go')
+GO_VERSION := $(shell grep '^go ' go.mod | cut -d ' ' -f 2)
 
 $(BINARY_NAME): $(PROTOS) $(GOSRC) go.mod go.sum
 	go build -o $@ $(GOFLAGS) ./cmd/cli
@@ -90,11 +91,11 @@ DOCKER_IMAGE_AMD64:=$(DOCKER_IMAGE_NAME):amd64-$(VERSION)
 
 .PHONY: image-amd64
 image-amd64:
-	docker build --platform linux/amd64 -t ${PROJECT_NAME} -t $(DOCKER_IMAGE_AMD64) --build-arg VERSION=$(VERSION) .
+	docker build --platform linux/amd64 -t ${PROJECT_NAME} -t $(DOCKER_IMAGE_AMD64) --build-arg VERSION=$(VERSION) --build-arg GO_VERSION=$(GO_VERSION) .
 
 .PHONY: image-arm64
 image-arm64:
-	docker build --platform linux/arm64 -t ${PROJECT_NAME} -t $(DOCKER_IMAGE_ARM64) --build-arg VERSION=$(VERSION) .
+	docker build --platform linux/arm64 -t ${PROJECT_NAME} -t $(DOCKER_IMAGE_ARM64) --build-arg VERSION=$(VERSION) --build-arg GO_VERSION=$(GO_VERSION) .
 
 .PHONY: images
 images: image-amd64 image-arm64 ## Build all docker images and manifest


### PR DESCRIPTION
## Description

This address the build failure in https://github.com/DefangLabs/defang/actions/runs/17596287811/job/49989520894#step:6:158
```
0.137 go: go.mod requires go >= 1.24 (running go 1.23.12; GOTOOLCHAIN=local)
```

Fix is to get the required Go version from `go.mod` and pass the Go version to Docker as a build arg.

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

