### PR TITLE
feat(up): warn on prod w/o replicas

### DIFF
--- a/src/pkg/cli/compose/validation.go
+++ b/src/pkg/cli/compose/validation.go
@@ -16,6 +16,7 @@ import (
 	"github.com/DefangLabs/defang/src/pkg"
 	"github.com/DefangLabs/defang/src/pkg/clouds/gcp"
 	"github.com/DefangLabs/defang/src/pkg/term"
+	defangv1 "github.com/DefangLabs/defang/src/protos/io/defang/v1"
 	composeTypes "github.com/compose-spec/compose-go/v2/types"
 )
 
@@ -29,7 +30,7 @@ func (e ErrMissingConfig) Error() string {
 
 var ErrDockerfileNotFound = errors.New("dockerfile not found")
 
-func ValidateProject(project *composeTypes.Project) error {
+func ValidateProject(project *composeTypes.Project, mode defangv1.DeploymentMode) error {
 	if project == nil {
 		return errors.New("no project found")
 	}
@@ -44,14 +45,10 @@ func ValidateProject(project *composeTypes.Project) error {
 
 	var errs []error
 	for _, svccfg := range services {
-		errs = append(errs, validateService(&svccfg, project))
+		errs = append(errs, validateService(&svccfg, project, mode))
 	}
 	for i, svccfg := range services {
 		for j := i + 1; j < len(services); j++ {
-			if svccfg.Name == services[j].Name {
-				errs = append(errs, fmt.Errorf("service %q defined multiple times", svccfg.Name))
-				continue
-			}
 			if gcp.SafeLabelValue(svccfg.Name) == gcp.SafeLabelValue(services[j].Name) { // TODO: Shouldn't be just gcp specific
 				errs = append(errs, fmt.Errorf("the service names %q and %q normalize to the same value, which causes a conflict. Please use distinct names that differ after normalization", svccfg.Name, services[j].Name))
 			}
@@ -60,7 +57,7 @@ func ValidateProject(project *composeTypes.Project) error {
 	return errors.Join(errs...)
 }
 
-func validateService(svccfg *composeTypes.ServiceConfig, project *composeTypes.Project) error {
+func validateService(svccfg *composeTypes.ServiceConfig, project *composeTypes.Project, mode defangv1.DeploymentMode) error {
 	if svccfg.ReadOnly {
 		term.Debugf("service %q: unsupported compose directive: read_only", svccfg.Name)
 	}
@@ -265,6 +262,7 @@ func validateService(svccfg *composeTypes.ServiceConfig, project *composeTypes.P
 			term.Debugf("service %q: unsupported compose directive: healthcheck start_interval", svccfg.Name)
 		}
 	}
+	var replicas int
 	var reservations *composeTypes.Resource
 	if svccfg.Deploy != nil {
 		if svccfg.Deploy.Mode != "" && svccfg.Deploy.Mode != "replicated" {
@@ -295,6 +293,12 @@ func validateService(svccfg *composeTypes.ServiceConfig, project *composeTypes.P
 		if len(svccfg.Deploy.Placement.Constraints) != 0 || len(svccfg.Deploy.Placement.Preferences) != 0 || svccfg.Deploy.Placement.MaxReplicas != 0 {
 			term.Debugf("service %q: unsupported compose directive: deploy placement", svccfg.Name)
 		}
+		if svccfg.Deploy.Replicas != nil {
+			replicas = *svccfg.Deploy.Replicas
+		}
+	}
+	if mode == defangv1.DeploymentMode_PRODUCTION && replicas < 2 && svccfg.Extensions["x-defang-autoscaling"] == nil {
+		term.Warnf("service %q: high-availability mode requires at least 2 replicas or x-defang-autoscaling", svccfg.Name)
 	}
 	if reservations == nil || reservations.MemoryBytes == 0 {
 		// Don't show this warning for managed pseudo-services like CDN

--- a/src/pkg/cli/compose/validation_test.go
+++ b/src/pkg/cli/compose/validation_test.go
@@ -56,7 +56,11 @@ func TestValidationAndConvert(t *testing.T) {
 			logs.WriteString(err.Error() + "\n")
 		}
 
-		if err := ValidateProject(project); err != nil {
+		mode := defangv1.DeploymentMode_DEVELOPMENT
+		if strings.Contains(path, "replicas") {
+			mode = defangv1.DeploymentMode_PRODUCTION
+		}
+		if err := ValidateProject(project, mode); err != nil {
 			t.Logf("Project validation failed: %v", err)
 			logs.WriteString(err.Error() + "\n")
 		}

--- a/src/pkg/cli/composeUp.go
+++ b/src/pkg/cli/composeUp.go
@@ -55,7 +55,7 @@ func ComposeUp(ctx context.Context, project *compose.Project, fabric client.Fabr
 		return nil, project, err
 	}
 
-	if err := compose.ValidateProject(fixedProject); err != nil {
+	if err := compose.ValidateProject(fixedProject, mode); err != nil {
 		return nil, project, &ComposeError{err}
 	}
 

--- a/src/testdata/replicas/compose.yaml
+++ b/src/testdata/replicas/compose.yaml
@@ -1,0 +1,17 @@
+services:
+  default:
+    image: nginx:latest
+  replicated:
+    image: nginx:latest
+    deploy:
+      replicas: 3
+  autoscaled:
+    image: nginx:latest
+    x-defang-autoscaling: true
+  deploy:
+    image: nginx:latest
+    deploy:
+      resources:
+        reservations:
+          memory: 256M
+          cpus: "0.25"

--- a/src/testdata/replicas/compose.yaml.fixup
+++ b/src/testdata/replicas/compose.yaml.fixup
@@ -1,0 +1,48 @@
+{
+  "autoscaled": {
+    "command": null,
+    "entrypoint": null,
+    "image": "nginx:latest",
+    "networks": {
+      "default": null
+    }
+  },
+  "default": {
+    "command": null,
+    "entrypoint": null,
+    "image": "nginx:latest",
+    "networks": {
+      "default": null
+    }
+  },
+  "deploy": {
+    "command": null,
+    "deploy": {
+      "resources": {
+        "reservations": {
+          "cpus": 0.25,
+          "memory": "268435456"
+        }
+      },
+      "placement": {}
+    },
+    "entrypoint": null,
+    "image": "nginx:latest",
+    "networks": {
+      "default": null
+    }
+  },
+  "replicated": {
+    "command": null,
+    "deploy": {
+      "replicas": 3,
+      "resources": {},
+      "placement": {}
+    },
+    "entrypoint": null,
+    "image": "nginx:latest",
+    "networks": {
+      "default": null
+    }
+  }
+}

--- a/src/testdata/replicas/compose.yaml.golden
+++ b/src/testdata/replicas/compose.yaml.golden
@@ -1,0 +1,29 @@
+name: replicas
+services:
+  autoscaled:
+    image: nginx:latest
+    networks:
+      default: null
+    x-defang-autoscaling: true
+  default:
+    image: nginx:latest
+    networks:
+      default: null
+  deploy:
+    deploy:
+      resources:
+        reservations:
+          cpus: 0.25
+          memory: "268435456"
+    image: nginx:latest
+    networks:
+      default: null
+  replicated:
+    deploy:
+      replicas: 3
+    image: nginx:latest
+    networks:
+      default: null
+networks:
+  default:
+    name: replicas_default

--- a/src/testdata/replicas/compose.yaml.warnings
+++ b/src/testdata/replicas/compose.yaml.warnings
@@ -1,0 +1,5 @@
+ ! service "autoscaled": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors
+ ! service "default": high-availability mode requires at least 2 replicas or x-defang-autoscaling
+ ! service "default": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors
+ ! service "deploy": high-availability mode requires at least 2 replicas or x-defang-autoscaling
+ ! service "replicated": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors


### PR DESCRIPTION
## Description

Warn when deploying HA without replicas, because it won't actually be highly available.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary
