### PR TITLE
Added rovo CLI to setup

### DIFF
--- a/src/pkg/mcp/setup.go
+++ b/src/pkg/mcp/setup.go
@@ -36,6 +36,7 @@ const (
 	MCPClientCodex            MCPClient = "codex"
 	MCPClientCursor           MCPClient = "cursor"
 	MCPClientKiro             MCPClient = "kiro"
+	MCPClientRovo             MCPClient = "rovo"
 	MCPClientUnspecified      MCPClient = ""
 	MCPClientVSCode           MCPClient = "vscode"
 	MCPClientVSCodeCodespaces MCPClient = "vscode-codespaces"
@@ -58,6 +59,7 @@ var ValidClients = append(
 		MCPClientCodex,
 		MCPClientCursor,
 		MCPClientKiro,
+		MCPClientRovo,
 		MCPClientWindsurf,
 	},
 	ValidVSCodeClients...,
@@ -127,6 +129,11 @@ var kiroConfig = ClientInfo{
 	useHomeDir: true,
 }
 
+var rovoConfig = ClientInfo{
+	configFile: ".rovodev/mcp.json",
+	useHomeDir: true,
+}
+
 var vscodeConfig = ClientInfo{
 	configFile: "Code/User/mcp.json",
 	useHomeDir: false,
@@ -154,6 +161,7 @@ var clientRegistry = map[MCPClient]ClientInfo{
 	MCPClientCodex:            codexConfig,
 	MCPClientCursor:           cursorConfig,
 	MCPClientKiro:             kiroConfig,
+	MCPClientRovo:             rovoConfig,
 	MCPClientVSCode:           vscodeConfig,
 	MCPClientVSCodeCodespaces: vscodeCodespacesConfig,
 	MCPClientVSCodeInsiders:   vscodeInsidersConfig,

--- a/src/pkg/mcp/setup_test.go
+++ b/src/pkg/mcp/setup_test.go
@@ -146,6 +146,22 @@ func TestGetClientConfigPath(t *testing.T) {
 			expectedPath: filepath.Join(homeDir, ".kiro", "settings", "mcp.json"),
 		},
 
+		// Rovo tests - Darwin
+		{
+			name:         "rovo_darwin",
+			client:       MCPClientRovo,
+			goos:         "darwin",
+			expectedPath: filepath.Join(homeDir, ".rovodev", "mcp.json"),
+		},
+
+		// Rovo tests - Linux
+		{
+			name:         "rovo_linux",
+			client:       MCPClientRovo,
+			goos:         "linux",
+			expectedPath: filepath.Join(homeDir, ".rovodev", "mcp.json"),
+		},
+
 		// Codex tests - default path
 		{
 			name:         "codex_default",


### PR DESCRIPTION
## Description
I’ve added the setup command for the [Rovo CLI](https://support.atlassian.com/rovo/docs/connect-to-an-mcp-server-in-rovo-dev-cli/).
I also sorted the MCP clients in ascending order to keep the list organized, since it’s likely to keep growing over time.

TODO: test for windows and add windows test.

<!-- Concise description of what this PR is tackling. -->

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

