### PR TITLE
Assume email from idToken is of type "user" for getting principal

### DIFF
--- a/src/pkg/clouds/gcp/account.go
+++ b/src/pkg/clouds/gcp/account.go
@@ -54,12 +54,16 @@ func (gcp Gcp) GetCurrentPrincipal(ctx context.Context) (string, error) {
 	// Try to extract email from id_token if present
 	if idToken, ok := token.Extra("id_token").(string); ok && idToken != "" {
 		if email, err := extractEmailFromIDToken(idToken); err == nil && email != "" {
-			return email, nil
+			return "user:" + email, nil
 		}
 	}
 
 	// Last resort: query tokeninfo endpoint
-	return getEmailFromToken(ctx, token.AccessToken)
+	email, err := getEmailFromToken(ctx, token.AccessToken)
+	if err != nil {
+		return "", fmt.Errorf("failed to get email from access token: %w", err)
+	}
+	return "user:" + email, nil
 }
 
 func extractEmailFromIDToken(idToken string) (string, error) {

--- a/src/pkg/clouds/gcp/account_test.go
+++ b/src/pkg/clouds/gcp/account_test.go
@@ -53,7 +53,7 @@ func TestGetCurrentAccountPrincipal(t *testing.T) {
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
-		expected := "test@email.com"
+		expected := "user:test@email.com"
 		if principal != expected {
 			t.Errorf("expected principal to be %s, got %s", expected, principal)
 		}


### PR DESCRIPTION
## Description
Fix GCP BYOC:

```
 * Uploading the project files for django
 * Setting up defang CD in GCP project eric-test-project-447121, this could take a few minutes
 - Enabling services: [storage.googleapis.com artifactregistry.googleapis.com run.googleapis.com iam.googleapis.com cloudresourcemanager.googleapis.com cloudbuild.googleapis.com compute.googleapis.com dns.googleapis.com secretmanager.googleapis.com sqladmin.googleapis.com servicenetworking.googleapis.com redis.googleapis.com certificatemanager.googleapis.com]
 - Bucket "defang-cd-543id4cf3wsm" already exists
 - Service account defang-cd already exists
 - serviceAccount:defang-cd@eric-test-project-447121.iam.gserviceaccount.com already has roles [roles/run.admin roles/iam.serviceAccountAdmin roles/iam.serviceAccountUser roles/artifactregistry.admin roles/compute.futureReservationViewer roles/compute.loadBalancerAdmin roles/compute.networkAdmin roles/compute.securityAdmin roles/dns.admin roles/cloudbuild.builds.editor roles/secretmanager.admin roles/resourcemanager.projectIamAdmin roles/compute.instanceAdmin.v1 roles/cloudsql.admin roles/redis.admin roles/certificatemanager.owner roles/serviceusage.serviceUsageAdmin roles/datastore.owner] on resource projects/eric-test-project-447121
 - Service account defang-cd@eric-test-project-447121.iam.gserviceaccount.com already has roles [roles/storage.admin] on bucket defang-cd-543id4cf3wsm
 - Service account defang-upload already exists
 - Service account defang-upload@eric-test-project-447121.iam.gserviceaccount.com already has roles [roles/storage.objectUser] on bucket defang-cd-543id4cf3wsm
 * Updating IAM policy for eric.liu@defang.io on service account defang-upload@eric-test-project-447121.iam.gserviceaccount.com
Error: failed to set IAM policy for service account defang-upload@eric-test-project-447121.iam.gserviceaccount.com: rpc error: code = InvalidArgument desc = The member eric.liu@defang.io is of an unknown type. Please set a valid type prefix for the member.
```

## Checklist

- [X] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

