### PR TITLE
HandleTermsOfServiceError is no longer necessary

### DIFF
--- a/src/pkg/mcp/common/common.go
+++ b/src/pkg/mcp/common/common.go
@@ -11,7 +11,6 @@ import (
 	"github.com/DefangLabs/defang/src/pkg/cli/compose"
 	"github.com/DefangLabs/defang/src/pkg/term"
 	defangv1 "github.com/DefangLabs/defang/src/protos/io/defang/v1"
-	"github.com/bufbuild/connect-go"
 	"github.com/mark3labs/mcp-go/mcp"
 )
 
@@ -54,18 +53,6 @@ func ConfigureLoader(request mcp.CallToolRequest) *compose.Loader {
 
 	term.Debug("Function invoked: compose.NewLoader")
 	return compose.NewLoader()
-}
-
-// HandleTermsOfServiceError checks if the error is related to terms of service not being accepted
-// and returns an appropriate error message if it is.
-// Returns nil if the error is not related to terms of service.
-func HandleTermsOfServiceError(err error) *mcp.CallToolResult {
-	if connect.CodeOf(err) == connect.CodeFailedPrecondition && strings.Contains(err.Error(), "terms of service") {
-		mcpResult := mcp.NewToolResultErrorFromErr("The operation failed because the terms of service were not accepted. Please accept the terms of service by logging in here: https://portal.defang.io/auth/login. Then try again.", err)
-		term.Debugf("MCP output error: %v", mcpResult)
-		return mcpResult
-	}
-	return nil
 }
 
 func HandleConfigError(err error) *mcp.CallToolResult {

--- a/src/pkg/mcp/common/common_test.go
+++ b/src/pkg/mcp/common/common_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/DefangLabs/defang/src/pkg/cli/client"
 	cliClient "github.com/DefangLabs/defang/src/pkg/cli/client"
 	defangv1 "github.com/DefangLabs/defang/src/protos/io/defang/v1"
-	"github.com/bufbuild/connect-go"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/stretchr/testify/assert"
 )
