### PR TITLE
handle SIGINT after starting MCP server

### DIFF
--- a/src/cmd/cli/command/mcp.go
+++ b/src/cmd/cli/command/mcp.go
@@ -62,8 +62,8 @@ var mcpServerCmd = &cobra.Command{
 
 		// Start the server
 		term.Println("Starting Defang MCP server")
-		if err := server.ServeStdio(s); err != nil {
-			return err
+		if err := server.NewStreamableHTTPServer(s).Start(":63546"); err != nil {
+			term.Error(err)
 		}
 
 		term.Println("Server shutdown")

--- a/src/cmd/cli/command/mcp.go
+++ b/src/cmd/cli/command/mcp.go
@@ -27,9 +27,10 @@ var mcpCmd = &cobra.Command{
 }
 
 var mcpServerCmd = &cobra.Command{
-	Use:   "serve",
-	Short: "Start defang MCP server",
-	Args:  cobra.NoArgs,
+	Use:     "serve",
+	Aliases: []string{"server"},
+	Short:   "Start defang MCP server",
+	Args:    cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		hideUpdate = true
 		authPort, _ := cmd.Flags().GetInt("auth-server")

--- a/src/cmd/cli/command/mcp.go
+++ b/src/cmd/cli/command/mcp.go
@@ -31,6 +31,7 @@ var mcpServerCmd = &cobra.Command{
 	Short: "Start defang MCP server",
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		hideUpdate = true
 		authPort, _ := cmd.Flags().GetInt("auth-server")
 		term.SetDebug(true)
 

--- a/src/pkg/mcp/setup.go
+++ b/src/pkg/mcp/setup.go
@@ -41,7 +41,7 @@ type VSCodeConfig struct {
 
 // VSCodeMCPServerConfig represents the configuration for a VSCode MCP server
 type VSCodeMCPServerConfig struct {
-	Type    string            `json:"type"`          // Required: "stdio" or "sse"
+	Type    string            `json:"type"`          // Required: "stdio" or "http"
 	Command string            `json:"command"`       // Required for stdio
 	Args    []string          `json:"args"`          // Required for stdio
 	URL     string            `json:"url,omitempty"` // Required for sse
@@ -229,7 +229,8 @@ func getVSCodeDefangMCPConfig() (*VSCodeMCPServerConfig, error) {
 		return nil, err
 	}
 	return &VSCodeMCPServerConfig{
-		Type:    "stdio",
+		Type:    "http",
+		URL:     "http://localhost:63546",
 		Command: currentPath,
 		Args:    []string{"mcp", "serve"},
 	}, nil
@@ -243,6 +244,7 @@ func getVSCodeServerConfig() (map[string]any, error) {
 	}
 	return map[string]any{
 		"type":    config.Type,
+		"url":     config.URL,
 		"command": config.Command,
 		"args":    config.Args,
 	}, nil

--- a/src/pkg/mcp/setup_test.go
+++ b/src/pkg/mcp/setup_test.go
@@ -276,7 +276,8 @@ func TestWriteConfig(t *testing.T) {
         "serve"
       ],
       "command": %s,
-      "type": "stdio"
+      "type": "http",
+      "url": "http://localhost:63546"
     }
   }
 }`,
@@ -299,7 +300,7 @@ func TestWriteConfig(t *testing.T) {
 					"Notion-Version": "2022-06-28"
 				}
 			},
-			"type": "stdio"
+			"type": "http"
 		},
 		"github": {
 			"url": "https://api.githubcopilot.com/mcp/"
@@ -330,7 +331,8 @@ func TestWriteConfig(t *testing.T) {
         "serve"
       ],
       "command": %s,
-      "type": "stdio"
+      "type": "http",
+      "url": "http://localhost:63546"
     },
     "github": {
       "url": "https://api.githubcopilot.com/mcp/"
@@ -347,7 +349,7 @@ func TestWriteConfig(t *testing.T) {
           "Notion-Version": "2022-06-28"
         }
       },
-      "type": "stdio"
+      "type": "http"
     }
   }
 }`,
@@ -409,7 +411,8 @@ func TestWriteConfig(t *testing.T) {
         "serve"
       ],
       "command": %s,
-      "type": "stdio"
+      "type": "http",
+      "url": "http://localhost:63546"
     },
     "github": {
       "url": "https://api.githubcopilot.com/mcp/"


### PR DESCRIPTION
## Description

* handle SIGINT after starting MCP server
* avoid preparing "update" text (the cli fetches version from fabric) when launching mcp server
* create a `defang mcp server` alias

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

