### PR TITLE
fix Makefile bug when running wo Nix

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,3 +1,5 @@
+SHELL := bash
+
 # VERSION is the version we should download and use.
 VERSION:=$(shell git describe --match=NeVeRmAtCh --always --dirty)
 


### PR DESCRIPTION
`make test` failed because Makefils use /bin/sh by default.

`set -o pipefail` is a Bashism, so it failed there.

Anyone running `make test` would hit this unless they were using an environment set up to make /bin/sh be bash.

This is an easy fix and how I start all GNU Makefiles.

