### PR TITLE
Improve devex when project already deployed elsewhere

### DIFF
--- a/src/cmd/cli/command/compose.go
+++ b/src/cmd/cli/command/compose.go
@@ -94,7 +94,8 @@ func makeComposeUpCmd() *cobra.Command {
 				})
 				if !samePlace && len(resp.Deployments) > 0 {
 					if nonInteractive {
-						term.Warnf("Project appears to be already deployed elsewhere. Use `defang deployments --project-name=%q` to view all deployments.", project.Name)
+						term.Errorf("Project appears to be already deployed elsewhere. Use `defang deployments --project-name=%q` to view all deployments.", project.Name)
+						return errors.New("Project is already deployed elsewhere.")
 					} else {
 						help := "Active deployments of this project:"
 						for _, dep := range resp.Deployments {


### PR DESCRIPTION
## Description

In the interactive case, mention that pressing `?` will list active deployments. In the non-interactive case, fail with a message that describes how to list active deployments.

We should suggest changing the project or stack name, but this is a small improvement for now

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

