### PR TITLE
Make limit int32

### DIFF
--- a/src/pkg/cli/client/byoc/aws/byoc.go
+++ b/src/pkg/cli/client/byoc/aws/byoc.go
@@ -686,7 +686,7 @@ func (b *ByocAws) QueryLogs(ctx context.Context, req *defangv1.TailRequest) (cli
 				etag = "" // no need to filter by etag
 			}
 		} else {
-			tailStream, err = b.driver.QueryTaskID(ctx, etag, time.Time{}, time.Now(), int(req.Limit))
+			tailStream, err = b.driver.QueryTaskID(ctx, etag, time.Time{}, time.Now(), req.Limit)
 			if err == nil {
 				b.cdTaskArn, err = b.driver.GetTaskArn(etag)
 				etag = "" // no need to filter by etag
@@ -713,12 +713,11 @@ func (b *ByocAws) QueryLogs(ctx context.Context, req *defangv1.TailRequest) (cli
 				lgis...,
 			)
 		} else {
-			limit := int(req.Limit)
 			evtsChan, errsChan := ecs.QueryLogGroups(
 				ctx,
 				start,
 				end,
-				limit,
+				req.Limit,
 				lgis...,
 			)
 			if evtsChan == nil {

--- a/src/pkg/cli/client/byoc/gcp/byoc.go
+++ b/src/pkg/cli/client/byoc/gcp/byoc.go
@@ -561,7 +561,7 @@ func (b *ByocGcp) QueryLogs(ctx context.Context, req *defangv1.TailRequest) (cli
 		if req.Follow {
 			subscribeStream.StartFollow(since)
 		} else {
-			subscribeStream.Start(int(req.Limit))
+			subscribeStream.Start(req.Limit)
 		}
 
 		var cancel context.CancelCauseFunc
@@ -624,7 +624,7 @@ func (b *ByocGcp) QueryLogs(ctx context.Context, req *defangv1.TailRequest) (cli
 	if req.Follow {
 		logStream.StartFollow(startTime)
 	} else {
-		logStream.Start(int(req.Limit))
+		logStream.Start(req.Limit)
 	}
 	return logStream, nil
 }

--- a/src/pkg/cli/client/byoc/gcp/stream.go
+++ b/src/pkg/cli/client/byoc/gcp/stream.go
@@ -125,7 +125,7 @@ func (s *ServerStream[T]) StartFollow(start time.Time) {
 	}()
 }
 
-func (s *ServerStream[T]) Start(limit int) {
+func (s *ServerStream[T]) Start(limit int32) {
 	query := s.query.GetQuery()
 	term.Debugf("Query logs with query: \n%v", query)
 	go func() {
@@ -146,7 +146,7 @@ func (s *ServerStream[T]) queryHead(query string) {
 	}
 }
 
-func (s *ServerStream[T]) queryTail(query string, limit int) {
+func (s *ServerStream[T]) queryTail(query string, limit int32) {
 	lister, err := s.gcp.ListLogEntries(s.ctx, query, gcp.OrderDescending)
 	if err != nil {
 		s.errCh <- err
@@ -171,7 +171,7 @@ func (s *ServerStream[T]) queryTail(query string, limit int) {
 	}
 }
 
-func (s *ServerStream[T]) listToBuffer(lister *gcp.Lister, limit int) ([]*T, error) {
+func (s *ServerStream[T]) listToBuffer(lister *gcp.Lister, limit int32) ([]*T, error) {
 	received := 0
 	buffer := make([]*T, 0, limit)
 	for range limit {
@@ -191,7 +191,7 @@ func (s *ServerStream[T]) listToBuffer(lister *gcp.Lister, limit int) ([]*T, err
 	return buffer, nil
 }
 
-func (s *ServerStream[T]) listToChannel(lister *gcp.Lister, limit int) error {
+func (s *ServerStream[T]) listToChannel(lister *gcp.Lister, limit int32) error {
 	received := 0
 	for {
 		entry, err := lister.Next()
@@ -206,7 +206,7 @@ func (s *ServerStream[T]) listToChannel(lister *gcp.Lister, limit int) error {
 			s.respCh <- resp
 		}
 		received += len(resps)
-		if limit > 0 && received >= limit {
+		if limit > 0 && received >= int(limit) {
 			return io.EOF
 		}
 	}

--- a/src/pkg/clouds/aws/ecs/stream.go
+++ b/src/pkg/clouds/aws/ecs/stream.go
@@ -51,7 +51,7 @@ func QueryAndTailLogGroup(ctx context.Context, lgi LogGroupInput, start, end tim
 				end = time.Now()
 			}
 			// Query the logs between the start time and now; TODO: could use a single CloudWatch client for all queries in same region
-			if err := QueryLogGroup(ctx, lgi, start, end, func(events []LogEvent) error {
+			if err := QueryLogGroup(ctx, lgi, start, end, 0, func(events []LogEvent) error {
 				es.ch <- &types.StartLiveTailResponseStreamMemberSessionUpdate{
 					Value: types.LiveTailSessionUpdate{SessionResults: events},
 				}


### PR DESCRIPTION
## Description

## Linked Issues

Ran into this while rebasing #1508. In particular, we should try to get rid of `takeLastN` because as it is now it appears to do a huge CloudWatch query ($$$), buffers it all, then takes the last N. CloudWatch cannot do descending query, so the long-term fix would be to incrementally decrease `since` until we got enough records.

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

