### PR TITLE
Added guard for empty region

### DIFF
--- a/src/pkg/mcp/prompts/awsBYOC.go
+++ b/src/pkg/mcp/prompts/awsBYOC.go
@@ -66,9 +66,11 @@ func setupAWSBYOPrompt(s *server.MCPServer, cluster string, providerId *client.P
 			}
 
 			region := getStringArg(req.Params.Arguments, "AWS_REGION", "")
-			err = os.Setenv("AWS_REGION", region)
-			if err != nil {
-				return nil, err
+			if region != "" {
+				err = os.Setenv("AWS_REGION", region)
+				if err != nil {
+					return nil, err
+				}
 			}
 		}
 

--- a/src/pkg/mcp/tools/estimate.go
+++ b/src/pkg/mcp/tools/estimate.go
@@ -47,12 +47,6 @@ func setupEstimateTool(s *server.MCPServer, cluster string, providerId *cliClien
 		term.Debug("Estimate tool called")
 		track.Evt("MCP Estimate Tool")
 
-		if *providerId == cliClient.ProviderDefang || *providerId == cliClient.ProviderAuto {
-			// We only support estimates for AWS and GCP, not playground; suggest use setup prompt for another provider
-			err := errors.New("estimates are only supported for AWS and GCP; please configure another provider using the appropriate prompts and type /mcp.defang.AWS_Setup for AWS or /mcp.defang.GCP_Setup for GCP")
-			return mcp.NewToolResultErrorFromErr("No compatible provider configured", err), err
-		}
-
 		wd, err := request.RequireString("working_directory")
 		if err != nil || wd == "" {
 			term.Error("Invalid working directory", "error", errors.New("working_directory is required"))


### PR DESCRIPTION
## Description

When doing a `defang estimate` on MCP, there is an bug when your are setting a profile using the prompt called "AWS Setup". The optional region env var could be set as empty or nil. 

@jordanstephens had also setup guards on the server side to defend again invalid regions now as well. 
https://github.com/DefangLabs/defang-mvp/pull/2199

<!-- Concise description of what this PR is tackling. -->

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

