### PR TITLE
chore: separate IsComputeService

### DIFF
--- a/src/cmd/cli/command/compose.go
+++ b/src/cmd/cli/command/compose.go
@@ -121,7 +121,7 @@ func makeComposeUpCmd() *cobra.Command {
 			// Show a warning for any (managed) services that we cannot monitor
 			var managedServices []string
 			for _, service := range project.Services {
-				if !cli.CanMonitorService(service) {
+				if !cli.CanMonitorService(&service) {
 					managedServices = append(managedServices, service.Name)
 				}
 			}

--- a/src/pkg/cli/compose/validation.go
+++ b/src/pkg/cli/compose/validation.go
@@ -505,3 +505,14 @@ func validateManagedStore(managedStore any) (bool, error) {
 		return false, errors.New("expected parameters in managed storage definition field")
 	}
 }
+
+func IsComputeService(service *composeTypes.ServiceConfig) bool {
+	if service.Extensions == nil {
+		return true
+	}
+
+	return service.Extensions["x-defang-static-files"] == nil &&
+		service.Extensions["x-defang-redis"] == nil &&
+		service.Extensions["x-defang-mongodb"] == nil &&
+		service.Extensions["x-defang-postgres"] == nil
+}

--- a/src/pkg/cli/tailAndMonitor.go
+++ b/src/pkg/cli/tailAndMonitor.go
@@ -102,7 +102,7 @@ func TailAndMonitor(ctx context.Context, project *compose.Project, provider clie
 	return serviceStates, errors.Join(cdErr, svcErr, tailErr)
 }
 
-func CanMonitorService(service compose.ServiceConfig) bool {
+func CanMonitorService(service *compose.ServiceConfig) bool {
 	// Services with "restart: no" are assumed to be one-off
 	// tasks, so they are not monitored.
 	if service.Restart == "no" {
@@ -113,17 +113,14 @@ func CanMonitorService(service compose.ServiceConfig) bool {
 		return true
 	}
 
-	return service.Extensions["x-defang-static-files"] == nil &&
-		service.Extensions["x-defang-redis"] == nil &&
-		service.Extensions["x-defang-mongodb"] == nil &&
-		service.Extensions["x-defang-postgres"] == nil
+	return compose.IsComputeService(service)
 }
 
 func splitManagedAndUnmanagedServices(serviceInfos compose.Services) ([]string, []string) {
 	var managedServices []string
 	var unmanagedServices []string
 	for _, service := range serviceInfos {
-		if CanMonitorService(service) {
+		if CanMonitorService(&service) {
 			unmanagedServices = append(unmanagedServices, service.Name)
 		} else {
 			managedServices = append(managedServices, service.Name)

--- a/src/testdata/replicas/compose.yaml
+++ b/src/testdata/replicas/compose.yaml
@@ -15,3 +15,6 @@ services:
         reservations:
           memory: 256M
           cpus: "0.25"
+  managed:
+    image: redis:latest
+    x-defang-redis: true

--- a/src/testdata/replicas/compose.yaml.fixup
+++ b/src/testdata/replicas/compose.yaml.fixup
@@ -32,6 +32,21 @@
       "default": null
     }
   },
+  "managed": {
+    "command": null,
+    "entrypoint": null,
+    "image": "redis:latest",
+    "networks": {
+      "default": null
+    },
+    "ports": [
+      {
+        "mode": "host",
+        "target": 6379,
+        "protocol": "tcp"
+      }
+    ]
+  },
   "replicated": {
     "command": null,
     "deploy": {

--- a/src/testdata/replicas/compose.yaml.golden
+++ b/src/testdata/replicas/compose.yaml.golden
@@ -18,6 +18,11 @@ services:
     image: nginx:latest
     networks:
       default: null
+  managed:
+    image: redis:latest
+    networks:
+      default: null
+    x-defang-redis: true
   replicated:
     deploy:
       replicas: 3

--- a/src/testdata/replicas/compose.yaml.warnings
+++ b/src/testdata/replicas/compose.yaml.warnings
@@ -2,4 +2,6 @@
  ! service "default": high-availability mode requires at least 2 replicas or x-defang-autoscaling
  ! service "default": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors
  ! service "deploy": high-availability mode requires at least 2 replicas or x-defang-autoscaling
+ ! service "managed": high-availability mode requires at least 2 replicas or x-defang-autoscaling
+ ! service "managed": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors
  ! service "replicated": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors


### PR DESCRIPTION
## Description

Running Defang in Nounly with `--mode=high_availability`, it's showing a warning:

>  ! service "redis": high-availability mode requires at least 2 replicas or x-defang-autoscaling

~~For managed services, we should not have to configure "replicas". (Although, for some of them, there's work for us to be done to configure them correctly for HA.)~~

Even managed services have replicas and the exact count should be specified in the compose file.