@@ -51,15 +50,6 @@ func TestConfigureLoaderBranches(t *testing.T) {
 	assert.NotNil(t, loader2)
 	loader3 := ConfigureLoader(makeReq(map[string]any{}))
 	assert.NotNil(t, loader3)
-}
-
-func TestHandleTermsOfServiceError(t *testing.T) {
-	origErr := connect.NewError(connect.CodeFailedPrecondition, errors.New("terms of service not accepted"))
-	res := HandleTermsOfServiceError(origErr)
-	assert.NotNil(t, res)
-	otherErr := errors.New("some other error")
-	res2 := HandleTermsOfServiceError(otherErr)
-	assert.Nil(t, res2)
 }
 
 func TestHandleConfigError(t *testing.T) {

--- a/src/pkg/mcp/tools/common.go
+++ b/src/pkg/mcp/tools/common.go
@@ -11,7 +11,6 @@ import (
 	"github.com/DefangLabs/defang/src/pkg/cli/compose"
 	"github.com/DefangLabs/defang/src/pkg/term"
 	defangv1 "github.com/DefangLabs/defang/src/protos/io/defang/v1"
-	"github.com/bufbuild/connect-go"
 	"github.com/mark3labs/mcp-go/mcp"
 )
 
@@ -42,18 +41,6 @@ func configureLoader(request mcp.CallToolRequest) *compose.Loader {
 
 	term.Debug("Function invoked: compose.NewLoader")
 	return compose.NewLoader()
-}
-
-// HandleTermsOfServiceError checks if the error is related to terms of service not being accepted
-// and returns an appropriate error message if it is.
-// Returns nil if the error is not related to terms of service.
-func HandleTermsOfServiceError(err error) *mcp.CallToolResult {
-	if connect.CodeOf(err) == connect.CodeFailedPrecondition && strings.Contains(err.Error(), "terms of service") {
-		mcpResult := mcp.NewToolResultErrorFromErr("The operation failed because the terms of service were not accepted. Please accept the terms of service by logging in here: https://portal.defang.io/auth/login. Then try again.", err)
-		term.Debugf("MCP output error: %v", mcpResult)
-		return mcpResult
-	}
-	return nil
 }
 
 func HandleConfigError(err error) *mcp.CallToolResult {

--- a/src/pkg/mcp/tools/common_test.go
+++ b/src/pkg/mcp/tools/common_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/DefangLabs/defang/src/pkg/cli/client"
 	cliClient "github.com/DefangLabs/defang/src/pkg/cli/client"
 	defangv1 "github.com/DefangLabs/defang/src/protos/io/defang/v1"
-	"github.com/bufbuild/connect-go"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/stretchr/testify/assert"
 )
@@ -51,15 +50,6 @@ func TestConfigureLoaderBranches(t *testing.T) {
 	assert.NotNil(t, loader2)
 	loader3 := configureLoader(makeReq(map[string]any{}))
 	assert.NotNil(t, loader3)
-}
-
-func TestHandleTermsOfServiceError(t *testing.T) {
-	origErr := connect.NewError(connect.CodeFailedPrecondition, errors.New("terms of service not accepted"))
-	res := HandleTermsOfServiceError(origErr)
-	assert.NotNil(t, res)
-	otherErr := errors.New("some other error")
-	res2 := HandleTermsOfServiceError(otherErr)
-	assert.Nil(t, res2)
 }
 
 func TestHandleConfigError(t *testing.T) {

--- a/src/pkg/mcp/tools/deploy.go
+++ b/src/pkg/mcp/tools/deploy.go
@@ -69,11 +69,7 @@ func handleDeployTool(ctx context.Context, request mcp.CallToolRequest, provider
 		err = fmt.Errorf("failed to compose up services: %w", err)
 		term.Error("Failed to compose up services", "error", err)
 
-		result := HandleTermsOfServiceError(err)
-		if result != nil {
-			return result, err
-		}
-		result = HandleConfigError(err)
+		result := HandleConfigError(err)
 		if result != nil {
 			return result, err
 		}

--- a/src/pkg/mcp/tools/destroy.go
+++ b/src/pkg/mcp/tools/destroy.go
@@ -68,11 +68,6 @@ func handleDestroyTool(ctx context.Context, request mcp.CallToolRequest, provide
 			return mcp.NewToolResultText("Project not found, nothing to destroy. Please use a valid project name, compose file path or project directory."), err
 		}
 
-		result := HandleTermsOfServiceError(err)
-		if result != nil {
-			return result, err
-		}
-
 		return mcp.NewToolResultErrorFromErr("Failed to send destroy request", err), err
 	}
 

--- a/src/pkg/mcp/tools/services.go
+++ b/src/pkg/mcp/tools/services.go
@@ -75,11 +75,6 @@ func handleServicesTool(ctx context.Context, request mcp.CallToolRequest, provid
 			return mcp.NewToolResultText(fmt.Sprintf("Project %s is not deployed in Playground", projectName)), err
 		}
 
-		result := HandleTermsOfServiceError(err)
-		if result != nil {
-			return result, err
-		}
-
 		term.Error("Failed to get services", "error", err)
 		return mcp.NewToolResultText("Failed to get services"), nil
 	}

--- a/src/pkg/mcp/tools/services_test.go
+++ b/src/pkg/mcp/tools/services_test.go
@@ -217,24 +217,6 @@ func TestHandleServicesToolWithMockCLI(t *testing.T) {
 			expectedProjectName: "test-project",
 		},
 		{
-			name:       "get_services_terms_of_service_error",
-			providerId: client.ProviderDefang,
-			requestArgs: map[string]interface{}{
-				"working_directory": ".",
-			},
-			mockCLI: &MockCLI{
-				MockClient:       &client.GrpcClient{},
-				MockProvider:     &client.PlaygroundProvider{},
-				MockProjectName:  "test-project",
-				GetServicesError: createConnectError(connect.CodeFailedPrecondition, "terms of service not accepted"),
-			},
-			expectedError:       true,
-			expectedResultError: true, // HandleTermsOfServiceError returns error result
-			errorMessage:        "terms of service not accepted",
-			expectedGetServices: true,
-			expectedProjectName: "test-project",
-		},
-		{
 			name:       "get_services_generic_error",
 			providerId: client.ProviderDefang,
 			requestArgs: map[string]interface{}{


### PR DESCRIPTION
## Description

after moving TOS acceptance to login page in auth.defang.io, fabric will not return this error to authenticated users, so we don't need to give this special handling in the mcp server.

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

