### PR TITLE
Add Makes support to src/Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.cache/
 node_modules/
 .envrc
 .direnv/

--- a/Makefile
+++ b/Makefile
@@ -7,11 +7,11 @@ install-git-hooks:
 
 .PHONY: pre-commit
 pre-commit:
-	@if git diff --cached --name-only | grep -q '^src/'; then make -C src lint; fi
+	@if git diff --cached --name-only | grep -q '^src/'; then $(MAKE) -C src lint; fi
 
 .PHONY: pre-push
 pre-push: pkgs/npm/README.md src/README.md test-nix
-	@make -C src test
+	@$(MAKE) -C src test
 
 .PHONY: setup
 setup:
@@ -29,4 +29,10 @@ pkgs/npm/README.md src/README.md: README.md
 
 .PHONY: test-nix
 test-nix:
+ifneq (,$(shell which nix))
 	nix run .#defang-cli --extra-experimental-features flakes --extra-experimental-features nix-command
+endif
+
+.PHONY: clean distclean
+clean distclean:
+	$(MAKE) -C src $@

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,16 +1,57 @@
 SHELL := bash
 
-# VERSION is the version we should download and use.
-VERSION:=$(shell git describe --match=NeVeRmAtCh --always --dirty)
+ifndef WITHOUT-NIX
+ifneq (,$(shell command -v nix))
+USING-NIX := true
+override GO :=
+override BUF :=
+endif
+endif
 
-PROTOS := protos/io/defang/v1/fabric.pb.go protos/io/defang/v1/defangv1connect/fabric.connect.go
-
-BINARY_NAME:=defang
-GOFLAGS:=-ldflags "-X main.version=$(VERSION)"
-GOSRC := $(shell find . -name '*.go')
 GO_VERSION := $(shell grep '^go ' go.mod | cut -d ' ' -f 2)
 
-$(BINARY_NAME): $(PROTOS) $(GOSRC) go.mod go.sum
+
+# Use Makes to auto-install all deps if/when needed (go & buf)
+ifndef USING-NIX
+R := $(abspath $(dir $(shell pwd)))
+M := $R/.cache/makes
+C := 606900040dd8132d2de51a0ea9302818a9826930
+$(shell [[ -d $M ]] || ( \
+  git clone -q https://github.com/makeplus/makes $M && \
+  git -C $M reset -q --hard $C))
+
+GO-VERSION ?= $(GO_VERSION).0
+
+include $M/init.mk
+include $M/go.mk
+include $M/buf.mk
+include $M/clean.mk
+include $M/shell.mk
+
+MAKES-CLEAN := defang
+
+GOLANGCI-LINT := $(LOCAL-BIN)/golangci-lint
+endif
+
+
+# VERSION is the version we should download and use.
+VERSION := $(shell git describe --match=NeVeRmAtCh --always --dirty)
+
+PROTOS := \
+  protos/io/defang/v1/fabric.pb.go \
+  protos/io/defang/v1/defangv1connect/fabric.connect.go \
+
+PROTOS-DEPS := \
+  protos/io/defang/v1/fabric.proto \
+  buf.gen.yaml \
+
+BINARY_NAME := defang
+GOFLAGS := -ldflags "-X main.version=$(VERSION)"
+GOSRC := $(shell find . -name '*.go')
+
+FAIL-RED := sed -e 's/\(--- FAIL.*\)/[0;31m\1[0m/g'
+
+$(BINARY_NAME): $(GO) $(PROTOS) $(GOSRC) go.mod go.sum
 	go build -o $@ $(GOFLAGS) ./cmd/cli
 
 .PHONY: build
@@ -18,7 +59,8 @@ build: $(BINARY_NAME)
 
 .PHONY: protos
 protos: $(PROTOS)
-$(PROTOS) &: protos/io/defang/v1/fabric.proto buf.gen.yaml
+
+$(PROTOS) &: $(BUF) $(PROTOS-DEPS)
 	cd protos && buf lint
 	buf generate protos
 
@@ -27,32 +69,47 @@ install: $(BINARY_NAME) test
 	install $(BINARY_NAME) "${HOME}/.local/bin/"
 
 .PHONY: test
