### PR TITLE
Added json mode to term

### DIFF
--- a/src/pkg/term/colorizer.go
+++ b/src/pkg/term/colorizer.go
@@ -442,7 +442,7 @@ type LogEntry struct {
 func (t *Term) outputJSON(level string, w *termenv.Output, v ...any) (int, error) {
 	entry := LogEntry{
 		Level:   level,
-		Message: strings.TrimSpace(fmt.Sprint(v...)),
+		Message: strings.TrimSpace(fmt.Sprintln(v...)),
 	}
 	data, err := json.Marshal(entry)
 	if err != nil {


### PR DESCRIPTION
## Description
Currently we do not have a good way debugging the MCP server, but with the logging feature in [mcp-go](https://github.com/mark3labs/mcp-go/tree/main) we see them in the stderr and stdout. If we do not have it in json the parser will complain.

Before:
```
2025-09-15 09:02:45.526 [info] Connection state: Running
2025-09-15 09:02:45.771 [warning] Failed to parse message: " - Setting up knowledge base\n"
2025-09-15 09:02:45.771 [warning] Failed to parse message: " - Setting up knowledge base\n"
2025-09-15 09:02:45.771 [warning] Failed to parse message: " - Attempting to download knowledge base files: [knowledge_base.json samples_examples.json]\n"
2025-09-15 09:02:45.771 [warning] Failed to parse message: " - Creating knowledge base directory: /Users/defang/.local/state/defang\n"
2025-09-15 09:02:45.771 [warning] Failed to parse message: " - Downloading knowledge base file: knowledge_base.json\n"
2025-09-15 09:02:45.771 [warning] Failed to parse message: " - fabricClient 0ui117ko9he5 /io.defang.v1.FabricController/Track {\"event\":\"MCP-SERVE INVOKED\",\"properties\":{\"CalledAs\":\"  serve\",\"args\":\"[]\",\"err\":\"\\u003cnil\\u003e\",\"non-interactive\":\"true\",\"provider\":\"auto\",\"version\":\"ea15b25e-dirty\"},\"os\":\"darwin\",\"arch\":\"arm64\"}\n"
2025-09-15 09:02:45.771 [warning] Failed to parse message: " - Creating file: /Users/defang/.local/state/defang/knowledge_base.json\n"
2025-09-15 09:02:46.196 [warning] Failed to parse message: " - Downloading file: /data/knowledge_base.json\n"
2025-09-15 09:02:46.196 [warning] Failed to parse message: " - Checking server response: 200 OK\n"
2025-09-15 09:02:46.197 [warning] Failed to parse message: " - Copying Using IO Copy: /Users/defang/.local/state/defang/knowledge_base.json\n"
2025-09-15 09:02:47.272 [warning] Failed to parse message: " - Downloading knowledge base file: samples_examples.json\n"
2025-09-15 09:02:47.272 [warning] Failed to parse message: " - Creating file: /Users/defang/.local/state/defang/samples_examples.json\n"
2025-09-15 09:02:47.351 [warning] Failed to parse message: " - Downloading file: /data/samples_examples.json\n"
2025-09-15 09:02:47.351 [warning] Failed to parse message: " - Checking server response: 200 OK\n"
2025-09-15 09:02:47.352 [warning] Failed to parse message: " - Copying Using IO Copy: /Users/defang/.local/state/defang/samples_examples.json\n"
2025-09-15 09:02:47.352 [warning] Failed to parse message: " - Successfully downloaded knowledge base files\n"
2025-09-15 09:02:47.352 [warning] Failed to parse message: " - Creating MCP server\n"
2025-09-15 09:02:47.355 [warning] Failed to parse message: "Starting Defang MCP server\n"
```

After:
```
2025-09-15 09:08:10.083 [info] Starting server defang
2025-09-15 09:08:10.083 [info] Connection state: Starting
2025-09-15 09:08:10.087 [info] Starting server from LocalProcess extension host
2025-09-15 09:08:10.088 [debug] Server command line: /Users/defang/.local/bin/defang mcp serve
2025-09-15 09:08:10.088 [info] Connection state: Starting
2025-09-15 09:08:10.089 [info] Connection state: Running
2025-09-15 09:08:10.089 [debug] [editor -> server] {"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{"roots":{"listChanged":true},"sampling":{},"elicitation":{}},"clientInfo":{"name":"Visual Studio Code","version":"1.103.2"}}}
2025-09-15 09:08:10.306 [debug] [server -> editor] {"level":"debug","message":"Setting up knowledge base"}
2025-09-15 09:08:10.306 [debug] [server -> editor] {"level":"debug","message":"Setting up knowledge base"}
2025-09-15 09:08:10.306 [debug] [server -> editor] {"level":"debug","message":"Attempting to download knowledge base files: [knowledge_base.json samples_examples.json]"}
2025-09-15 09:08:10.306 [debug] [server -> editor] {"level":"debug","message":"Creating knowledge base directory: /Users/defang/.local/state/defang"}
2025-09-15 09:08:10.306 [debug] [server -> editor] {"level":"debug","message":"fabricClient8tr48iujk19l/io.defang.v1.FabricController/Track{\"event\":\"MCP-SERVE INVOKED\",\"properties\":{\"CalledAs\":\"  serve\",\"args\":\"[]\",\"err\":\"\\u003cnil\\u003e\",\"non-interactive\":\"true\",\"provider\":\"auto\",\"version\":\"ea15b25e-dirty\"},\"os\":\"darwin\",\"arch\":\"arm64\"}"}
2025-09-15 09:08:10.307 [debug] [server -> editor] {"level":"debug","message":"Downloading knowledge base file: knowledge_base.json"}
2025-09-15 09:08:10.309 [debug] [server -> editor] {"level":"debug","message":"Creating file: /Users/defang/.local/state/defang/knowledge_base.json"}
2025-09-15 09:08:10.719 [debug] [server -> editor] {"level":"debug","message":"Downloading file: /data/knowledge_base.json"}
2025-09-15 09:08:10.720 [debug] [server -> editor] {"level":"debug","message":"Checking server response: 200 OK"}
2025-09-15 09:08:10.720 [debug] [server -> editor] {"level":"debug","message":"Copying Using IO Copy: /Users/defang/.local/state/defang/knowledge_base.json"}
2025-09-15 09:08:11.579 [debug] [server -> editor] {"level":"debug","message":"Downloading knowledge base file: samples_examples.json"}
2025-09-15 09:08:11.579 [debug] [server -> editor] {"level":"debug","message":"Creating file: /Users/defang/.local/state/defang/samples_examples.json"}
2025-09-15 09:08:11.664 [debug] [server -> editor] {"level":"debug","message":"Downloading file: /data/samples_examples.json"}
2025-09-15 09:08:11.664 [debug] [server -> editor] {"level":"debug","message":"Checking server response: 200 OK"}
2025-09-15 09:08:11.665 [debug] [server -> editor] {"level":"debug","message":"Copying Using IO Copy: /Users/defang/.local/state/defang/samples_examples.json"}
2025-09-15 09:08:11.665 [debug] [server -> editor] {"level":"debug","message":"Successfully downloaded knowledge base files"}
2025-09-15 09:08:11.666 [debug] [server -> editor] {"level":"debug","message":"Creating MCP server"}
2025-09-15 09:08:11.666 [debug] [server -> editor] {"level":"debug","message":"Setting up resources"}
2025-09-15 09:08:11.666 [debug] [server -> editor] {"level":"info","message":"Creating documentation resource"}
2025-09-15 09:08:11.666 [debug] [server -> editor] {"level":"info","message":"Creating samples examples resource"}
2025-09-15 09:08:11.666 [debug] [server -> editor] {"level":"debug","message":"Setting up prompts"}
2025-09-15 09:08:11.666 [debug] [server -> editor] {"level":"debug","message":"Setting up tools"}
2025-09-15 09:08:11.666 [debug] [server -> editor] {"level":"debug","message":"Setting up login tool"}
2025-09-15 09:08:11.666 [debug] [server -> editor] {"level":"debug","message":"Creating login tool"}
2025-09-15 09:08:11.666 [debug] [server -> editor] {"level":"debug","message":"Login tool created"}
2025-09-15 09:08:11.666 [debug] [server -> editor] {"level":"debug","message":"Adding login tool handler"}
2025-09-15 09:08:11.666 [debug] [server -> editor] {"level":"debug","message":"Setting up services tool"}
```

<!-- Concise description of what this PR is tackling. -->

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

