### PR TITLE
fix: use region env vars from docs

### DIFF
--- a/src/pkg/cli/client/region.go
+++ b/src/pkg/cli/client/region.go
@@ -7,9 +7,9 @@ func GetRegion(provider ProviderID) string {
 	case ProviderAWS:
 		return pkg.Getenv("AWS_REGION", "us-west-2") // Default region for AWS
 	case ProviderGCP:
-		return pkg.Getenv("CLOUDSDK_COMPUTE_REGION", "us-central1") // Default region for GCP
+		return pkg.Getenv("GCP_LOCATION", "us-central1") // Default region for GCP
 	case ProviderDO:
-		return pkg.Getenv("DO_REGION", "nyc3") // Default region for DigitalOcean
+		return pkg.Getenv("REGION", "nyc3") // Default region for DigitalOcean
 	default:
 		return "" // No default region for unsupported providers
 	}


### PR DESCRIPTION
## Description

Use existing env vars from our current docs: `GCP_LOCATION` and `REGION` for [GCP](https://docs.defang.io/docs/providers/gcp#location) and [DO](https://docs.defang.io/docs/providers/digitalocean#region), respectively. 

## Linked Issues

Fixes #1580

Also see #1578 

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

