### PR TITLE
typo on playground DNS

### DIFF
--- a/src/pkg/cli/client/playground.go
+++ b/src/pkg/cli/client/playground.go
@@ -107,7 +107,7 @@ func (g PlaygroundProvider) ServicePrivateDNS(name string) string {
 
 func (g PlaygroundProvider) ServicePublicDNS(name string, projectName string) string {
 	// TODO: Move this to fabric since we do not know what shard was assigned, placeholder for now
-	return dns.SafeLabel(string(g.GetTenantName())) + "-" + dns.SafeLabel(name) + "prod1b" + ".defang.dev"
+	return dns.SafeLabel(string(g.GetTenantName())) + "-" + dns.SafeLabel(name) + "." + "prod1b" + ".defang.dev"
 }
 
 func (g PlaygroundProvider) RemoteProjectName(ctx context.Context) (string, error) {


### PR DESCRIPTION
## Description
The public DNS still won’t work for the playground, since we need to know which shard it belongs to in Fabric. We also still need to include an extra “.” — just noting this to avoid confusion when reading the code in the future.

<!-- Concise description of what this PR is tackling. -->

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

