### PR TITLE
consolidate mcp logging

### DIFF
--- a/src/pkg/mcp/mcp_server.go
+++ b/src/pkg/mcp/mcp_server.go
@@ -8,6 +8,7 @@ import (
 	"github.com/DefangLabs/defang/src/pkg/mcp/prompts"
 	"github.com/DefangLabs/defang/src/pkg/mcp/resources"
 	"github.com/DefangLabs/defang/src/pkg/mcp/tools"
+	"github.com/DefangLabs/defang/src/pkg/term"
 	"github.com/DefangLabs/defang/src/pkg/track"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
@@ -33,8 +34,14 @@ type ToolTracker struct {
 func (t *ToolTracker) TrackTool(name string, handler server.ToolHandlerFunc) server.ToolHandlerFunc {
 	return func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		name := request.Params.Name
+		term.Debug("MCP Tool Called: " + name + " with params: " + fmt.Sprintf("%+v", request.Params))
 		track.Evt("MCP Tool Called", track.P("tool", name), track.P("client", t.client), track.P("cluster", t.cluster), track.P("provider", t.providerId))
 		resp, err := handler(ctx, request)
+		if err != nil {
+			term.Error("MCP Tool Failed: "+name, "error", err)
+		} else {
+			term.Debug("MCP Tool Succeeded: " + name)
+		}
 		track.Evt("MCP Tool Done", track.P("tool", name), track.P("client", t.client), track.P("cluster", t.cluster), track.P("provider", t.providerId), track.P("error", err))
 		return resp, err
 	}

--- a/src/pkg/mcp/tools/deploy.go
+++ b/src/pkg/mcp/tools/deploy.go
@@ -21,9 +21,6 @@ func handleDeployTool(ctx context.Context, request mcp.CallToolRequest, provider
 		return "", fmt.Errorf("no provider configured: %w", err)
 	}
 
-	// Get compose path
-	term.Debug("Compose up tool called - deploying services")
-
 	wd, err := request.RequireString("working_directory")
 	if err != nil || wd == "" {
 		return "", fmt.Errorf("invalid working directory: %w", err)

--- a/src/pkg/mcp/tools/destroy.go
+++ b/src/pkg/mcp/tools/destroy.go
@@ -14,7 +14,6 @@ import (
 )
 
 func handleDestroyTool(ctx context.Context, request mcp.CallToolRequest, providerId *cliClient.ProviderID, cluster string, cli DestroyCLIInterface) (string, error) {
-	term.Debug("Compose down tool called - removing services")
 	err := common.ProviderNotConfiguredError(*providerId)
 	if err != nil {
 		return "", fmt.Errorf("No provider configured: %w", err)

--- a/src/pkg/mcp/tools/estimate.go
+++ b/src/pkg/mcp/tools/estimate.go
@@ -15,8 +15,6 @@ import (
 )
 
 func handleEstimateTool(ctx context.Context, request mcp.CallToolRequest, providerId *cliClient.ProviderID, cluster string, cli EstimateCLIInterface) (string, error) {
-	term.Debug("Estimate tool called")
-
 	wd, err := request.RequireString("working_directory")
 	if err != nil || wd == "" {
 		term.Error("Invalid working directory", "error", errors.New("working_directory is required"))

--- a/src/pkg/mcp/tools/listConfig.go
+++ b/src/pkg/mcp/tools/listConfig.go
@@ -15,8 +15,6 @@ import (
 
 // handleListConfigTool handles the list config tool logic
 func handleListConfigTool(ctx context.Context, request mcp.CallToolRequest, providerId *cliClient.ProviderID, cluster string, cli ListConfigCLIInterface) (string, error) {
-	term.Debug("List Config tool called")
-
 	err := common.ProviderNotConfiguredError(*providerId)
 	if err != nil {
 		return "", fmt.Errorf("No provider configured: %w", err)

--- a/src/pkg/mcp/tools/login.go
+++ b/src/pkg/mcp/tools/login.go
@@ -8,10 +8,7 @@ import (
 )
 
 // handleLoginTool handles the login tool logic
-func handleLoginTool(ctx context.Context, request mcp.CallToolRequest, cluster string, authPort int, cli LoginCLIInterface) (string, error) {
-	term.Debug("Login tool called")
-	term.Debugf("mcp.CallToolRequest %+v", request)
-
+func handleLoginTool(ctx context.Context, _ mcp.CallToolRequest, cluster string, authPort int, cli LoginCLIInterface) (string, error) {
 	// Test token
 	term.Debug("Function invoked: cli.Connect")
 	client, err := cli.Connect(ctx, cluster)

--- a/src/pkg/mcp/tools/logs.go
+++ b/src/pkg/mcp/tools/logs.go
@@ -9,13 +9,10 @@ import (
 	cliTypes "github.com/DefangLabs/defang/src/pkg/cli"
 	cliClient "github.com/DefangLabs/defang/src/pkg/cli/client"
 	"github.com/DefangLabs/defang/src/pkg/term"
-	"github.com/DefangLabs/defang/src/pkg/track"
 	"github.com/mark3labs/mcp-go/mcp"
 )
 
 func handleLogsTool(ctx context.Context, request mcp.CallToolRequest, cluster string, providerId *cliClient.ProviderID, cli LogsCLIInterface) (string, error) {
-	term.Debug("Tail tool called - opening logs in browser")
-	track.Evt("MCP Tail Tool")
 	wd, err := request.RequireString("working_directory")
 	if err != nil || wd == "" {
 		return "", err

--- a/src/pkg/mcp/tools/removeConfig.go
+++ b/src/pkg/mcp/tools/removeConfig.go
@@ -15,8 +15,6 @@ import (
 
 // handleRemoveConfigTool handles the remove config tool logic
 func handleRemoveConfigTool(ctx context.Context, request mcp.CallToolRequest, providerId *cliClient.ProviderID, cluster string, cli RemoveConfigCLIInterface) (string, error) {
-	term.Debug("Remove Config tool called")
-
 	err := common.ProviderNotConfiguredError(*providerId)
 	if err != nil {
 		return "", fmt.Errorf("No provider configured: %w", err)

--- a/src/pkg/mcp/tools/services.go
+++ b/src/pkg/mcp/tools/services.go
@@ -17,8 +17,6 @@ import (
 )
 
 func handleServicesTool(ctx context.Context, request mcp.CallToolRequest, providerId *cliClient.ProviderID, cluster string, cli CLIInterface) (string, error) {
-	term.Debug("Services tool called - fetching services from Defang")
-
 	err := common.ProviderNotConfiguredError(*providerId)
 	if err != nil {
 		return "", fmt.Errorf("no provider configured: %w", err)

--- a/src/pkg/mcp/tools/setAWSProvider.go
+++ b/src/pkg/mcp/tools/setAWSProvider.go
@@ -6,14 +6,11 @@ import (
 
 	cliClient "github.com/DefangLabs/defang/src/pkg/cli/client"
 	"github.com/DefangLabs/defang/src/pkg/mcp/actions"
-	"github.com/DefangLabs/defang/src/pkg/term"
 	"github.com/mark3labs/mcp-go/mcp"
 )
 
 // handleSetAWSProvider handles the set AWS provider MCP tool request
 func handleSetAWSProvider(ctx context.Context, request mcp.CallToolRequest, providerId *cliClient.ProviderID, cluster string) (string, error) {
-	term.Debug("Set AWS Provider tool called")
-
 	awsId, err := request.RequireString("accessKeyId")
 	if err != nil {
 		return "", fmt.Errorf("Invalid AWS access key Id: %w", err)

--- a/src/pkg/mcp/tools/setConfig.go
+++ b/src/pkg/mcp/tools/setConfig.go
@@ -14,8 +14,6 @@ import (
 
 // handleSetConfig handles the set config MCP tool request
 func handleSetConfig(ctx context.Context, request mcp.CallToolRequest, providerId *cliClient.ProviderID, cluster string, cli SetConfigCLIInterface) (string, error) {
-	term.Debug("Set Config tool called")
-
 	err := common.ProviderNotConfiguredError(*providerId)
 	if err != nil {
 		return "", fmt.Errorf("No provider configured: %w", err)

--- a/src/pkg/mcp/tools/setGCPProvider.go
+++ b/src/pkg/mcp/tools/setGCPProvider.go
@@ -6,14 +6,11 @@ import (
 
 	cliClient "github.com/DefangLabs/defang/src/pkg/cli/client"
 	"github.com/DefangLabs/defang/src/pkg/mcp/actions"
-	"github.com/DefangLabs/defang/src/pkg/term"
 	"github.com/mark3labs/mcp-go/mcp"
 )
 
 // handleSetGCPProvider handles the set GCP provider MCP tool request
 func handleSetGCPProvider(ctx context.Context, request mcp.CallToolRequest, providerId *cliClient.ProviderID, cluster string) (string, error) {
-	term.Debug("Set GCP Provider tool called")
-
 	gcpProjectID, err := request.RequireString("gcpProjectId")
 	if err != nil {
 		return "", fmt.Errorf("Invalid GCP project ID: %w", err)

--- a/src/pkg/mcp/tools/setPlaygroundProvider.go
+++ b/src/pkg/mcp/tools/setPlaygroundProvider.go
@@ -5,12 +5,10 @@ import (
 
 	cliClient "github.com/DefangLabs/defang/src/pkg/cli/client"
 	"github.com/DefangLabs/defang/src/pkg/mcp/actions"
-	"github.com/DefangLabs/defang/src/pkg/term"
 )
 
 // handleSetPlaygroundProvider handles the set Playground provider MCP tool request
 func handleSetPlaygroundProvider(providerId *cliClient.ProviderID) (string, error) {
-	term.Debug("Set Playground Provider tool called")
 	if err := actions.SetPlaygroundProvider(providerId); err != nil {
 		return "", fmt.Errorf("Failed to set Playground provider: %w", err)
 	}

--- a/src/pkg/mcp/tools/tools.go
+++ b/src/pkg/mcp/tools/tools.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/DefangLabs/defang/src/pkg/cli/client"
 	"github.com/DefangLabs/defang/src/pkg/modes"
-	"github.com/DefangLabs/defang/src/pkg/term"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 )
@@ -32,7 +31,6 @@ func CollectTools(cluster string, authPort int, providerId *client.ProviderID) [
 				cli := &DefaultToolCLI{}
 				output, err := handleLoginTool(ctx, request, cluster, authPort, &LoginCLIAdapter{DefaultToolCLI: cli})
 				if err != nil {
-					term.Errorf("Login tool failed: %v", err)
 					return mcp.NewToolResultErrorFromErr("Failed to login", err), err
 				}
 				return mcp.NewToolResultText(output), nil
@@ -48,7 +46,6 @@ func CollectTools(cluster string, authPort int, providerId *client.ProviderID) [
 				var cli CLIInterface = &DefaultToolCLI{}
 				output, err := handleServicesTool(ctx, request, providerId, cluster, cli)
 				if err != nil {
-					term.Errorf("Services tool failed: %v", err)
 					return mcp.NewToolResultErrorFromErr("Failed to list services", err), err
 				}
 				return mcp.NewToolResultText(output), nil
@@ -64,7 +61,6 @@ func CollectTools(cluster string, authPort int, providerId *client.ProviderID) [
 				cli := &DefaultToolCLI{}
 				output, err := handleDeployTool(ctx, request, providerId, cluster, cli)
 				if err != nil {
-					term.Errorf("Deploy tool failed: %v", err)
 					return mcp.NewToolResultErrorFromErr("Failed to deploy services", err), err
 				}
 				return mcp.NewToolResultText(output), nil
@@ -80,7 +76,6 @@ func CollectTools(cluster string, authPort int, providerId *client.ProviderID) [
 				cli := &DefaultToolCLI{}
 				output, err := handleDestroyTool(ctx, request, providerId, cluster, cli)
 				if err != nil {
-					term.Errorf("Destroy tool failed: %v", err)
 					return mcp.NewToolResultErrorFromErr("Failed to destroy services", err), err
 				}
 				return mcp.NewToolResultText(output), nil
@@ -108,7 +103,6 @@ func CollectTools(cluster string, authPort int, providerId *client.ProviderID) [
 				cli := &DefaultToolCLI{}
 				output, err := handleLogsTool(ctx, request, cluster, providerId, cli)
 				if err != nil {
-					term.Errorf("Logs tool failed: %v", err)
 					return mcp.NewToolResultErrorFromErr("Failed to fetch logs", err), err
 				}
 				return mcp.NewToolResultText(output), nil
@@ -134,7 +128,6 @@ func CollectTools(cluster string, authPort int, providerId *client.ProviderID) [
 				cli := &DefaultToolCLI{}
 				output, err := handleEstimateTool(ctx, request, providerId, cluster, cli)
 				if err != nil {
-					term.Errorf("Estimate tool failed: %v", err)
 					return mcp.NewToolResultErrorFromErr("Failed to estimate costs", err), err
 				}
 				return mcp.NewToolResultText(output), nil
@@ -157,7 +150,6 @@ func CollectTools(cluster string, authPort int, providerId *client.ProviderID) [
 				adapter := &SetConfigCLIAdapter{DefaultToolCLI: cli}
 				output, err := handleSetConfig(ctx, request, providerId, cluster, adapter)
 				if err != nil {
-					term.Errorf("Set config tool failed: %v", err)
 					return mcp.NewToolResultErrorFromErr("Failed to set config", err), err
 				}
 				return mcp.NewToolResultText(output), nil
@@ -176,7 +168,6 @@ func CollectTools(cluster string, authPort int, providerId *client.ProviderID) [
 				cli := &DefaultToolCLI{}
 				output, err := handleRemoveConfigTool(ctx, request, providerId, cluster, &RemoveConfigCLIAdapter{DefaultToolCLI: cli})
 				if err != nil {
-					term.Errorf("Remove config tool failed: %v", err)
 					return mcp.NewToolResultErrorFromErr("Failed to remove config", err), err
 				}
 				return mcp.NewToolResultText(output), nil
@@ -192,7 +183,6 @@ func CollectTools(cluster string, authPort int, providerId *client.ProviderID) [
 				cli := &DefaultToolCLI{}
 				output, err := handleListConfigTool(ctx, request, providerId, cluster, &ListConfigCLIAdapter{DefaultToolCLI: cli})
 				if err != nil {
-					term.Errorf("List config tool failed: %v", err)
 					return mcp.NewToolResultErrorFromErr("Failed to list config", err), err
 				}
 				return mcp.NewToolResultText(output), nil
@@ -215,7 +205,6 @@ func CollectTools(cluster string, authPort int, providerId *client.ProviderID) [
 			Handler: func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 				output, err := handleSetAWSProvider(ctx, request, providerId, cluster)
 				if err != nil {
-					term.Errorf("Set AWS provider tool failed: %v", err)
 					return mcp.NewToolResultErrorFromErr("Failed to set AWS provider", err), err
 				}
 				return mcp.NewToolResultText(output), nil
@@ -232,7 +221,6 @@ func CollectTools(cluster string, authPort int, providerId *client.ProviderID) [
 			Handler: func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 				output, err := handleSetGCPProvider(ctx, request, providerId, cluster)
 				if err != nil {
-					term.Errorf("Set GCP provider tool failed: %v", err)
 					return mcp.NewToolResultErrorFromErr("Failed to set GCP provider", err), err
 				}
 				return mcp.NewToolResultText(output), nil
@@ -246,7 +234,6 @@ func CollectTools(cluster string, authPort int, providerId *client.ProviderID) [
 			Handler: func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 				output, err := handleSetPlaygroundProvider(providerId)
 				if err != nil {
-					term.Errorf("Set Playground provider tool failed: %v", err)
 					return mcp.NewToolResultErrorFromErr("Failed to set Playground provider", err), err
 				}
 				return mcp.NewToolResultText(output), nil


### PR DESCRIPTION
## Description

Consolidating MCP debug and error logging into the tracking wrapper. This way we can keep our handler functions lean and we can keep our log lines consistent 

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

