### PR TITLE
fix(mcp): return URLs to agent

### DIFF
--- a/src/pkg/mcp/tests/client_test.go
+++ b/src/pkg/mcp/tests/client_test.go
@@ -524,6 +524,7 @@ func TestInProcessMCPServer(t *testing.T) {
 	}
 
 	TestInProcessMCPServer_DeployAndDestroy := func(t *testing.T) {
+		t.Skip("broken")
 		const dummyToken = "Testing.Token.1234"
 		t.Setenv("DEFANG_ACCESS_TOKEN", dummyToken)
 

--- a/src/pkg/mcp/tests/client_test.go
+++ b/src/pkg/mcp/tests/client_test.go
@@ -524,7 +524,6 @@ func TestInProcessMCPServer(t *testing.T) {
 	}
 
 	TestInProcessMCPServer_DeployAndDestroy := func(t *testing.T) {
-		t.Skip("broken")
 		const dummyToken = "Testing.Token.1234"
 		t.Setenv("DEFANG_ACCESS_TOKEN", dummyToken)
 

--- a/src/pkg/mcp/tools/common.go
+++ b/src/pkg/mcp/tools/common.go
@@ -84,7 +84,7 @@ func CanIUseProvider(ctx context.Context, grpcClient client.FabricClient, provid
 func providerNotConfiguredError(providerId client.ProviderID) error {
 	if providerId == client.ProviderAuto {
 		term.Error("No provider configured")
-		return errors.New("No provider configured, please use the appropriate prompts and type /mcp.defang.AWS_Setup for AWS, /mcp.defang.GCP_Setup for GCP, or /mcp.defang.Playground_Setup for Playground in the chat.")
+		return errors.New("no provider is configured; please type in the chat /defang.AWS_Setup for AWS, /defang.GCP_Setup for GCP, or /defang.Playground_Setup for Playground.")
 	}
 	return nil
 }

--- a/src/pkg/mcp/tools/deploy.go
+++ b/src/pkg/mcp/tools/deploy.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/pkg/browser"
 
@@ -182,6 +183,13 @@ func handleDeployTool(ctx context.Context, request mcp.CallToolRequest, provider
 		term.Debugf("  Status: %s", serviceInfo.Status)
 	}
 
+	urls := strings.Builder{}
+	for _, serviceInfo := range deployResp.Services {
+		if serviceInfo.PublicFqdn != "" {
+			urls.WriteString(fmt.Sprintf("- %s: %s %s\n", serviceInfo.Service.Name, serviceInfo.PublicFqdn, serviceInfo.Domainname))
+		}
+	}
+
 	// Return the etag data as text
-	return mcp.NewToolResultText(fmt.Sprintf("%s to follow the deployment of %s, with the deployment ID of %s", portal, project.Name, deployResp.Etag)), nil
+	return mcp.NewToolResultText(fmt.Sprintf("%s to follow the deployment of %s, with the deployment ID of %s:\n%s", portal, project.Name, deployResp.Etag, urls.String())), nil
 }

--- a/src/pkg/mcp/tools/deploy_test.go
+++ b/src/pkg/mcp/tools/deploy_test.go
@@ -213,7 +213,7 @@ func TestHandleDeployTool(t *testing.T) {
 			providerID:            client.ProviderAuto,
 			setupMock:             func(m *MockDeployCLI) {},
 			expectError:           true,
-			expectedErrorContains: "No provider configured",
+			expectedErrorContains: "no provider is configured",
 		},
 	}
 

--- a/src/pkg/mcp/tools/destroy_test.go
+++ b/src/pkg/mcp/tools/destroy_test.go
@@ -180,7 +180,7 @@ func TestHandleDestroyTool(t *testing.T) {
 			providerID:            client.ProviderAuto,
 			setupMock:             func(m *MockDestroyCLI) {},
 			expectError:           true,
-			expectedErrorContains: "No provider configured",
+			expectedErrorContains: "no provider is configured",
 		},
 	}
 

--- a/src/pkg/mcp/tools/listConfig_test.go
+++ b/src/pkg/mcp/tools/listConfig_test.go
@@ -97,7 +97,7 @@ func TestHandleListConfigTool(t *testing.T) {
 			setupMock:             func(m *MockListConfigCLI) {},
 			expectError:           true,
 			expectErrorResult:     true,
-			expectedErrorContains: "No provider configured",
+			expectedErrorContains: "no provider is configured",
 		},
 		{
 			name:             "connect_error",

--- a/src/pkg/mcp/tools/removeConfig_test.go
+++ b/src/pkg/mcp/tools/removeConfig_test.go
@@ -81,7 +81,7 @@ func TestHandleRemoveConfigTool(t *testing.T) {
 			setupMock:             func(m *MockRemoveConfigCLI) {},
 			expectError:           true,
 			expectErrorResult:     true,
-			expectedErrorContains: "No provider configured",
+			expectedErrorContains: "no provider is configured",
 		},
 		{
 			name:                  "missing_working_directory",

--- a/src/pkg/mcp/tools/services_test.go
+++ b/src/pkg/mcp/tools/services_test.go
@@ -145,7 +145,7 @@ func TestHandleServicesToolWithMockCLI(t *testing.T) {
 			mockDeploymentInfo:  &MockDeploymentInfo{},
 			expectedError:       true,
 			expectedResultError: true,
-			errorMessage:        "No provider configured",
+			errorMessage:        "no provider is configured",
 			expectedGetServices: false,
 		},
 		{

--- a/src/pkg/mcp/utils.go
+++ b/src/pkg/mcp/utils.go
@@ -11,8 +11,8 @@ import (
 )
 
 const DocumentationEndpoint = "data"
-// AskDefangBaseURL is a var so tests can override it
 
+// AskDefangBaseURL is a var so tests can override it
 var AskDefangBaseURL = "https://ask.defang.io"
 var KnowledgeBaseDir = client.StateDir
 


### PR DESCRIPTION
This PR will improve the quality of the deployment response to have the expected user website domain in the response.