### PR TITLE
Added a client picker for mcp setup command

### DIFF
--- a/src/cmd/cli/command/commands.go
+++ b/src/cmd/cli/command/commands.go
@@ -300,7 +300,6 @@ func SetupCommands(ctx context.Context, version string) {
 	mcpCmd.AddCommand(mcpServerCmd)
 	mcpSetupCmd.Flags().String("client", "", fmt.Sprintf("MCP setup client %v", mcp.ValidClients))
 	mcpServerCmd.Flags().Int("auth-server", 0, "auth server port")
-	mcpSetupCmd.MarkFlagRequired("client")
 	RootCmd.AddCommand(mcpCmd)
 
 	// Send Command

--- a/src/cmd/cli/command/mcp.go
+++ b/src/cmd/cli/command/mcp.go
@@ -79,9 +79,36 @@ var mcpSetupCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		term.Debug("Setting up MCP client")
 		client, _ := cmd.Flags().GetString("client")
-		term.Debugf("MCP Client: %q", client)
-		if err := mcp.SetupClient(client); err != nil {
-			return err
+
+		if client != "" {
+
+			// Aliases mapping
+			switch client {
+			case "code":
+				client = string(mcp.MCPClientVSCode)
+			case "code-insiders":
+				client = string(mcp.MCPClientVSCodeInsiders)
+			case "cascade", "codeium":
+				client = string(mcp.MCPClientWindsurf)
+			}
+
+			term.Debugf("Using MCP client flag: %q", client)
+			if err := mcp.SetupClient(client); err != nil {
+				return err
+			}
+		} else {
+			term.Debugf("Using MCP client picker: %q", client)
+			clients, err := mcp.SelectMCPclients()
+			if err != nil {
+				return err
+			}
+			for _, client := range clients {
+				term.Debugf("Selected MCP client using picker: %q", client)
+
+				if err := mcp.SetupClient(client); err != nil {
+					return err
+				}
+			}
 		}
 
 		return nil

--- a/src/pkg/mcp/setup.go
+++ b/src/pkg/mcp/setup.go
@@ -17,7 +17,7 @@ import (
 )
 
 var clientQs = &survey.MultiSelect{
-	Message: "Choose a client:",
+	Message: "Choose a client(s):",
 	Options: ValidClientStrings(),
 }
 
@@ -86,6 +86,7 @@ var ValidClients = append(
 	ValidVSCodeClients...,
 )
 
+// ParseMCPClient parses and validates the MCP client string
 func ParseMCPClient(clientStr string) (MCPClient, error) {
 	clientStr = strings.ToLower(clientStr)
 	client := MCPClient(clientStr)
@@ -104,14 +105,15 @@ func ValidClientStrings() []string {
 	return strings
 }
 
+// SelectMCPclients prompts the user to select one or more MCP clients
 func SelectMCPclients() ([]string, error) {
-	var client []string
-	err := survey.AskOne(clientQs, &client)
+	var clients []string
+	err := survey.AskOne(clientQs, &clients)
 	if err != nil {
 		return nil, fmt.Errorf("failed to select MCP client: %w", err)
 	}
 
-	return client, nil
+	return clients, nil
 }
 
 // ClientInfo defines where each client stores its MCP configuration

--- a/src/pkg/mcp/setup.go
+++ b/src/pkg/mcp/setup.go
@@ -16,11 +16,6 @@ import (
 	"github.com/DefangLabs/defang/src/pkg/track"
 )
 
-var clientQs = &survey.MultiSelect{
-	Message: "Choose a client(s):",
-	Options: ValidClientStrings(),
-}
-
 // MCPServerConfig represents the configuration for an MCP server
 type MCPServerConfig struct {
 	Command string            `json:"command"`
@@ -108,9 +103,12 @@ func ValidClientStrings() []string {
 // SelectMCPclients prompts the user to select one or more MCP clients
 func SelectMCPclients() ([]string, error) {
 	var clients []string
-	err := survey.AskOne(clientQs, &clients)
+	err := survey.AskOne(&survey.MultiSelect{
+		Message: "Choose a client(s):",
+		Options: ValidClientStrings(),
+	}, &clients)
 	if err != nil {
-		return nil, fmt.Errorf("failed to select MCP client: %w", err)
+		return nil, fmt.Errorf("failed to select MCP client(s): %w", err)
 	}
 
 	return clients, nil

--- a/src/pkg/mcp/setup.go
+++ b/src/pkg/mcp/setup.go
@@ -10,9 +10,16 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/AlecAivazis/survey/v2"
+
 	"github.com/DefangLabs/defang/src/pkg/term"
 	"github.com/DefangLabs/defang/src/pkg/track"
 )
+
+var clientQs = &survey.MultiSelect{
+	Message: "Choose a client:",
+	Options: ValidClientStrings(),
+}
 
 // MCPServerConfig represents the configuration for an MCP server
 type MCPServerConfig struct {
@@ -53,14 +60,10 @@ type MCPClient string
 
 const (
 	MCPClientVSCode         MCPClient = "vscode"
-	MCPClientCode           MCPClient = "code"
 	MCPClientVSCodeInsiders MCPClient = "vscode-insiders"
-	MCPClientInsiders       MCPClient = "code-insiders"
 	MCPClientClaudeDesktop  MCPClient = "claude-desktop"
 	MCPClientClaudeCode     MCPClient = "claude-code"
 	MCPClientWindsurf       MCPClient = "windsurf"
-	MCPClientCascade        MCPClient = "cascade"
-	MCPClientCodeium        MCPClient = "codeium"
 	MCPClientCursor         MCPClient = "cursor"
 	MCPClientKiro           MCPClient = "kiro"
 )
@@ -68,9 +71,7 @@ const (
 // ValidVSCodeClients is a list of supported VSCode MCP clients with shorthand names
 var ValidVSCodeClients = []MCPClient{
 	MCPClientVSCode,
-	MCPClientCode,
 	MCPClientVSCodeInsiders,
-	MCPClientInsiders,
 }
 
 // ValidClients is a list of supported MCP clients
@@ -79,8 +80,6 @@ var ValidClients = append(
 		MCPClientClaudeDesktop,
 		MCPClientClaudeCode,
 		MCPClientWindsurf,
-		MCPClientCascade,
-		MCPClientCodeium,
 		MCPClientCursor,
 		MCPClientKiro,
 	},
@@ -93,6 +92,25 @@ func ParseMCPClient(clientStr string) (MCPClient, error) {
 	if !slices.Contains(ValidClients, client) {
 		return "", fmt.Errorf("invalid MCP client: %q. Valid MCP clients are %v", clientStr, ValidClients)
 	}
+	return client, nil
+}
+
+// ValidClientStrings converts ValidClients to []string for survey options
+func ValidClientStrings() []string {
+	strings := make([]string, len(ValidClients))
+	for i, client := range ValidClients {
+		strings[i] = string(client)
+	}
+	return strings
+}
+
+func SelectMCPclients() ([]string, error) {
+	var client []string
+	err := survey.AskOne(clientQs, &client)
+	if err != nil {
+		return nil, fmt.Errorf("failed to select MCP client: %w", err)
+	}
+
 	return client, nil
 }
 
@@ -140,12 +158,8 @@ var kiroConfig = ClientInfo{
 // clientRegistry maps client names to their configuration details
 var clientRegistry = map[MCPClient]ClientInfo{
 	MCPClientWindsurf:       windsurfConfig,
-	MCPClientCascade:        windsurfConfig,
-	MCPClientCodeium:        windsurfConfig,
 	MCPClientVSCode:         vscodeConfig,
-	MCPClientCode:           vscodeConfig,
 	MCPClientVSCodeInsiders: codeInsidersConfig,
-	MCPClientInsiders:       codeInsidersConfig,
 	MCPClientClaudeDesktop:  claudeDesktopConfig,
 	MCPClientClaudeCode:     claudeCodeConfig,
 	MCPClientCursor:         cursorConfig,

--- a/src/pkg/mcp/setup_test.go
+++ b/src/pkg/mcp/setup_test.go
@@ -30,16 +30,6 @@ func TestGetClientConfigPath(t *testing.T) {
 			client:       MCPClientWindsurf,
 			expectedPath: filepath.Join(homeDir, ".codeium", "windsurf", "mcp_config.json"),
 		},
-		{
-			name:         "cascade",
-			client:       MCPClientCascade,
-			expectedPath: filepath.Join(homeDir, ".codeium", "windsurf", "mcp_config.json"),
-		},
-		{
-			name:         "codeium",
-			client:       MCPClientCodeium,
-			expectedPath: filepath.Join(homeDir, ".codeium", "windsurf", "mcp_config.json"),
-		},
 
 		// Claude Desktop tests - Darwin
 		{
@@ -159,12 +149,6 @@ func TestGetClientConfigPath(t *testing.T) {
 			goos:         "darwin",
 			expectedPath: filepath.Join(homeDir, "Library", "Application Support", "Code", "User", "mcp.json"),
 		},
-		{
-			name:         "code_darwin",
-			client:       MCPClientCode,
-			goos:         "darwin",
-			expectedPath: filepath.Join(homeDir, "Library", "Application Support", "Code", "User", "mcp.json"),
-		},
 
 		// VSCode tests - Windows with APPDATA
 		{
@@ -206,12 +190,6 @@ func TestGetClientConfigPath(t *testing.T) {
 		{
 			name:         "vscode_insiders_darwin",
 			client:       MCPClientVSCodeInsiders,
-			goos:         "darwin",
-			expectedPath: filepath.Join(homeDir, "Library", "Application Support", "Code - Insiders", "User", "mcp.json"),
-		},
-		{
-			name:         "insiders_darwin",
-			client:       MCPClientInsiders,
 			goos:         "darwin",
 			expectedPath: filepath.Join(homeDir, "Library", "Application Support", "Code - Insiders", "User", "mcp.json"),
 		},


### PR DESCRIPTION
## Description
It’s not a good UX to expect users to know and correctly spell the client they want our MCP server to connect to. Instead, we should provide a list of IDEs for them to pick from.

Also move the alias to the --client flag only.  I did keep backwards compatibility for the --client flag. 
You can also install 1 or all the clients with the picker.

<img width="745" height="161" alt="Screenshot 2025-09-18 at 4 55 48 PM" src="https://github.com/user-attachments/assets/d1bddf49-9aad-4f95-ad4d-57db8173cddf" />
<img width="652" height="132" alt="Screenshot 2025-09-18 at 4 56 02 PM" src="https://github.com/user-attachments/assets/e858bb6d-a2f5-46fa-8fa8-47ad8eecff4c" />
<img width="551" height="68" alt="Screenshot 2025-09-18 at 4 56 40 PM" src="https://github.com/user-attachments/assets/c2292949-1279-465f-ba4f-17965a247fcf" />

<!-- Concise description of what this PR is tackling. -->

## Linked Issues
#1444 
<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

