### PR TITLE
Add MCP setup instruction to installation script

### DIFF
--- a/src/bin/install
+++ b/src/bin/install
@@ -250,6 +250,7 @@ rm -r "$EXTRACT_DIR"
 rm "$FILENAME"
 
 echo "Installation completed. You can now use defang by typing '$BINARY_NAME' in the terminal."
+echo "Run '$BINARY_NAME mcp setup' to install the Defang MCP server."
 
 # Unset the variables and functions to avoid polluting the user's environment
 unset EXTRACT_DIR DOWNLOAD_URL RELEASE_JSON RELEASE_PATH ARCH_SUFFIX ARCH OS FILENAME INSTALL_DIR BINARY_NAME REPLY EXPORT_PATH CURRENT_SHELL FOUND_PROFILE_FILE AUTH_HEADER


### PR DESCRIPTION
Added instructions to run MCP setup after installation.

- [ ] make `defang mcp setup` interactive.

## Description

<!-- Concise description of what this PR is tackling. -->

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

