### PR TITLE
add "user:" prefix to fallback principal cases

### DIFF
--- a/src/pkg/clouds/gcp/account.go
+++ b/src/pkg/clouds/gcp/account.go
@@ -54,12 +54,16 @@ func (gcp Gcp) GetCurrentPrincipal(ctx context.Context) (string, error) {
 	// Try to extract email from id_token if present
 	if idToken, ok := token.Extra("id_token").(string); ok && idToken != "" {
 		if email, err := extractEmailFromIDToken(idToken); err == nil && email != "" {
-			return email, nil
+			return "user:" + email, nil
 		}
 	}
 
 	// Last resort: query tokeninfo endpoint
-	return getEmailFromToken(ctx, token.AccessToken)
+	email, err := getEmailFromToken(ctx, token.AccessToken)
+	if err != nil {
+		return "", fmt.Errorf("failed to get email from token: %w", err)
+	}
+	return "user:" + email, nil
 }
 
 func extractEmailFromIDToken(idToken string) (string, error) {

--- a/src/pkg/clouds/gcp/account_test.go
+++ b/src/pkg/clouds/gcp/account_test.go
@@ -53,7 +53,7 @@ func TestGetCurrentAccountPrincipal(t *testing.T) {
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
-		expected := "test@email.com"
+		expected := "user:test@email.com"
 		if principal != expected {
 			t.Errorf("expected principal to be %s, got %s", expected, principal)
 		}


### PR DESCRIPTION
## Description

We see this error when deploying to GCP:
```
* Updating IAM policy for eric.liu@defang.io on service account defang-upload@eric-test-project-447121.iam.gserviceaccount.com
Error: failed to set IAM policy for service account defang-upload@eric-test-project-447121.iam.gserviceaccount.com: rpc error: code = InvalidArgument desc = The member eric.liu@defang.io is of an unknown type. Please set a valid type prefix for the member.
```

I missed two cases in #1517 where I moved the `user:` prefix from `EnsureUserHasServiceAccountRoles` into `GetCurrentPrincipal`.

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

