### PR TITLE
fix: query LogGroups without limit before merge

### DIFF
--- a/src/cmd/cli/command/compose.go
+++ b/src/cmd/cli/command/compose.go
@@ -510,6 +510,7 @@ func makeLogsCmd() *cobra.Command {
 		RunE:        handleLogsCmd,
 	}
 	setupLogsFlags(logsCmd)
+	logsCmd.Flags().Int32("limit", 100, "maximum number of log lines to show")
 	return logsCmd
 }
 
@@ -551,6 +552,7 @@ func handleLogsCmd(cmd *cobra.Command, args []string) error {
 	var filter, _ = cmd.Flags().GetString("filter")
 	var until, _ = cmd.Flags().GetString("until")
 	var follow, _ = cmd.Flags().GetBool("follow")
+	var limit, _ = cmd.Flags().GetInt32("limit")
 
 	if follow && until != "" {
 		return errors.New("cannot use --follow and --until together")
@@ -615,6 +617,7 @@ func handleLogsCmd(cmd *cobra.Command, args []string) error {
 		Until:      untilTs,
 		Verbose:    verbose,
 		Follow:     follow,
+		Limit:      limit,
 	}
 	return cli.Tail(cmd.Context(), provider, projectName, tailOptions)
 }


### PR DESCRIPTION
## Description

Fix a small regression where the new default limit (100) would limit each LogGroup query separately, then take the last 100 of the merged result, but LogGroups with many more messages (like `cd`) would be absent from the final result, because their most recent events got cut off.

Adding `--limit` to `logs` command to override the default limit.

## Linked Issues

See #1567 

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

