### PR TITLE
fix(gcp): don't return EOF when query part of tail is done

### DIFF
--- a/src/pkg/clouds/aws/ecs/stream_test.go
+++ b/src/pkg/clouds/aws/ecs/stream_test.go
@@ -15,7 +15,7 @@ func TestPendingStream(t *testing.T) {
 
 	ps, _ := QueryAndTailLogGroup(context.Background(), LogGroupInput{
 		LogGroupARN: "arn:aws:logs:us-west-2:532501343364:log-group:/ecs/lio/logss:*",
-	}, time.Now().Add(-time.Minute), time.Time{})
+	}, time.Now().Add(-time.Minute), time.Time{}, true)
 
 	go func() {
 		time.Sleep(5 * time.Second)


### PR DESCRIPTION
## Description

Fix a regression in 2.1.15: GCP "up" would exit prematurely because of the query part of the log streaming (which does first query for historical logs, then tail/follow for real-time logs) would return error `io.EOF`.
