### PR TITLE
MCP setup bug on empty JSON file

### DIFF
--- a/src/cmd/cli/command/mcp.go
+++ b/src/cmd/cli/command/mcp.go
@@ -81,7 +81,6 @@ var mcpSetupCmd = &cobra.Command{
 		client, _ := cmd.Flags().GetString("client")
 
 		if client != "" {
-
 			// Aliases mapping
 			switch client {
 			case "code":

--- a/src/pkg/mcp/setup.go
+++ b/src/pkg/mcp/setup.go
@@ -411,7 +411,7 @@ func SetupClient(clientStr string) error {
 		}
 	}
 
-	term.Infof("Restart %s for the changes to take effect.\n", client)
+	term.Infof("Ensure that %s is upgraded to the latest version and restarted so the changes can take effect.\n", client)
 
 	return nil
 }

--- a/src/pkg/mcp/setup.go
+++ b/src/pkg/mcp/setup.go
@@ -264,7 +264,7 @@ func handleVSCodeConfig(configPath string) error {
 			// File is empty, treat as new config
 			existingData = make(map[string]any)
 		} else {
-			// File exists, parse it
+			// File is not empty, attempt to parse it
 			if err := json.Unmarshal(data, &existingData); err != nil {
 				return fmt.Errorf("failed to unmarshal existing vscode config: %w", err)
 			}

--- a/src/pkg/mcp/setup.go
+++ b/src/pkg/mcp/setup.go
@@ -259,9 +259,15 @@ func handleVSCodeConfig(configPath string) error {
 
 	// Check if the file exists
 	if data, err := os.ReadFile(configPath); err == nil {
-		// File exists, parse it
-		if err := json.Unmarshal(data, &existingData); err != nil {
-			return fmt.Errorf("failed to unmarshal existing vscode config %w", err)
+		// Check if file is empty or only contains whitespace
+		if len(strings.TrimSpace(string(data))) == 0 {
+			// File is empty, treat as new config
+			existingData = make(map[string]any)
+		} else {
+			// File exists, parse it
+			if err := json.Unmarshal(data, &existingData); err != nil {
+				return fmt.Errorf("failed to unmarshal existing vscode config: %w", err)
+			}
 		}
 
 		// Check if "servers" section exists
@@ -310,9 +316,15 @@ func handleStandardConfig(configPath string) error {
 
 	// Check if the file exists
 	if data, err := os.ReadFile(configPath); err == nil {
-		// Parse the JSON into a generic map to preserve all settings
-		if err := json.Unmarshal(data, &existingData); err != nil {
-			return fmt.Errorf("failed to unmarshal existing config: %w", err)
+		// Check if file is empty or only contains whitespace
+		if len(strings.TrimSpace(string(data))) == 0 {
+			// File is empty, treat as new config
+			existingData = make(map[string]any)
+		} else {
+			// Parse the JSON into a generic map to preserve all settings
+			if err := json.Unmarshal(data, &existingData); err != nil {
+				return fmt.Errorf("failed to unmarshal existing config: %w", err)
+			}
 		}
 
 		// Try to extract MCPServers from existing data

--- a/src/pkg/mcp/setup.go
+++ b/src/pkg/mcp/setup.go
@@ -1,6 +1,7 @@
 package mcp
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -41,13 +42,13 @@ type VSCodeConfig struct {
 
 // VSCodeMCPServerConfig represents the configuration for a VSCode MCP server
 type VSCodeMCPServerConfig struct {
-	Type    string            `json:"type"`          // Required: "stdio" or "sse"
-	Command string            `json:"command"`       // Required for stdio
-	Args    []string          `json:"args"`          // Required for stdio
-	URL     string            `json:"url,omitempty"` // Required for sse
-	Env     map[string]string `json:"env,omitempty"`
+	Args    []string          `json:"args,omitempty"`    // Required for stdio
+	Command string            `json:"command,omitempty"` // Required for stdio
+	Env     map[string]any    `json:"env,omitempty"`
 	EnvFile string            `json:"envFile,omitempty"`
 	Headers map[string]string `json:"headers,omitempty"` // For sse
+	Type    string            `json:"type,omitempty"`    // Required: "stdio" or "sse"
+	URL     string            `json:"url,omitempty"`     // Required for sse
 }
 
 // MCPClient represents the supported MCP clients as an enum
@@ -236,16 +237,30 @@ func getVSCodeDefangMCPConfig() (*VSCodeMCPServerConfig, error) {
 }
 
 // getVSCodeServerConfig returns a map with the VSCode-specific MCP server config
-func getVSCodeServerConfig() (map[string]any, error) {
+func getVSCodeServerConfig() (*VSCodeMCPServerConfig, error) {
 	config, err := getVSCodeDefangMCPConfig()
 	if err != nil {
 		return nil, err
 	}
-	return map[string]any{
-		"type":    config.Type,
-		"command": config.Command,
-		"args":    config.Args,
+	return &VSCodeMCPServerConfig{
+		Args:    config.Args,
+		Command: config.Command,
+		Type:    config.Type,
 	}, nil
+}
+
+func parseExistingConfig(data []byte, existingData *map[string]any) error {
+	// Check if file is empty or only contains whitespace
+	if len(bytes.TrimSpace(data)) == 0 {
+		// File is empty, treat as new config
+		*existingData = make(map[string]any)
+	} else {
+		// Parse the JSON into a generic map to preserve all settings
+		if err := json.Unmarshal(data, &existingData); err != nil {
+			return fmt.Errorf("failed to unmarshal existing config: %w", err)
+		}
+	}
+	return nil
 }
 
 // handleVSCodeConfig handles the special case for VSCode mcp.json
@@ -259,15 +274,8 @@ func handleVSCodeConfig(configPath string) error {
 
 	// Check if the file exists
 	if data, err := os.ReadFile(configPath); err == nil {
-		// Check if file is empty or only contains whitespace
-		if len(strings.TrimSpace(string(data))) == 0 {
-			// File is empty, treat as new config
-			existingData = make(map[string]any)
-		} else {
-			// File is not empty, attempt to parse it
-			if err := json.Unmarshal(data, &existingData); err != nil {
-				return fmt.Errorf("failed to unmarshal existing vscode config: %w", err)
-			}
+		if err := parseExistingConfig(data, &existingData); err != nil {
+			return err
 		}
 
 		// Check if "servers" section exists
@@ -316,15 +324,8 @@ func handleStandardConfig(configPath string) error {
 
 	// Check if the file exists
 	if data, err := os.ReadFile(configPath); err == nil {
-		// Check if file is empty or only contains whitespace
-		if len(strings.TrimSpace(string(data))) == 0 {
-			// File is empty, treat as new config
-			existingData = make(map[string]any)
-		} else {
-			// Parse the JSON into a generic map to preserve all settings
-			if err := json.Unmarshal(data, &existingData); err != nil {
-				return fmt.Errorf("failed to unmarshal existing config: %w", err)
-			}
+		if err := parseExistingConfig(data, &existingData); err != nil {
+			return err
 		}
 
 		// Try to extract MCPServers from existing data
@@ -411,7 +412,7 @@ func SetupClient(clientStr string) error {
 		}
 	}
 
-	term.Infof("Ensure that %s is upgraded to the latest version and restarted so the changes can take effect.\n", client)
+	term.Infof("Ensure %s is upgraded to the latest version and restarted for mcp settings to take effect.\n", client)
 
 	return nil
 }

--- a/src/pkg/mcp/setup_test.go
+++ b/src/pkg/mcp/setup_test.go
@@ -445,7 +445,25 @@ func TestWriteConfig(t *testing.T) {
 			expectedError: true,
 		},
 		{
-			name:         "standard_config_new_file",
+			name:         "vscode_config_new_file_empty",
+			fileExists:   true,
+			vscodeConfig: true,
+			existingData: "",
+			expectedData: `{
+  "servers": {
+    "defang": {
+      "args": [
+        "mcp",
+        "serve"
+      ],
+      "command": %s,
+      "type": "stdio"
+    }
+  }
+}`,
+		},
+		{
+			name:         "standard_config_new_file_non_empty",
 			fileExists:   false,
 			existingData: "",
 			expectedData: `{
@@ -592,6 +610,22 @@ func TestWriteConfig(t *testing.T) {
 			fileExists:    true,
 			existingData:  `{"mcpServers": "not an object}`,
 			expectedError: true,
+		},
+		{
+			name:         "standard_config_new_file_empty",
+			fileExists:   true,
+			existingData: "",
+			expectedData: `{
+  "mcpServers": {
+    "defang": {
+      "command": %s,
+      "args": [
+        "mcp",
+        "serve"
+      ]
+    }
+  }
+}`,
 		},
 	}
 	for _, tt := range test {

--- a/src/pkg/mcp/setup_test.go
+++ b/src/pkg/mcp/setup_test.go
@@ -463,7 +463,7 @@ func TestWriteConfig(t *testing.T) {
 }`,
 		},
 		{
-			name:         "standard_config_new_file_non_empty",
+			name:         "standard_config_new_file",
 			fileExists:   false,
 			existingData: "",
 			expectedData: `{

--- a/src/pkg/mcp/setup_test.go
+++ b/src/pkg/mcp/setup_test.go
@@ -463,6 +463,24 @@ func TestWriteConfig(t *testing.T) {
 }`,
 		},
 		{
+			name:         "vscode_config_new_file_with_whitespace",
+			fileExists:   true,
+			vscodeConfig: true,
+			existingData: "   \t  \n ",
+			expectedData: `{
+  "servers": {
+    "defang": {
+      "args": [
+        "mcp",
+        "serve"
+      ],
+      "command": %s,
+      "type": "stdio"
+    }
+  }
+}`,
+		},
+		{
 			name:         "standard_config_new_file",
 			fileExists:   false,
 			existingData: "",
@@ -615,6 +633,22 @@ func TestWriteConfig(t *testing.T) {
 			name:         "standard_config_new_file_empty",
 			fileExists:   true,
 			existingData: "",
+			expectedData: `{
+  "mcpServers": {
+    "defang": {
+      "command": %s,
+      "args": [
+        "mcp",
+        "serve"
+      ]
+    }
+  }
+}`,
+		},
+		{
+			name:         "standard_config_new_file_with_whitespace",
+			fileExists:   true,
+			existingData: "   \t  \n ",
 			expectedData: `{
   "mcpServers": {
     "defang": {


### PR DESCRIPTION
## Description
Currently, when we run `defang mcp setup`, the command attempts to write the config. One edge case I didn’t account for is when an mcp.json file already exists but is empty or just has a bunch of white spaces. Right now, we don’t overwrite it (though we should, since it’s empty). If the file exists and contains invalid JSON, we just return an error.

I also updated the messaging to tell user to update their IDE to the new version for the best experenice.

This PR will fix the mention edge case.
<img width="603" height="81" alt="Screenshot 2025-09-19 at 5 19 06 PM" src="https://github.com/user-attachments/assets/b4c18a5a-255c-431c-9692-40c2eae72f25" />


<!-- Concise description of what this PR is tackling. -->

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

