### PR TITLE
avoid keychain conflict during parallel builds

### DIFF
--- a/src/bin/codesign.sh
+++ b/src/bin/codesign.sh
@@ -23,9 +23,13 @@ fi
 if [ -n "$RUNNER_TEMP" ]; then
     # assume MACOS_P12_BASE64, KEYCHAIN_PASSWORD, MACOS_P12_PASSWORD are set in the env
 
-    # create variables
-    TMP_CERTIFICATE_PATH=$RUNNER_TEMP/build_certificate.p12
-    TMP_KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
+    # create variables with unique names to avoid conflicts
+    UNIQUE_ID=$(date +%s)-$$-$(od -An -N4 -tx4 < /dev/urandom | tr -d ' ')
+    TMP_CERTIFICATE_PATH=$RUNNER_TEMP/build_certificate_${UNIQUE_ID}.p12
+    TMP_KEYCHAIN_PATH=$RUNNER_TEMP/app-signing-${UNIQUE_ID}.keychain-db
+
+    # Clean up any existing certificates in default keychain that might conflict
+    security delete-identity -c "$MACOS_CERTIFICATE_NAME" 2>/dev/null || true
 
     # import certificate and provisioning profile from secrets
     echo $MACOS_P12_BASE64 | base64 --decode > "$TMP_CERTIFICATE_PATH"
@@ -33,7 +37,10 @@ if [ -n "$RUNNER_TEMP" ]; then
     # We need to create a new keychain, otherwise using the certificate will prompt
     # with a UI dialog asking for the certificate password, which we can't
     # use in a headless CI environment
-    security create-keychain -p "$KEYCHAIN_PASSWORD" "$TMP_KEYCHAIN_PATH" || true
+
+    # Create new keychain (should be unique, but remove if exists just in case)
+    security delete-keychain "$TMP_KEYCHAIN_PATH" 2>/dev/null || true
+    security create-keychain -p "$KEYCHAIN_PASSWORD" "$TMP_KEYCHAIN_PATH"
     # security set-keychain-settings -lut 21600 "$TMP_KEYCHAIN_PATH"
         # security default-keychain -s "$TMP_KEYCHAIN_PATH"
     security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$TMP_KEYCHAIN_PATH"
@@ -43,6 +50,16 @@ if [ -n "$RUNNER_TEMP" ]; then
     security list-keychain -d user -s "$TMP_KEYCHAIN_PATH"
 
     security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" "$TMP_KEYCHAIN_PATH"
+
+    # Clean up the certificate file
+    rm -f "$TMP_CERTIFICATE_PATH"
+
+    # Set up cleanup trap
+    cleanup() {
+        echo "Cleaning up keychain..."
+        security delete-keychain "$TMP_KEYCHAIN_PATH" 2>/dev/null || true
+    }
+    trap cleanup EXIT
 fi
 
 # We finally codesign our app bundle. Add '--options runtime' for the Hardened runtime option (required for notarization)


### PR DESCRIPTION
## Description

goreleaser may be running parallel builds (arm64 and amd64) leading to conflicts when reusing the same keychain

This PR updates the codesign script to create a keychain with a unique name during each build to avoid conflcits

## Linked Issues

Fixes #1432 

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

