### PR TITLE
fix(estimate): tool response should show real provider

### DIFF
--- a/src/pkg/mcp/tools/estimate.go
+++ b/src/pkg/mcp/tools/estimate.go
@@ -96,5 +96,5 @@ func handleEstimateTool(ctx context.Context, request mcp.CallToolRequest, provid
 
 	estimateText := cli.CaptureTermOutput(mode, estimate)
 
-	return mcp.NewToolResultText("Successfully estimated the cost of the project to AWS:\n" + estimateText), nil
+	return mcp.NewToolResultText("Successfully estimated the cost of the project to " + providerID.Name() + ":\n" + estimateText), nil
 }

--- a/src/pkg/mcp/tools/estimate_test.go
+++ b/src/pkg/mcp/tools/estimate_test.go
@@ -244,7 +244,7 @@ func TestHandleEstimateTool(t *testing.T) {
 			},
 			expectError:          false,
 			expectTextResult:     true,
-			expectedTextContains: "Successfully estimated the cost of the project to AWS",
+			expectedTextContains: "Successfully estimated the cost of the project to Google Cloud Platform",
 		},
 	}
 


### PR DESCRIPTION
## Description

Estimate tool responds with "AWS" even though I did a GCP estimation.