-test: $(PROTOS)
-	go mod tidy
-	set -o pipefail ; go test -short ./... | sed -e 's/\(--- FAIL.*\)/[0;31m\1[0m/g'
+test: tidy $(GO) $(PROTOS)
+	set -o pipefail && go test -short ./... | $(FAIL-RED)
 
 .PHONY: integ
-integ: $(PROTOS)
-	set -o pipefail ; go test -v -tags=integration ./... | sed -e 's/\(--- FAIL.*\)/[0;31m\1[0m/g'
+integ: $(GO) $(PROTOS)
+	set -o pipefail && go test -v -tags=integration ./... | $(FAIL-RED)
 
 .PHONY: linux-amd64
-linux-amd64: test
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o $(BINARY_NAME) $(GOFLAGS) ./cmd/cli
+linux-amd64: $(GO) test
+	CGO_ENABLED=0 \
+	GOOS=linux \
+	GOARCH=amd64 \
+	go build -o $(BINARY_NAME) $(GOFLAGS) ./cmd/cli
+
+.PHONY: tidy
+tidy: $(GO)
+	go mod tidy
 
 defang_linux_amd64.zip: linux-amd64
 	zip $@ $(BINARY_NAME)
 
-defang-amd64: test
-	CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -o $@ $(GOFLAGS) ./cmd/cli
-	codesign -f -s "${MACOS_CERTIFICATE_NAME}" $@ --timestamp --options runtime
+defang-amd64: $(GO) test
+	CGO_ENABLED=0 \
+	GOOS=darwin \
+	GOARCH=amd64 \
+	go build -o $@ $(GOFLAGS) ./cmd/cli
+	codesign -f -s "${MACOS_CERTIFICATE_NAME}" $@ \
+	  --timestamp --options runtime
 
-defang-arm64: test
-	CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -o $@ $(GOFLAGS) ./cmd/cli
-	codesign -f -s "${MACOS_CERTIFICATE_NAME}" $@ --timestamp --options runtime
+defang-arm64: $(GO) test
+	CGO_ENABLED=0 \
+	GOOS=darwin \
+	GOARCH=arm64 \
+	go build -o $@ $(GOFLAGS) ./cmd/cli
+	codesign -f -s "${MACOS_CERTIFICATE_NAME}" $@ \
+	  --timestamp --options runtime
 
 defang_darwin.zip: defang-arm64 defang-amd64
 	lipo -create -output $(BINARY_NAME) defang-arm64 defang-amd64
-	codesign -f -s "${MACOS_CERTIFICATE_NAME}" $(BINARY_NAME) --timestamp --options runtime
+	codesign -f -s "${MACOS_CERTIFICATE_NAME}" $(BINARY_NAME) \
+	  --timestamp --options runtime
 	zip $@ $(BINARY_NAME)
 
 .PHONY: zips
@@ -60,7 +117,8 @@ zips: defang_linux_amd64.zip defang_darwin.zip
 
 .PHONY: no-diff
 no-diff:
-	git diff-index --quiet HEAD --       # check that there are no uncommitted changes
+	@# check that there are no uncommitted changes
+	git diff-index --quiet HEAD --
 
 .PHONY: pull
 pull:
@@ -68,19 +126,33 @@ pull:
 
 .PHONY: version
 version:
-	git tag $$(git tag -l 'v*' --sort=-v:refname | head -n1 | awk -F. '{$$NF = $$NF + 1;} 1' OFS=.)
+	git tag $$(
+	  git tag -l 'v*' --sort=-v:refname | \
+	  head -n1 | \
+	  awk -F. '{$$NF = $$NF + 1;} 1' OFS=. \
+	)
 
 .PHONY: release
 release: pull test no-diff version
 	git push --follow-tags --tags
 
 .PHONY: lint
-lint:
-	@golangci-lint run || (echo "Run 'make lint-fix' to try to fix the linting errors" && exit 1)
+lint: $(GOLANGCI-LINT)
+	@golangci-lint run || ( \
+	  echo "Run 'make lint-fix' to try to fix the linting errors"; \
+	  exit 1; \
+	)
 
 .PHONY: lint-fix
-lint-fix:
+lint-fix: $(GOLANGCI-LINT)
 	golangci-lint run --fix
+
+GOLANGCI-LINT-INSTALL := \
+  https://github.com/golangci/golangci-lint/raw/HEAD/install.sh
+
+$(GOLANGCI-LINT): $(GO)
+	curl -sSfL $(GOLANGCI-LINT-INSTALL) | \
+	  sh -s -- -b $(LOCAL-BIN) v2.5.0
 
 PROJECT_NAME := defang-cli
 
