### PR TITLE
make chan

### DIFF
--- a/src/pkg/clouds/aws/ecs/logs.go
+++ b/src/pkg/clouds/aws/ecs/logs.go
@@ -126,7 +126,7 @@ func TailLogGroup(ctx context.Context, input LogGroupInput) (LiveTailStream, err
 
 func QueryLogGroups(ctx context.Context, start, end time.Time, limit int32, logGroups ...LogGroupInput) (<-chan LogEvent, <-chan error) {
 	var evtsChan chan LogEvent
-	var errChan chan error
+	errChan := make(chan error, len(logGroups))
 	for _, lgi := range logGroups {
 		lgEvtChan := make(chan LogEvent)
 		// Start a go routine for each log group


### PR DESCRIPTION
## Description

1.	Declaration without initialization:
The errChan variable is declared but never initialized using make(chan error).

2.	Error sending to nil channel:
When an error occurs in any goroutine (for example, when a LogGroup doesn’t exist), the code tries to send the error using:
`errChan <- fmt.Errorf(...)`

3.	Goroutine hangs:
Because sending to a nil channel blocks forever, the goroutine never completes.

4.	Callers never receive errors:
The main function or caller waits for errors from errChan, but it never receives any because all sends are blocked. This results in a deadlock or indefinite hang.
<!-- Concise description of what this PR is tackling. -->

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

