### PR TITLE
allow HIGH_AVAILABILITY deployment_mode

### DIFF
--- a/src/pkg/mcp/tools/estimate.go
+++ b/src/pkg/mcp/tools/estimate.go
@@ -100,13 +100,11 @@ func handleEstimateTool(ctx context.Context, request mcp.CallToolRequest, provid
 		mode = defangv1.DeploymentMode_DEVELOPMENT
 	case "BALANCED":
 		mode = defangv1.DeploymentMode_STAGING
-	case "HIGH_AVAILABILITY":
-		mode = defangv1.DeploymentMode_PRODUCTION
-	case "HIGH AVAILABILITY":
+	case "HIGH_AVAILABILITY", "HIGH AVAILABILITY":
 		mode = defangv1.DeploymentMode_PRODUCTION
 	default:
 		term.Warn("Unknown deployment mode provided, defaulting to AFFORDABLE")
-		mode = defangv1.DeploymentMode_DEVELOPMENT
+		return mcp.NewToolResultError("Unknown deployment mode provided, please use one of AFFORDABLE, BALANCED or HIGH_AVAILABILITY"), fmt.Errorf("unknown deployment mode: %s", modeString)
 	}
 
 	term.Debugf("Deployment mode set to: %s", mode.String())

--- a/src/pkg/mcp/tools/estimate.go
+++ b/src/pkg/mcp/tools/estimate.go
@@ -100,6 +100,8 @@ func handleEstimateTool(ctx context.Context, request mcp.CallToolRequest, provid
 		mode = defangv1.DeploymentMode_DEVELOPMENT
 	case "BALANCED":
 		mode = defangv1.DeploymentMode_STAGING
+	case "HIGH_AVAILABILITY":
+		mode = defangv1.DeploymentMode_PRODUCTION
 	case "HIGH AVAILABILITY":
 		mode = defangv1.DeploymentMode_PRODUCTION
 	default:

--- a/src/pkg/mcp/tools/estimate.go
+++ b/src/pkg/mcp/tools/estimate.go
@@ -100,7 +100,7 @@ func handleEstimateTool(ctx context.Context, request mcp.CallToolRequest, provid
 		mode = defangv1.DeploymentMode_DEVELOPMENT
 	case "BALANCED":
 		mode = defangv1.DeploymentMode_STAGING
-	case "HIGH_AVAILABILITY", "HIGH AVAILABILITY":
+	case "HIGH_AVAILABILITY":
 		mode = defangv1.DeploymentMode_PRODUCTION
 	default:
 		term.Warn("Unknown deployment mode provided, defaulting to AFFORDABLE")

--- a/src/pkg/mcp/tools/estimate.go
+++ b/src/pkg/mcp/tools/estimate.go
@@ -103,7 +103,7 @@ func handleEstimateTool(ctx context.Context, request mcp.CallToolRequest, provid
 	case "HIGH_AVAILABILITY":
 		mode = defangv1.DeploymentMode_PRODUCTION
 	default:
-		term.Warn("Unknown deployment mode provided, defaulting to AFFORDABLE")
+		term.Warnf("Unknown deployment mode provided - %q", modeString)
 		return mcp.NewToolResultError("Unknown deployment mode provided, please use one of AFFORDABLE, BALANCED or HIGH_AVAILABILITY"), fmt.Errorf("unknown deployment mode: %s", modeString)
 	}
 

--- a/src/pkg/mcp/tools/estimate_test.go
+++ b/src/pkg/mcp/tools/estimate_test.go
@@ -132,7 +132,7 @@ func TestHandleEstimateTool(t *testing.T) {
 			expectedErrorContains: "no such file or directory",
 		},
 		{
-			name:             "unknown_deployment_mode_defaults",
+			name:             "unknown_deployment_mode_fails",
 			workingDirectory: ".",
 			deploymentMode:   "unknown-mode",
 			providerID:       client.ProviderAWS,
@@ -149,9 +149,9 @@ func TestHandleEstimateTool(t *testing.T) {
 				}
 				m.CapturedOutput = "Estimated cost: $15.00/month"
 			},
-			expectError:          false,
+			expectError:          true,
 			expectTextResult:     true,
-			expectedTextContains: "Successfully estimated the cost of the project to AWS",
+			expectedTextContains: "Unknown deployment mode provided, please use one of AFFORDABLE, BALANCED or HIGH_AVAILABILITY",
 		},
 		{
 			name:             "load_project_error",

--- a/src/pkg/mcp/tools/estimate_test.go
+++ b/src/pkg/mcp/tools/estimate_test.go
@@ -226,7 +226,7 @@ func TestHandleEstimateTool(t *testing.T) {
 		{
 			name:             "successful_estimate_high_availability_mode",
 			workingDirectory: ".",
-			deploymentMode:   "HIGH AVAILABILITY",
+			deploymentMode:   "HIGH_AVAILABILITY",
 			provider:         "GCP",
 			providerID:       client.ProviderGCP,
 			setupMock: func(m *MockEstimateCLI) {

--- a/src/pkg/mcp/tools/tools.go
+++ b/src/pkg/mcp/tools/tools.go
@@ -78,9 +78,9 @@ func CollectTools(cluster string, authPort int, providerId *client.ProviderID) [
 				),
 
 				mcp.WithString("deployment_mode",
-					mcp.Description("The deployment mode for the estimate. Options are AFFORDABLE, BALANCED or HIGH AVAILABILITY."),
+					mcp.Description("The deployment mode for the estimate. Options are AFFORDABLE, BALANCED or HIGH_AVAILABILITY."),
 					mcp.DefaultString("AFFORDABLE"),
-					mcp.Enum("AFFORDABLE", "BALANCED", "HIGH AVAILABILITY"),
+					mcp.Enum("AFFORDABLE", "BALANCED", "HIGH_AVAILABILITY"),
 				),
 			),
 			Handler: func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {


### PR DESCRIPTION
## Description

change the `estimate` tool parameter schema for `deployment_mode` to include `HIGH_AVAILABILITY`(with an underscore) instead of `HIGH AVAILABILITY` (with a space). It looks like the llm ignored it and added the underscore. 🤷  Probably possible that it will add the space at some point, so we're adding an error in the default case instead of defaulting to `AFFORDABLE`.

<img width="1000" height="1318" alt="image" src="https://github.com/user-attachments/assets/a9714ec5-d1cd-4d58-821f-8be16dea72f6" />

<!-- Concise description of what this PR is tackling. -->

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

