### PR TITLE
fix: ignore .defangrc

### DIFF
--- a/src/pkg/cli/compose/context.go
+++ b/src/pkg/cli/compose/context.go
@@ -71,7 +71,7 @@ Dockerfile
 defang
 defang.exe
 # Ignore our project-level state
-.defang`
+.defang*`
 )
 
 type ArchiveType struct {

--- a/src/testdata/alttestproj/.defangrc
+++ b/src/testdata/alttestproj/.defangrc
@@ -1,0 +1,1 @@
+# This file intentionally left blank


### PR DESCRIPTION
## Description

As we start to use `.defangrc` and `.defangrc.env` etc. for deployment info, we should make sure we don't upload these to servers.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