@@ -93,30 +165,57 @@ DOCKER_IMAGE_AMD64:=$(DOCKER_IMAGE_NAME):amd64-$(VERSION)
 
 .PHONY: image-amd64
 image-amd64:
-	docker build --platform linux/amd64 -t ${PROJECT_NAME} -t $(DOCKER_IMAGE_AMD64) --build-arg VERSION=$(VERSION) --build-arg GO_VERSION=$(GO_VERSION) .
+	docker build \
+	  --platform linux/amd64 \
+	  -t ${PROJECT_NAME} \
+	  -t $(DOCKER_IMAGE_AMD64) \
+	  --build-arg VERSION=$(VERSION) \
+	  --build-arg GO_VERSION=$(GO_VERSION) \
+	  .
 
 .PHONY: image-arm64
 image-arm64:
-	docker build --platform linux/arm64 -t ${PROJECT_NAME} -t $(DOCKER_IMAGE_ARM64) --build-arg VERSION=$(VERSION) --build-arg GO_VERSION=$(GO_VERSION) .
+	docker build \
+	  --platform linux/arm64 \
+	  -t ${PROJECT_NAME} \
+	  -t $(DOCKER_IMAGE_ARM64) \
+	  --build-arg VERSION=$(VERSION) \
+	  --build-arg GO_VERSION=$(GO_VERSION) \
+	  .
 
+## Build all docker images and manifest
 .PHONY: images
-images: image-amd64 image-arm64 ## Build all docker images and manifest
+images: image-amd64 image-arm64
 
+## Push all docker images
 .PHONY: push-images
-push-images: images login ## Push all docker images
+push-images: images login
 	docker push $(DOCKER_IMAGE_AMD64)
 	docker push $(DOCKER_IMAGE_ARM64)
-	docker manifest create --amend $(DOCKER_IMAGE_NAME):$(VERSION) $(DOCKER_IMAGE_AMD64) $(DOCKER_IMAGE_ARM64)
-	docker manifest create --amend $(DOCKER_IMAGE_NAME):latest $(DOCKER_IMAGE_AMD64) $(DOCKER_IMAGE_ARM64)
-	docker manifest push --purge $(DOCKER_IMAGE_NAME):$(VERSION)
-	docker manifest push --purge $(DOCKER_IMAGE_NAME):latest
+	docker manifest create --amend \
+	  $(DOCKER_IMAGE_NAME):$(VERSION) \
+	  $(DOCKER_IMAGE_AMD64) \
+	  $(DOCKER_IMAGE_ARM64)
+	docker manifest create --amend \
+	  $(DOCKER_IMAGE_NAME):latest \
+	  $(DOCKER_IMAGE_AMD64) \
+	  $(DOCKER_IMAGE_ARM64)
+	docker manifest push --purge \
+	  $(DOCKER_IMAGE_NAME):$(VERSION)
+	docker manifest push --purge \
+	  $(DOCKER_IMAGE_NAME):latest
 
+## Login to docker
 .PHONY: login
-login: ## Login to docker
+login:
 	@docker login
 
+## Used for local testing of goreleaser
 .PHONY: snapshot
-snapshot: ## Used for local testing of goreleaser
-	GORELEASER_ALLOW_DIRTY=true GORELEASER_LOG=debug \
-	goreleaser release --snapshot --clean \
-	--skip=publish,announce,sign,notarize,validate
+snapshot:
+	GORELEASER_ALLOW_DIRTY=true \
+	GORELEASER_LOG=debug \
+	goreleaser release \
+	  --snapshot \
+	  --clean \
+	  --skip=publish,announce,sign,notarize,validate


### PR DESCRIPTION
The main point of this PR is to add support for https://github.com/makeplus/makes which will allow people to use all the make commands with needing nix, go or buf installed. Things like `make -C src build` will just work.

Also auto-installs golangci-lint for non-nix users.

Nix users should be completely unaffected but can try things out with:

    make -C src build WITHOUT-NIX=true

This should make open source contributions much easier because it removes the Nix requirement for development, while still maintaining deterministic builds.

Reformatted some long lines by wrapping them for better readability.
