### PR TITLE
log deployment verbose only if it was set in compose up

### DIFF
--- a/src/pkg/cli/tail.go
+++ b/src/pkg/cli/tail.go
@@ -386,9 +386,7 @@ func logEntryPrintHandler(e *defangv1.LogEntry, options *TailOptions) error {
 		return nil
 	}
 
-	if options.Verbose {
-		printLogEntry(e, options)
-	}
+	printLogEntry(e, options)
 
 	// Detect end logging event
 	if options.EndEventDetectFunc != nil {
@@ -409,6 +407,7 @@ func printLogEntry(e *defangv1.LogEntry, options *TailOptions) {
 	if e.Stderr {
 		tsColor = termenv.ANSIBrightRed
 	}
+
 	var prefixLen int
 	trimmed := strings.TrimRight(e.Message, "\t\r\n ")
 	buf := term.NewMessageBuilder(term.StdoutCanColor())
@@ -440,7 +439,10 @@ func printLogEntry(e *defangv1.LogEntry, options *TailOptions) {
 		buf.WriteString(line)
 		buf.WriteRune('\n')
 	}
-	term.Print(buf.String())
+
+	if options.Verbose || e.Stderr {
+		term.Print(buf.String())
+	}
 }
 
 func valueOrDefault(value, def string) string {

--- a/src/pkg/cli/tail.go
+++ b/src/pkg/cli/tail.go
@@ -386,6 +386,20 @@ func logEntryPrintHandler(e *defangv1.LogEntry, options *TailOptions) error {
 		return nil
 	}
 
+	if options.Verbose {
+		printLogEntry(e, options)
+	}
+
+	// Detect end logging event
+	if options.EndEventDetectFunc != nil {
+		if err := options.EndEventDetectFunc(e); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func printLogEntry(e *defangv1.LogEntry, options *TailOptions) {
 	ts := e.Timestamp.AsTime()
 	tsString := ts.Local().Format(RFC3339Milli)
 	tsColor := termenv.ANSIBrightBlack
@@ -427,14 +441,6 @@ func logEntryPrintHandler(e *defangv1.LogEntry, options *TailOptions) error {
 		buf.WriteRune('\n')
 	}
 	term.Print(buf.String())
-
-	// Detect end logging event
-	if options.EndEventDetectFunc != nil {
-		if err := options.EndEventDetectFunc(e); err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 func valueOrDefault(value, def string) string {


### PR DESCRIPTION
## Description

Fix: "compose up" not automatically in "verbose" mode.

## Linked Issues

fixes #1462  

## Checklist

- [X] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

