### PR TITLE
fix test does not open browser

### DIFF
--- a/src/pkg/mcp/tools/deploy_test.go
+++ b/src/pkg/mcp/tools/deploy_test.go
@@ -219,6 +219,13 @@ func TestHandleDeployTool(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			var originalOpenURLFunc = OpenURLFunc
+			OpenURLFunc = func(url string) error {
+				// Mock implementation that doesn't actually open a browser
+				return nil
+			}
+			defer func() { OpenURLFunc = originalOpenURLFunc }()
+
 			// Create mock and configure it
 			mockCLI := &MockDeployCLI{
 				CallLog: []string{},


### PR DESCRIPTION
## Description

mcp deploy_test does not override the the function to open the browser to portal. This fix will make a dummy function to for the open brower.

## Linked Issues

#1422 

## Checklist

- [X] I have performed a self-review of my code
- [X] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

