### PR TITLE
added support for different compose file(s)

### DIFF
--- a/src/pkg/mcp/tools/common.go
+++ b/src/pkg/mcp/tools/common.go
@@ -26,15 +26,12 @@ func configureLoader(request mcp.CallToolRequest) *compose.Loader {
 		term.Debug("Function invoked: compose.NewLoader")
 		return compose.NewLoader(compose.WithProjectName(projectName))
 	}
-	arguments := request.GetArguments()
-	composeFilePathsArgs, ok := arguments["compose_file_paths"]
-	if ok {
-		composeFilePaths, ok := composeFilePathsArgs.([]string)
-		if ok {
-			term.Debugf("Compose file paths provided: %s", composeFilePaths)
-			term.Debug("Function invoked: compose.NewLoader")
-			return compose.NewLoader(compose.WithPath(composeFilePaths...))
-		}
+
+	composeFilePathsArgs, err := request.RequireStringSlice("compose_file_paths")
+	if err == nil {
+		term.Debugf("Compose file paths provided: %s", composeFilePathsArgs)
+		term.Debug("Function invoked: compose.NewLoader")
+		return compose.NewLoader(compose.WithPath(composeFilePathsArgs...))
 	}
 
 	//TODO: Talk about using both project name and compose file paths

--- a/src/pkg/mcp/tools/tools.go
+++ b/src/pkg/mcp/tools/tools.go
@@ -12,6 +12,12 @@ import (
 
 var workingDirectoryOption = mcp.WithString("working_directory",
 	mcp.Description("Path to project's working directory"),
+	mcp.Required(),
+)
+
+var multipleComposeFilesOptions = mcp.WithArray("compose_file_paths",
+	mcp.Description("Path(s) to docker-compose files"),
+	mcp.Items(map[string]string{"type": "string"}),
 )
 
 func CollectTools(cluster string, authPort int, providerId *client.ProviderID) []server.ServerTool {
@@ -29,6 +35,7 @@ func CollectTools(cluster string, authPort int, providerId *client.ProviderID) [
 			Tool: mcp.NewTool("services",
 				mcp.WithDescription("List deployed services for the project in the current working directory"),
 				workingDirectoryOption,
+				multipleComposeFilesOptions,
 			),
 			Handler: func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 				cli := &DefaultCLI{}
@@ -40,6 +47,7 @@ func CollectTools(cluster string, authPort int, providerId *client.ProviderID) [
 			Tool: mcp.NewTool("deploy",
 				mcp.WithDescription("Deploy services using defang"),
 				workingDirectoryOption,
+				multipleComposeFilesOptions,
 			),
 			Handler: func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 				cli := &DefaultToolCLI{}
@@ -50,6 +58,7 @@ func CollectTools(cluster string, authPort int, providerId *client.ProviderID) [
 			Tool: mcp.NewTool("destroy",
 				mcp.WithDescription("Destroy deployed services for the project in the current working directory"),
 				workingDirectoryOption,
+				multipleComposeFilesOptions,
 			),
 			Handler: func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 				cli := &DefaultToolCLI{}
@@ -61,6 +70,7 @@ func CollectTools(cluster string, authPort int, providerId *client.ProviderID) [
 			Tool: mcp.NewTool("estimate",
 				mcp.WithDescription("Estimate the cost of deployed a Defang project."),
 				workingDirectoryOption,
+				multipleComposeFilesOptions,
 				mcp.WithString("provider",
 					mcp.Description("The cloud provider to estimate costs for. Supported options are AWS or GCP"),
 					mcp.DefaultString(strings.ToUpper(providerId.String())),
@@ -82,6 +92,7 @@ func CollectTools(cluster string, authPort int, providerId *client.ProviderID) [
 			Tool: mcp.NewTool("set_config",
 				mcp.WithDescription("Tail logs for a deployment."),
 				workingDirectoryOption,
+				multipleComposeFilesOptions,
 				mcp.WithString("key",
 					mcp.Description("The config key to set"),
 				),
@@ -99,6 +110,7 @@ func CollectTools(cluster string, authPort int, providerId *client.ProviderID) [
 			Tool: mcp.NewTool("remove_config",
 				mcp.WithDescription("Remove a config variable from the defang project"),
 				workingDirectoryOption,
+				multipleComposeFilesOptions,
 				mcp.WithString("key",
 					mcp.Description("The config key to remove"),
 				),
@@ -112,6 +124,7 @@ func CollectTools(cluster string, authPort int, providerId *client.ProviderID) [
 			Tool: mcp.NewTool("list_configs",
 				mcp.WithDescription("List config variables for the defang project"),
 				workingDirectoryOption,
+				multipleComposeFilesOptions,
 			),
 			Handler: func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 				cli := &DefaultToolCLI{}


### PR DESCRIPTION
## Description
Added support for any Compose file(s). This means it will either default to compose.yaml if none is specified, accept a combination of multiple Compose files, or work with a single non-standard Compose file.

I also think the working directory should be a required requirement because we rely on it. 

Below are results of BYOC and Playground during testing the changes:

Full path non-standard compose file estimate:
<img width="669" height="598" alt="Screenshot 2025-09-26 at 7 28 21 PM" src="https://github.com/user-attachments/assets/c3d0096c-fb91-4b50-bae8-95d994da53cf" />

non-standard compose file AWS BYOC deployment:
<img width="831" height="326" alt="Screenshot 2025-09-26 at 7 25 57 PM" src="https://github.com/user-attachments/assets/a240c92e-e19c-4a72-9f90-f51c028536dc" />

Two combine compose files playground deployment:
<img width="832" height="384" alt="Screenshot 2025-09-26 at 7 25 14 PM" src="https://github.com/user-attachments/assets/e14c9c7a-3dae-4155-82aa-93a830636c22" />

Standard compose, showing that backward compatibility is not broken:
<img width="662" height="336" alt="Screenshot 2025-09-26 at 8 05 04 PM" src="https://github.com/user-attachments/assets/7b8712bc-1bff-4626-818b-bbcbcab34db9" />


If it cannot find/failed on the compose file it tried it will try other compose files in the working directory:
<img width="670" height="1052" alt="Screenshot 2025-09-26 at 7 59 36 PM" src="https://github.com/user-attachments/assets/6c18db5b-fd34-41dd-8dc6-39e5bb4d7fa7" />


<!-- Concise description of what this PR is tackling. -->

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->
#1387 
## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

