### PR TITLE
avoid failing on empty mcp.json file

### DIFF
--- a/src/pkg/mcp/setup.go
+++ b/src/pkg/mcp/setup.go
@@ -259,9 +259,11 @@ func handleVSCodeConfig(configPath string) error {
 
 	// Check if the file exists
 	if data, err := os.ReadFile(configPath); err == nil {
-		// File exists, parse it
-		if err := json.Unmarshal(data, &existingData); err != nil {
-			return fmt.Errorf("failed to unmarshal existing vscode config %w", err)
+		if string(data) != "" {
+			// File exists and is not empty, try to parse it
+			if err := json.Unmarshal(data, &existingData); err != nil {
+				return fmt.Errorf("failed to unmarshal existing vscode config %w", err)
+			}
 		}
 
 		// Check if "servers" section exists


### PR DESCRIPTION
## Description

If `mcp.json` exists, but is empty, we would fail to parse it and so we would fail to proceed and configure our server. it seems reasonable to me that we can keep going : )

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

