### PR TITLE
feat: add additional redis and valkey images

### DIFF
--- a/src/pkg/cli/compose/fixup.go
+++ b/src/pkg/cli/compose/fixup.go
@@ -457,7 +457,8 @@ func IsPostgresRepo(repo string) bool {
 }
 
 func IsRedisRepo(repo string) bool {
-	return strings.HasSuffix(repo, "redis") || strings.HasSuffix(repo, "valkey")
+	return strings.HasSuffix(repo, "redis") || strings.HasSuffix(repo, "redis-stack") ||
+		strings.HasSuffix(repo, "valkey") || strings.HasSuffix(repo, "valkey-bundle")
 }
 
 func IsMongoRepo(repo string) bool {

--- a/src/pkg/cli/compose/stateful.go
+++ b/src/pkg/cli/compose/stateful.go
@@ -21,10 +21,12 @@ var statefulImages = []string{
 	"postgres",
 	"rabbitmq",
 	"redis",
+	"redis-stack",
 	"rethinkdb",
 	"scylla",
 	"timescaledb",
 	"valkey",
+	"valkey-bundle",
 	"vault",
 	"zookeeper",
 }


### PR DESCRIPTION
## Description

There are images that extend the default redis/valkey with extension like vector search:
- https://hub.docker.com/r/redis/redis-stack
- https://hub.docker.com/r/valkey/valkey-bundle

Also see #1604 