### PR TITLE
default to all logs when tailing

### DIFF
--- a/src/pkg/cli/tail.go
+++ b/src/pkg/cli/tail.go
@@ -141,7 +141,7 @@ func (cerr CancelError) Unwrap() error {
 
 func Tail(ctx context.Context, provider client.Provider, projectName string, options TailOptions) error {
 	if options.LogType == logs.LogTypeUnspecified {
-		options.LogType = logs.LogTypeRun
+		options.LogType = logs.LogTypeAll
 	}
 
 	term.Debugf("Tailing %s logs in project %q", options.LogType, projectName)

--- a/src/pkg/cli/tail_test.go
+++ b/src/pkg/cli/tail_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/DefangLabs/defang/src/pkg/cli/client"
 	"github.com/DefangLabs/defang/src/pkg/clouds/aws/ecs"
+	"github.com/DefangLabs/defang/src/pkg/logs"
 	"github.com/DefangLabs/defang/src/pkg/term"
 	defangv1 "github.com/DefangLabs/defang/src/protos/io/defang/v1"
 	cwTypes "github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
@@ -190,8 +191,8 @@ func TestTail(t *testing.T) {
 	if p.Reqs[0].Project != projectName {
 		t.Errorf("Tail() sent request with project %v, want %v", p.Reqs[0].Project, projectName)
 	}
-	if p.Reqs[0].LogType != 2 {
-		t.Errorf("Tail() sent request with log type %v, want 2", p.Reqs[0].LogType)
+	if p.Reqs[0].LogType != uint32(logs.LogTypeAll) {
+		t.Errorf("Tail() sent request with log type %v, want %v", p.Reqs[0].LogType, logs.LogTypeAll)
 	}
 	if p.Reqs[0].Since != nil {
 		t.Errorf("Tail() sent request with since %v, want nil", p.Reqs[0].Since)
@@ -205,8 +206,8 @@ func TestTail(t *testing.T) {
 	if p.Reqs[1].Project != projectName {
 		t.Errorf("Tail() sent request with project %v, want %v", p.Reqs[0].Project, projectName)
 	}
-	if p.Reqs[1].LogType != 2 {
-		t.Errorf("Tail() sent request with log type %v, want 2", p.Reqs[0].LogType)
+	if p.Reqs[1].LogType != uint32(logs.LogTypeAll) {
+		t.Errorf("Tail() sent request with log type %v, want %v", p.Reqs[1].LogType, logs.LogTypeAll)
 	}
 	if p.Reqs[1].Since == nil {
 		t.Errorf("Tail() sent request with since nil, want not nil")
@@ -307,7 +308,7 @@ func (m mockQueryErrorProvider) QueryLogs(ctx context.Context, req *defangv1.Tai
 }
 
 func TestTailError(t *testing.T) {
-	const cancelError = "tail --since=2024-01-02T03:04:05Z --verbose=0 --type=RUN --project-name=project"
+	const cancelError = "tail --since=2024-01-02T03:04:05Z --verbose=0 --type=ALL --project-name=project"
 	tailOptions := TailOptions{
 		Since: time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC),
 	}
@@ -342,7 +343,7 @@ func TestTailError(t *testing.T) {
 }
 
 func TestTailContext(t *testing.T) {
-	const cancelError = "tail --since=2024-01-02T03:04:05Z --verbose=0 --type=RUN --project-name=project"
+	const cancelError = "tail --since=2024-01-02T03:04:05Z --verbose=0 --type=ALL --project-name=project"
 	tailOptions := TailOptions{
 		Since: time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC),
 	}


### PR DESCRIPTION
## Description

default to all logs when running `defang tail`

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

