### PR TITLE
fix: use String func, not cast

### DIFF
--- a/src/cmd/cli/command/globals.go
+++ b/src/cmd/cli/command/globals.go
@@ -48,8 +48,8 @@ func readGlobals(stackName string) {
 	stack = pkg.Getenv("DEFANG_STACK", stack)
 	hasTty = term.IsTerminal() && !pkg.GetenvBool("CI")
 	hideUpdate = pkg.GetenvBool("DEFANG_HIDE_UPDATE")
-	mode, _ = modes.Parse(pkg.Getenv("DEFANG_MODE", string(mode)))
+	mode, _ = modes.Parse(pkg.Getenv("DEFANG_MODE", mode.String()))
 	modelId = pkg.Getenv("DEFANG_MODEL_ID", modelId) // for Pro users only
 	nonInteractive = !hasTty
-	providerID = cliClient.ProviderID(pkg.Getenv("DEFANG_PROVIDER", string(providerID)))
+	providerID = cliClient.ProviderID(pkg.Getenv("DEFANG_PROVIDER", providerID.String()))
 }

--- a/src/pkg/cli/composeUp.go
+++ b/src/pkg/cli/composeUp.go
@@ -77,7 +77,7 @@ func ComposeUp(ctx context.Context, project *compose.Project, fabric client.Fabr
 	}
 
 	deployRequest := &defangv1.DeployRequest{
-		Mode:           defangv1.DeploymentMode(mode),
+		Mode:           mode.Value(),
 		Project:        project.Name,
 		Compose:        bytes,
 		DelegateDomain: delegateDomain.Zone,

--- a/src/pkg/cli/estimate.go
+++ b/src/pkg/cli/estimate.go
@@ -58,7 +58,7 @@ func GeneratePreview(ctx context.Context, project *compose.Project, client clien
 
 	resp, err := client.Preview(ctx, &defangv1.PreviewRequest{
 		Provider:    estimateProviderID.Value(),
-		Mode:        defangv1.DeploymentMode(mode),
+		Mode:        mode.Value(),
 		Region:      region,
 		Compose:     composeData,
 		ProjectName: project.Name,


### PR DESCRIPTION
## Description

Another regression from #1598. `string(int32)` interprets the int as a unicode code point.
