### PR TITLE
Check if the err of set config is nil after enable secret manager api

### DIFF
--- a/src/pkg/cli/client/byoc/gcp/byoc.go
+++ b/src/pkg/cli/client/byoc/gcp/byoc.go
@@ -737,10 +737,12 @@ func (b *ByocGcp) PutConfig(ctx context.Context, req *defangv1.PutConfigRequest)
 			}
 			_, err = b.driver.CreateSecret(ctx, secretId)
 		}
-		if stat, ok := status.FromError(err); ok && stat.Code() == codes.AlreadyExists {
-			term.Debugf("Secret %q already exists", secretId)
-		} else {
-			return fmt.Errorf("failed to create secret %q: %w", secretId, err)
+		if err != nil {
+			if stat, ok := status.FromError(err); ok && stat.Code() == codes.AlreadyExists {
+				term.Debugf("Secret %q already exists", secretId)
+			} else {
+				return fmt.Errorf("failed to create secret %q: %w", secretId, err)
+			}
 		}
 	}
 	term.Debugf("Adding a new secret version for %q", secretId)


### PR DESCRIPTION
Fixes: https://github.com/DefangLabs/defang-mvp/issues/2290

## Description
We should check if the error is nil again after retry of `b.driver.CreateSecret` after enabling secret manager. Currently, if it succeeds, we still report a nil error.jk

## Linked Issues
https://github.com/DefangLabs/defang-mvp/issues/2290

- [x] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

