### PR TITLE
Handle the case where email from tokens is a service account

### DIFF
--- a/src/pkg/clouds/gcp/account.go
+++ b/src/pkg/clouds/gcp/account.go
@@ -18,7 +18,7 @@ var FindGoogleDefaultCredentials func(ctx context.Context, scopes ...string) (*g
 // TODO: Possibly need to support google groups and domains type of principals
 // Currently we only support:
 // - Google Accounts (user:email)
-// - Service Accounts (serviceAccount:xxx@xxx.gsserviceaccount.com)
+// - Service Accounts (serviceAccount:xxx@xxx.gserviceaccount.com)
 // - Principal Sets, i.e. Workload Identity Federation (principalSet:...)
 //
 // Whole list of possible principal types:
@@ -98,7 +98,7 @@ func extractEmailFromIDToken(idToken string) (string, error) {
 }
 
 func getPrincipalFromEmail(email string) string {
-	if strings.HasSuffix(email, "gserviceaccount.com") {
+	if strings.HasSuffix(email, ".gserviceaccount.com") {
 		return "serviceAccount:" + email
 	}
 	return "user:" + email

--- a/src/pkg/clouds/gcp/account_test.go
+++ b/src/pkg/clouds/gcp/account_test.go
@@ -79,7 +79,7 @@ func TestGetCurrentAccountPrincipal(t *testing.T) {
 	t.Run("ServiceAccount email in refreshed token", func(t *testing.T) {
 		token := &oauth2.Token{}
 		token = token.WithExtra(map[string]any{
-			"id_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ1bml0IHRlc3QiLCJpYXQiOm51bGwsImV4cCI6bnVsbCwiYXVkIjoiIiwic3ViIjoiIiwiZW1haWwiOiJ0ZXN0QEBnc2VydmljZWFjY291bnQuY29tIn0.OYcvDGRQgBPpPt7YrO2anQVYAspUsGaQD7iw5kc8uS0",
+			"id_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ1bml0IHRlc3QiLCJpYXQiOm51bGwsImV4cCI6bnVsbCwiYXVkIjoiIiwic3ViIjoiIiwiZW1haWwiOiIxMjM0NTY3ODkwLWNvbXB1dGVAZGV2ZWxvcGVyLmdzZXJ2aWNlYWNjb3VudC5jb20ifQ.jEjLklHM1qcB9Bo6TXepFy-wVHkEetUWq5DaQmVSsyo",
 		})
 		FindGoogleDefaultCredentials = func(ctx context.Context, scopes ...string) (*google.Credentials, error) {
 			return &google.Credentials{
@@ -92,7 +92,7 @@ func TestGetCurrentAccountPrincipal(t *testing.T) {
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
-		expected := "serviceAccount:test@@gserviceaccount.com"
+		expected := "serviceAccount:1234567890-compute@developer.gserviceaccount.com"
 		if principal != expected {
 			t.Errorf("expected principal to be %s, got %s", expected, principal)
 		}


### PR DESCRIPTION
## Description
Handle the case the email from the access tokens is a serviceAccount instead of user, currently we assume all email address cases are users, which might not be true, user could be using generated access token of a service account.

## Checklist

- [X] I have performed a self-review of my code
- [X] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

