### PR TITLE
fix: CD task expects mode enum from PB

### DIFF
--- a/src/pkg/cli/client/byoc/gcp/byoc.go
+++ b/src/pkg/cli/client/byoc/gcp/byoc.go
@@ -26,7 +26,6 @@ import (
 	"github.com/DefangLabs/defang/src/pkg/dns"
 	"github.com/DefangLabs/defang/src/pkg/http"
 	"github.com/DefangLabs/defang/src/pkg/logs"
-	"github.com/DefangLabs/defang/src/pkg/modes"
 	"github.com/DefangLabs/defang/src/pkg/term"
 	"github.com/DefangLabs/defang/src/pkg/types"
 	defangv1 "github.com/DefangLabs/defang/src/protos/io/defang/v1"
@@ -318,8 +317,8 @@ func (b *ByocGcp) BootstrapCommand(ctx context.Context, req client.BootstrapComm
 		return "", err
 	}
 	cmd := cdCommand{
-		Project: req.Project,
-		Command: []string{req.Command},
+		project: req.Project,
+		command: []string{req.Command},
 	}
 	cdTaskId, err := b.runCdCommand(ctx, cmd) // TODO: make domain optional for defang cd
 	if err != nil {
@@ -329,11 +328,11 @@ func (b *ByocGcp) BootstrapCommand(ctx context.Context, req client.BootstrapComm
 }
 
 type cdCommand struct {
-	Project        string
-	Command        []string
-	EnvOverride    map[string]string
-	Mode           modes.Mode
-	DelegateDomain string
+	command        []string
+	delegateDomain string
+	envOverride    map[string]string
+	mode           defangv1.DeploymentMode
+	project        string
 }
 
 func (b *ByocGcp) runCdCommand(ctx context.Context, cmd cdCommand) (string, error) {
@@ -345,12 +344,12 @@ func (b *ByocGcp) runCdCommand(ctx context.Context, cmd cdCommand) (string, erro
 	env := map[string]string{
 		"DEFANG_DEBUG":             os.Getenv("DEFANG_DEBUG"), // TODO: use the global DoDebug flag
 		"DEFANG_JSON":              os.Getenv("DEFANG_JSON"),
-		"DEFANG_MODE":              strings.ToLower(cmd.Mode.String()),
+		"DEFANG_MODE":              strings.ToLower(cmd.mode.String()),
 		"DEFANG_ORG":               "defang",
 		"DEFANG_PREFIX":            byoc.DefangPrefix,
 		"DEFANG_STATE_URL":         defangStateUrl,
 		"GCP_PROJECT":              b.driver.ProjectId,
-		"PROJECT":                  cmd.Project,
+		"PROJECT":                  cmd.project,
 		pulumiBackendKey:           pulumiBackendValue,          // TODO: make secret
 		"PULUMI_CONFIG_PASSPHRASE": byoc.PulumiConfigPassphrase, // TODO: make secret
 		"PULUMI_COPILOT":           "false",
@@ -363,13 +362,13 @@ func (b *ByocGcp) runCdCommand(ctx context.Context, cmd cdCommand) (string, erro
 		env["NO_COLOR"] = "1"
 	}
 
-	if cmd.DelegateDomain != "" {
-		env["DOMAIN"] = b.GetProjectDomain(cmd.Project, cmd.DelegateDomain)
+	if cmd.delegateDomain != "" {
+		env["DOMAIN"] = b.GetProjectDomain(cmd.project, cmd.delegateDomain)
 	} else {
 		env["DOMAIN"] = "dummy.domain"
 	}
 
-	for k, v := range cmd.EnvOverride {
+	for k, v := range cmd.envOverride {
 		env[k] = v
 	}
 
@@ -381,12 +380,12 @@ func (b *ByocGcp) runCdCommand(ctx context.Context, cmd cdCommand) (string, erro
 		for k, v := range env {
 			debugEnv = append(debugEnv, k+"="+v)
 		}
-		if err := byoc.DebugPulumiGolang(ctx, debugEnv, cmd.Command...); err != nil {
+		if err := byoc.DebugPulumiGolang(ctx, debugEnv, cmd.command...); err != nil {
 			return "", err
 		}
 	}
 
-	execution, err := b.driver.Run(ctx, gcp.JobNameCD, env, cmd.Command...)
+	execution, err := b.driver.Run(ctx, gcp.JobNameCD, env, cmd.command...)
 	if err != nil {
 		return "", err
 	}
@@ -503,15 +502,14 @@ func (b *ByocGcp) deploy(ctx context.Context, req *defangv1.DeployRequest, comma
 		payload = strings.Replace(payload, "https://storage.googleapis.com/", "gs://", 1)
 	}
 
-	cmd := cdCommand{
-		Mode:           modes.Mode(req.Mode),
-		Project:        project.Name,
-		Command:        []string{command, payload},
-		EnvOverride:    map[string]string{"DEFANG_ETAG": etag},
-		DelegateDomain: req.DelegateDomain,
+	cdCmd := cdCommand{
+		command:        []string{command, payload},
+		delegateDomain: req.DelegateDomain,
+		envOverride:    map[string]string{"DEFANG_ETAG": etag},
+		mode:           req.Mode,
+		project:        project.Name,
 	}
-
-	execution, err := b.runCdCommand(ctx, cmd)
+	execution, err := b.runCdCommand(ctx, cdCmd)
 	if err != nil {
 		return nil, err
 	}

--- a/src/pkg/cli/client/byoc/gcp/byoc_test.go
+++ b/src/pkg/cli/client/byoc/gcp/byoc_test.go
@@ -25,8 +25,8 @@ func TestSetUpCD(t *testing.T) {
       - "8080:80"
 `))
 	cmd := cdCommand{
-		Project: "testproj",
-		Command: []string{"up", payload},
+		project: "testproj",
+		command: []string{"up", payload},
 	}
 
 	if op, err := b.runCdCommand(ctx, cmd); err != nil {


### PR DESCRIPTION
## Description

This fixes a regression from #1524: the contract between the CLI and the CD task follows the proto buffer. When we changed from `defangv1.DeploymentMode` enum to the new `modes.Mode` enum, the CD task could not interpret the resulting string value.

Also noticed that the DO provider did not use "mode" at all. 

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

