### PR TITLE
fix: handle non-interactive generate/init

### DIFF
--- a/src/cmd/cli/command/commands.go
+++ b/src/cmd/cli/command/commands.go
@@ -544,6 +544,13 @@ var generateCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := cmd.Context()
 
+		if nonInteractive {
+			if len(args) == 0 {
+				return errors.New("cannot run in non-interactive mode")
+			}
+			return cli.InitFromSamples(ctx, args[0], args)
+		}
+
 		setupClient := setup.SetupClient{
 			Surveyor: surveyor.NewDefaultSurveyor(),
 			Heroku:   migrate.NewHerokuClient(),
@@ -552,7 +559,7 @@ var generateCmd = &cobra.Command{
 			Cluster:  getCluster(),
 		}
 
-		sample := ""
+		var sample string
 		if len(args) > 0 {
 			sample = args[0]
 		}
@@ -572,6 +579,14 @@ var initCmd = &cobra.Command{
 	Short:   "Create a new Defang project from a sample",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := cmd.Context()
+
+		if nonInteractive {
+			if len(args) == 0 {
+				return errors.New("cannot run in non-interactive mode")
+			}
+			return cli.InitFromSamples(ctx, args[0], args)
+		}
+
 		setupClient := setup.SetupClient{
 			Surveyor: surveyor.NewDefaultSurveyor(),
 			Heroku:   migrate.NewHerokuClient(),
@@ -583,10 +598,6 @@ var initCmd = &cobra.Command{
 		if len(args) > 0 {
 			_, err := setupClient.CloneSample(ctx, args[0])
 			return err
-		}
-
-		if nonInteractive {
-			return errors.New("cannot run in non-interactive mode")
 		}
 
 		result, err := setupClient.Start(ctx)


### PR DESCRIPTION
## Description

Gracefully handle non-interactive `defang generate` and `defang init`: when a sample name is given (positional arg), it'll instantiate that sample in a folder with the same name as the sample. If no sample was given, abort with error.

