### PR TITLE
tracking  show nil in error

### DIFF
--- a/src/cmd/cli/command/commands.go
+++ b/src/cmd/cli/command/commands.go
@@ -348,7 +348,12 @@ var RootCmd = &cobra.Command{
 
 		// Use "defer" to track any errors that occur during the command
 		defer func() {
-			track.Cmd(cmd, "Invoked", P("args", args), P("err", err), P("non-interactive", nonInteractive), P("provider", providerID))
+			var errString = ""
+			if err != nil {
+				errString = err.Error()
+			}
+
+			track.Cmd(cmd, "Invoked", P("args", args), P("err", errString), P("non-interactive", nonInteractive), P("provider", providerID))
 		}()
 
 		// Do this first, since any errors will be printed to the console


### PR DESCRIPTION
## Description

Use error String if there is an error, otherwise empty string for "err" property in tracking event.

## Linked Issues

fixes #1352 

## Checklist

- [X] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

