### PR TITLE
Added one click install vscode

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ The Defang Command-Line Interface [(CLI)](https://docs.defang.io/docs/getting-st
 
 [![Install in VS Code](https://img.shields.io/badge/VS_Code-Install_defang-0098FF?style=flat&logo=visualstudiocode&logoColor=ffffff)](vscode:mcp/install?%7B%22name%22%3A%22defang%22%2C%22type%22%3A%22stdio%22%2C%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22defang%22%2C%22mcp%22%2C%22serve%22%2C%22--client%22%2C%22vscode%22%5D%7D)
 [![Install in VS Code Insiders](https://img.shields.io/badge/VS_Code_Insiders-Install_defang-24bfa5?style=flat&logo=visualstudiocode&logoColor=ffffff)](vscode-insiders:mcp/install?%7B%22name%22%3A%22defang%22%2C%22type%22%3A%22stdio%22%2C%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22defang%22%2C%22mcp%22%2C%22serve%22%2C%22--client%22%2C%22vscode-insiders%22%5D%7D)
+[![Install MCP Server](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/en-US/install-mcp?name=defang&config=eyJ0eXBlIjoic3RkaW8iLCJjb21tYW5kIjoibnB4IC15IGRlZmFuZyBtY3Agc2VydmUgLS1jbGllbnQgY3Vyc29yIn0%3D)
 
 The Defang Model Context Protocol [(MCP)](https://docs.defang.io/docs/concepts/mcp) Server is tailored for developers who work primarily within integrated development environments (IDEs). It enables seamless cloud deployment from supported editors such as Cursor, Windsurf, VS Code, VS Code Insiders and Claude delivering a fully integrated experience without leaving your development environment.
 


### PR DESCRIPTION
## Description
I added these markdown buttons to install our defang mcp to vscode, vscode-insiders and cursor.

You can test these buttons here:
[![Install in VS Code](https://img.shields.io/badge/VS_Code-Install_defang-0098FF?style=flat&logo=visualstudiocode&logoColor=ffffff)](vscode:mcp/install?%7B%22name%22%3A%22defang%22%2C%22type%22%3A%22stdio%22%2C%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22defang%22%2C%22mcp%22%2C%22serve%22%2C%22--client%22%2C%22vscode%22%5D%7D)
[![Install in VS Code Insiders](https://img.shields.io/badge/VS_Code_Insiders-Install_defang-24bfa5?style=flat&logo=visualstudiocode&logoColor=ffffff)](vscode-insiders:mcp/install?%7B%22name%22%3A%22defang%22%2C%22type%22%3A%22stdio%22%2C%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22defang%22%2C%22mcp%22%2C%22serve%22%2C%22--client%22%2C%22vscode-insiders%22%5D%7D)
[![Install MCP Server](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/en-US/install-mcp?name=defang&config=eyJ0eXBlIjoic3RkaW8iLCJjb21tYW5kIjoibnB4IC15IGRlZmFuZyBtY3Agc2VydmUgLS1jbGllbnQgY3Vyc29yIn0%3D)

You can also click on my branch to see it in the README as well:
https://github.com/DefangLabs/defang/tree/kevin/vsClick?tab=readme-ov-file#defang-mcp-server

<!-- Concise description of what this PR is tackling. -->

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

