### PR TITLE
Show a warning on down when there's still configs

### DIFF
--- a/src/cmd/cli/command/compose.go
+++ b/src/cmd/cli/command/compose.go
@@ -358,8 +358,17 @@ func makeComposeDownCmd() *cobra.Command {
 
 			term.Info("Deleted services, deployment ID", deployment)
 
+			listConfigs, err := provider.ListConfig(cmd.Context(), &defangv1.ListConfigsRequest{Project: projectName})
+			if err == nil {
+				if len(listConfigs.Names) > 0 {
+					term.Warn("Stored project configs are not deleted.")
+				}
+			} else {
+				term.Debugf("ListConfigs failed: %v", err)
+			}
+
 			if detach {
-				printDefangHint("To track the update, do:", "tail --deployment "+deployment)
+				printDefangHint("To track the update, do:", "tail --project-name="+projectName+" --deployment="+deployment)
 				return nil
 			}
 
@@ -378,6 +387,9 @@ func makeComposeDownCmd() *cobra.Command {
 				return err
 			}
 			term.Info("Done.")
+			if len(listConfigs.Names) > 0 {
+				printDefangHint("To delete stored project configs, run:", "config rm --project-name="+projectName+" "+strings.Join(listConfigs.Names, " "))
+			}
 			return nil
 		},
 	}


### PR DESCRIPTION
## Description

Doing a `defang up` after a `defang down` does not result in a clean deployment, because any previous "config" will still be present in the cloud. This is by design, but we should make it clear that `defang down` does not delete those.

This PR adds a warnings (and a hint) to "down" when there's config present.