### PR TITLE
fix whoami subscribertier

### DIFF
--- a/src/cmd/cli/command/commands.go
+++ b/src/cmd/cli/command/commands.go
@@ -456,7 +456,7 @@ var whoamiCmd = &cobra.Command{
 				"AccountID",
 				"Tenant",
 				"TenantID",
-				"Subscription Tier",
+				"SubscriberTier",
 				"Region",
 			})
 		}


### PR DESCRIPTION
## Description

The property is called `SubscriberTier` not `Subscription Tier` and the typesystem can't help because `term.Table` uses reflection. 

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

