### PR TITLE
fix: suppress env warnings during config set

### DIFF
--- a/src/cmd/cli/command/compose.go
+++ b/src/cmd/cli/command/compose.go
@@ -5,8 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
-	"path/filepath"
 	"slices"
 	"strings"
 	"time"
@@ -27,31 +25,6 @@ import (
 	"github.com/bufbuild/connect-go"
 	"github.com/spf13/cobra"
 )
-
-func createProjectForDebug(loader *compose.Loader) (*compose.Project, error) {
-	projOpts, err := loader.NewProjectOptions()
-	if err != nil {
-		return nil, err
-	}
-
-	// get the project name
-	if projOpts.Name == "" {
-		dir, err := os.Getwd()
-		if err != nil {
-			return nil, err
-		}
-
-		projOpts.Name = filepath.Base(dir)
-	}
-	project := &compose.Project{
-		Name:         projOpts.Name,
-		WorkingDir:   projOpts.WorkingDir,
-		Environment:  projOpts.Environment,
-		ComposeFiles: projOpts.ConfigPaths,
-	}
-
-	return project, nil
-}
 
 func makeComposeUpCmd() *cobra.Command {
 	composeUpCmd := &cobra.Command{
@@ -86,7 +59,7 @@ func makeComposeUpCmd() *cobra.Command {
 				}
 
 				term.Error("Cannot load project:", loadErr)
-				project, err := createProjectForDebug(loader)
+				project, err := loader.CreateProjectForDebug()
 				if err != nil {
 					return err
 				}
@@ -451,7 +424,7 @@ func makeComposeConfigCmd() *cobra.Command {
 				}
 
 				term.Error("Cannot load project:", loadErr)
-				project, err := createProjectForDebug(loader)
+				project, err := loader.CreateProjectForDebug()
 				if err != nil {
 					return err
 				}

--- a/src/pkg/cli/compose/compose_test.go
+++ b/src/pkg/cli/compose/compose_test.go
@@ -14,10 +14,12 @@ func TestLoadProjectName(t *testing.T) {
 		"tests":          "../../../testdata/testproj/compose.yaml",
 		"fancy-proj_dir": "../../../testdata/Fancy-Proj_Dir/compose.yaml",
 		"altcomp":        "../../../testdata/alttestproj/altcomp.yaml",
+		"interpolate":    "../../../testdata/interpolate/compose.yaml",
 	}
 
 	for expectedName, path := range tests {
 		t.Run("Load project name from compose file or directory:"+expectedName, func(t *testing.T) {
+			t.Setenv("POSTGRES_PASSWORD", "example") // used in interpolate/compose.yaml for warning test
 			loader := NewLoader(WithPath(path))
 			name, err := loader.LoadProjectName(t.Context())
 			if err != nil {
@@ -25,6 +27,9 @@ func TestLoadProjectName(t *testing.T) {
 			}
 			if name != expectedName {
 				t.Errorf("LoadProjectName() failed: expected project name %q, got %q", expectedName, name)
+			}
+			if term.HadWarnings() {
+				t.Errorf("LoadProjectName() failed: unexpected warnings")
 			}
 		})
 	}

--- a/src/pkg/cli/compose/fixup_test.go
+++ b/src/pkg/cli/compose/fixup_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestFixup(t *testing.T) {
-	testRunCompose(t, func(t *testing.T, path string) {
+	testAllComposeFiles(t, func(t *testing.T, path string) {
 		loader := NewLoader(WithPath(path))
 		proj, err := loader.LoadProject(t.Context())
 		if err != nil {

--- a/src/pkg/cli/compose/load_content_test.go
+++ b/src/pkg/cli/compose/load_content_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestRoundTrip(t *testing.T) {
-	testRunCompose(t, func(t *testing.T, path string) {
+	testAllComposeFiles(t, func(t *testing.T, path string) {
 		loader := NewLoader(WithPath(path))
 		p, err := loader.LoadProject(t.Context())
 		if err != nil {

--- a/src/pkg/cli/compose/loader_test.go
+++ b/src/pkg/cli/compose/loader_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestLoader(t *testing.T) {
-	testRunCompose(t, func(t *testing.T, path string) {
+	testAllComposeFiles(t, func(t *testing.T, path string) {
 		loader := NewLoader(WithPath(path))
 		proj, err := loader.LoadProject(t.Context())
 		if err != nil {
@@ -29,7 +29,7 @@ func TestLoader(t *testing.T) {
 	})
 }
 
-func testRunCompose(t *testing.T, f func(t *testing.T, path string)) {
+func testAllComposeFiles(t *testing.T, f func(t *testing.T, path string)) {
 	t.Helper()
 
 	composeRegex := regexp.MustCompile(`^(?i)(docker-)?compose.ya?ml$`)

--- a/src/pkg/cli/compose/validation_test.go
+++ b/src/pkg/cli/compose/validation_test.go
@@ -35,7 +35,7 @@ func TestValidationAndConvert(t *testing.T) {
 		return configs.Names, nil
 	}
 
-	testRunCompose(t, func(t *testing.T, path string) {
+	testAllComposeFiles(t, func(t *testing.T, path string) {
 		logs := new(bytes.Buffer)
 		term.DefaultTerm = term.NewTerm(os.Stdin, logs, logs)
 


### PR DESCRIPTION
## Description

When we only need the project name (for example, when setting config), we need to load the compose file, but don't need to show warnings during loading.

* Added a new bool param `suppressWarn` to *private* `Loader` funcs.

## Linked Issues

Fixes #1413 

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

