### PR TITLE
Support deploying to GCP as a service account

### DIFF
--- a/src/pkg/clouds/gcp/iam.go
+++ b/src/pkg/clouds/gcp/iam.go
@@ -244,6 +244,9 @@ func (gcp Gcp) EnsureUserHasServiceAccountRoles(ctx context.Context, user, servi
 
 	resource := fmt.Sprintf("projects/%s/serviceAccounts/%s", gcp.ProjectId, serviceAccount)
 	member := "user:" + user
+	if strings.HasSuffix(serviceAccount, ".iam.gserviceaccount.com") {
+		member = "serviceAccount:" + serviceAccount
+	}
 
 	policy, err := client.GetIamPolicy(ctx, &iampb.GetIamPolicyRequest{Resource: resource})
 	if err != nil {


### PR DESCRIPTION
## Description

Support deploying to GCP while authenticated as a service account. This is useful when deploying from a CI workflow when you want to use Workload Identity Federation to impersonate a service account

## Linked Issues

This is a dependency for https://github.com/DefangLabs/defang-mvp/pull/2285

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

