### PR TITLE
Fix gcp logging not stop and not providing the correct project without --since is given

### DIFF
--- a/src/pkg/cli/client/byoc/gcp/byoc.go
+++ b/src/pkg/cli/client/byoc/gcp/byoc.go
@@ -320,11 +320,11 @@ func (b *ByocGcp) BootstrapCommand(ctx context.Context, req client.BootstrapComm
 		project: req.Project,
 		command: []string{req.Command},
 	}
-	cdTaskId, err := b.runCdCommand(ctx, cmd) // TODO: make domain optional for defang cd
+	cdExecutionId, err := b.runCdCommand(ctx, cmd) // TODO: make domain optional for defang cd
 	if err != nil {
 		return "", err
 	}
-	return cdTaskId, nil
+	return cdExecutionId, nil
 }
 
 type cdCommand struct {
@@ -548,44 +548,20 @@ func (b *ByocGcp) Subscribe(ctx context.Context, req *defangv1.SubscribeRequest)
 }
 
 func (b *ByocGcp) QueryLogs(ctx context.Context, req *defangv1.TailRequest) (client.ServerStream[defangv1.TailResponse], error) {
-	if b.cdExecution != "" && req.Etag == b.cdExecution { // Only follow CD log, we need to subscribe to cd activities to detect when the job is done
-		subscribeStream, err := NewSubscribeStream(ctx, b.driver, true, req.Etag, req.Services)
+	// BootstrapCommand returns the job execution ID as the eTag, which subsequently passed in as eTag in TailRequest,
+	// in those cases, we need a way to detect when the CD task has finished running and stop tailing thg logs by cancelling the logging context.
+	if b.cdExecution != "" && req.Etag == b.cdExecution {
+		var err error
+		ctx, err = b.getCDExecutionContext(ctx, b.driver, req)
 		if err != nil {
 			return nil, err
 		}
-		subscribeStream.AddJobExecutionUpdate(path.Base(b.cdExecution))
-		var since time.Time
-		if req.Since.IsValid() {
-			since = req.Since.AsTime()
-		}
-		if req.Follow {
-			subscribeStream.StartFollow(since)
-		} else {
-			subscribeStream.Start(req.Limit)
-		}
-
-		var cancel context.CancelCauseFunc
-		ctx, cancel = context.WithCancelCause(ctx)
-		go func() {
-			defer subscribeStream.Close()
-			for subscribeStream.Receive() {
-				msg := subscribeStream.Msg()
-				if msg.State == defangv1.ServiceState_BUILD_FAILED || msg.State == defangv1.ServiceState_DEPLOYMENT_FAILED {
-					pkg.SleepWithContext(ctx, 3*time.Second) // Make sure the logs are flushed, gcp logs has a longer delay, thus 3s
-					cancel(fmt.Errorf("CD job failed %s", msg.Status))
-					return
-				}
-				if msg.State == defangv1.ServiceState_DEPLOYMENT_COMPLETED {
-					pkg.SleepWithContext(ctx, 3*time.Second) // Make sure the logs are flushed, gcp logs has a longer delay, thus 3s
-					cancel(io.EOF)
-					return
-				}
-			}
-			cancel(subscribeStream.Err())
-		}()
 	}
+	return b.getLogStream(ctx, b.driver, req)
+}
 
-	logStream, err := NewLogStream(ctx, b.driver, req.Services)
+func (b *ByocGcp) getLogStream(ctx context.Context, gcpLogsClient GcpLogsClient, req *defangv1.TailRequest) (client.ServerStream[defangv1.TailResponse], error) {
+	logStream, err := NewLogStream(ctx, gcpLogsClient, req.Services)
 	if err != nil {
 		return nil, err
 	}
@@ -598,35 +574,72 @@ func (b *ByocGcp) QueryLogs(ctx context.Context, req *defangv1.TailRequest) (cli
 	if req.Until.IsValid() {
 		endTime = req.Until.AsTime()
 	}
-	if req.Since.IsValid() || req.Etag != "" {
+	etag := req.Etag
+	if etag == b.cdExecution { // Do not pass the cd execution name as etag
+		etag = ""
+	}
+	if logs.LogType(req.LogType).Has(logs.LogTypeBuild) {
 		execName := path.Base(b.cdExecution)
 		if execName == "." {
 			execName = ""
 		}
-		etag := req.Etag
-		if etag == b.cdExecution { // Do not pass the cd execution name as etag
-			etag = ""
-		}
-		if logs.LogType(req.LogType).Has(logs.LogTypeBuild) {
-			logStream.AddJobExecutionLog(execName) // CD log when there is an execution name
-			// TODO: update stack (1st param) to b.PulumiStack
-			logStream.AddJobLog("", req.Project, etag, req.Services)        // Kaniko or CD logs when there is no execution name
-			logStream.AddCloudBuildLog("", req.Project, etag, req.Services) // CloudBuild logs
-		}
-		if logs.LogType(req.LogType).Has(logs.LogTypeRun) {
-			// TODO: update stack (1st param) to b.PulumiStack
-			logStream.AddServiceLog("", req.Project, etag, req.Services) // Service logs
-		}
-		logStream.AddSince(startTime)
-		logStream.AddUntil(endTime)
-		logStream.AddFilter(req.Pattern)
+		logStream.AddJobExecutionLog(execName) // CD log when there is an execution name
+		// TODO: update stack (1st param) to b.PulumiStack
+		logStream.AddJobLog("", req.Project, etag, req.Services)        // Kaniko or CD logs when there is no execution name
+		logStream.AddCloudBuildLog("", req.Project, etag, req.Services) // CloudBuild logs
 	}
+	if logs.LogType(req.LogType).Has(logs.LogTypeRun) {
+		// TODO: update stack (1st param) to b.PulumiStack
+		logStream.AddServiceLog("", req.Project, etag, req.Services) // Service logs
+	}
+	logStream.AddSince(startTime)
+	logStream.AddUntil(endTime)
+	logStream.AddFilter(req.Pattern)
 	if req.Follow {
 		logStream.StartFollow(startTime)
 	} else {
 		logStream.Start(req.Limit)
 	}
 	return logStream, nil
+}
+
+func (b *ByocGcp) getCDExecutionContext(ctx context.Context, gcpLogsClient GcpLogsClient, req *defangv1.TailRequest) (context.Context, error) {
+	subscribeStream, err := NewSubscribeStream(ctx, gcpLogsClient, true, req.Etag, req.Services)
+	if err != nil {
+		return nil, err
+	}
+	subscribeStream.AddJobExecutionUpdate(path.Base(b.cdExecution))
+	var since time.Time
+	if req.Since.IsValid() {
+		since = req.Since.AsTime()
+	}
+	if req.Follow {
+		subscribeStream.StartFollow(since)
+	} else {
+		subscribeStream.Start(req.Limit)
+	}
+
+	var cancel context.CancelCauseFunc
+	ctx, cancel = context.WithCancelCause(ctx)
+	// Note: No defer cancel as cancel will always be called in the goroutine below
+	go func() {
+		defer subscribeStream.Close()
+		for subscribeStream.Receive() {
+			msg := subscribeStream.Msg()
+			if msg.State == defangv1.ServiceState_BUILD_FAILED || msg.State == defangv1.ServiceState_DEPLOYMENT_FAILED {
+				pkg.SleepWithContext(ctx, 3*time.Second) // Make sure the logs are flushed, gcp logs has a longer delay, thus 3s
+				cancel(fmt.Errorf("CD job failed %s", msg.Status))
+				return
+			}
+			if msg.State == defangv1.ServiceState_DEPLOYMENT_COMPLETED {
+				pkg.SleepWithContext(ctx, 3*time.Second) // Make sure the logs are flushed, gcp logs has a longer delay, thus 3s
+				cancel(io.EOF)
+				return
+			}
+		}
+		cancel(subscribeStream.Err())
+	}()
+	return ctx, nil
 }
 
 func (b *ByocGcp) GetService(ctx context.Context, req *defangv1.GetRequest) (*defangv1.ServiceInfo, error) {
@@ -770,7 +783,7 @@ func (b *ByocGcp) createDeploymentLogQuery(req *defangv1.DebugRequest) string {
 	if req.Until.IsValid() {
 		until = req.Until.AsTime()
 	}
-	query := NewLogQuery(b.driver.ProjectId)
+	query := NewLogQuery(b.driver.GetProjectID())
 	if b.cdExecution != "" {
 		query.AddJobExecutionQuery(path.Base(b.cdExecution))
 	}

--- a/src/pkg/cli/client/byoc/gcp/byoc_test.go
+++ b/src/pkg/cli/client/byoc/gcp/byoc_test.go
@@ -1,8 +1,18 @@
 package gcp
 
 import (
+	"context"
 	"encoding/base64"
+	"io"
 	"testing"
+	"time"
+
+	"cloud.google.com/go/logging/apiv2/loggingpb"
+	"github.com/DefangLabs/defang/src/pkg"
+	"github.com/DefangLabs/defang/src/pkg/clouds/gcp"
+	"github.com/DefangLabs/defang/src/pkg/logs"
+	defangv1 "github.com/DefangLabs/defang/src/protos/io/defang/v1"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 func TestSetUpCD(t *testing.T) {
@@ -33,5 +43,206 @@ func TestSetUpCD(t *testing.T) {
 		t.Errorf("BootstrapCommand() error = %v, want nil", err)
 	} else {
 		t.Logf("BootstrapCommand() = %v", op)
+	}
+}
+
+type MockGcpLogsClient struct {
+	lister gcp.Lister
+	tailer gcp.Tailer
+}
+
+func (m MockGcpLogsClient) ListLogEntries(ctx context.Context, query string, order gcp.Order) (gcp.Lister, error) {
+	return m.lister, nil
+}
+
+func (m MockGcpLogsClient) NewTailer(ctx context.Context) (gcp.Tailer, error) {
+	return m.tailer, nil
+}
+func (m MockGcpLogsClient) GetExecutionEnv(ctx context.Context, executionName string) (map[string]string, error) {
+	return nil, nil
+}
+func (m MockGcpLogsClient) GetProjectID() gcp.ProjectId {
+	return "test-project"
+}
+func (m MockGcpLogsClient) GetBuildInfo(ctx context.Context, buildId string) (*gcp.BuildTag, error) {
+	return &gcp.BuildTag{
+		Stack:   "test-stack",
+		Project: "test-project",
+		Service: "test-service",
+		Etag:    "test-etag",
+	}, nil
+}
+
+type MockGcpLoggingLister struct {
+	logEntries []loggingpb.LogEntry
+}
+
+func (m *MockGcpLoggingLister) Next() (*loggingpb.LogEntry, error) {
+	if len(m.logEntries) > 0 {
+		entry := &m.logEntries[0]
+		m.logEntries = m.logEntries[1:]
+		return entry, nil
+	}
+	return nil, io.EOF
+}
+
+type MockGcpLoggingTailer struct {
+	MockGcpLoggingLister
+}
+
+func (m *MockGcpLoggingTailer) Close() error {
+	return nil
+}
+
+func (m *MockGcpLoggingTailer) Start(ctx context.Context, query string) error {
+	return nil
+}
+
+func (m *MockGcpLoggingTailer) Next(ctx context.Context) (*loggingpb.LogEntry, error) {
+	return m.MockGcpLoggingLister.Next()
+}
+
+func TestGetCDExecutionContext(t *testing.T) {
+	tests := []struct {
+		name        string
+		listEntries []loggingpb.LogEntry
+		tailEntries []loggingpb.LogEntry
+	}{
+		{name: "no entries"},
+		{name: "with only list entries",
+			listEntries: []loggingpb.LogEntry{
+				{Payload: &loggingpb.LogEntry_TextPayload{TextPayload: "log entry 1 from lister"}},
+				{Payload: &loggingpb.LogEntry_TextPayload{TextPayload: "log entry 2 from lister"}},
+			},
+		},
+		{name: "with only tail entries",
+			tailEntries: []loggingpb.LogEntry{
+				{Payload: &loggingpb.LogEntry_TextPayload{TextPayload: "log entry 1 from tailer"}},
+				{Payload: &loggingpb.LogEntry_TextPayload{TextPayload: "log entry 2 from tailer"}},
+			},
+		},
+		{name: "with both list and tail entries",
+			listEntries: []loggingpb.LogEntry{
+				{Payload: &loggingpb.LogEntry_TextPayload{TextPayload: "log entry 1 from lister"}},
+				{Payload: &loggingpb.LogEntry_TextPayload{TextPayload: "log entry 2 from lister"}},
+			},
+			tailEntries: []loggingpb.LogEntry{
+				{Payload: &loggingpb.LogEntry_TextPayload{TextPayload: "log entry 1 from tailer"}},
+				{Payload: &loggingpb.LogEntry_TextPayload{TextPayload: "log entry 2 from tailer"}},
+			},
+		},
+	}
+
+	ctx := t.Context()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := NewByocProvider(ctx, "testTenantID", "")
+
+			driver := &MockGcpLogsClient{
+				lister: &MockGcpLoggingLister{},
+				tailer: &MockGcpLoggingTailer{},
+			}
+			newCtx, err := b.getCDExecutionContext(ctx, driver, &defangv1.TailRequest{})
+			if err != nil {
+				t.Errorf("getCDExecutionContext() error = %v, want nil", err)
+			}
+			if newCtx == ctx {
+				t.Errorf("getCDExecutionContext() returned same context, want new context")
+			}
+			// Wait for subscription done
+			select {
+			case <-newCtx.Done():
+			case <-time.After(10 * time.Second):
+				t.Errorf("getCDExecutionContext() timeout waiting for done")
+			}
+		})
+	}
+}
+
+func TestGetLogStream(t *testing.T) {
+	tests := []struct {
+		name        string
+		req         *defangv1.TailRequest
+		cdExecution string
+	}{
+		// TODO: use golang 1.25 synctest to avoid needing a fixed Since in every test case
+		{name: "since", req: &defangv1.TailRequest{Since: timestamppb.New(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC))}},
+		{name: "since_and_until", req: &defangv1.TailRequest{
+			Since: timestamppb.New(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)),
+			Until: timestamppb.New(time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC)),
+		}},
+		{name: "with_pattern", req: &defangv1.TailRequest{
+			Since:   timestamppb.New(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)),
+			Pattern: "error",
+		}},
+		{name: "with_project", req: &defangv1.TailRequest{
+			Since:   timestamppb.New(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)),
+			Project: "test-project",
+			LogType: uint32(logs.LogTypeAll),
+		}},
+		{name: "with_logtype_build", req: &defangv1.TailRequest{
+			Since:   timestamppb.New(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)),
+			LogType: uint32(logs.LogTypeBuild),
+		}},
+		{name: "with_logtype_run", req: &defangv1.TailRequest{
+			Since:   timestamppb.New(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)),
+			LogType: uint32(logs.LogTypeRun),
+		}},
+		{name: "with_logtype_all", req: &defangv1.TailRequest{
+			Since:   timestamppb.New(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)),
+			Pattern: "error",
+			LogType: uint32(logs.LogTypeAll),
+		}},
+		{name: "with_cd_exec", req: &defangv1.TailRequest{
+			Since:   timestamppb.New(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)),
+			LogType: uint32(logs.LogTypeAll),
+		},
+			cdExecution: "test-execution-id",
+		},
+		{name: "with_etag", req: &defangv1.TailRequest{
+			Since:   timestamppb.New(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)),
+			LogType: uint32(logs.LogTypeAll),
+			Etag:    "test-etag",
+		}},
+		{name: "with_etag_equal_cd_exec", req: &defangv1.TailRequest{
+			Since:   timestamppb.New(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)),
+			LogType: uint32(logs.LogTypeAll),
+			Etag:    "test-execution-id",
+		},
+			cdExecution: "test-execution-id",
+		},
+	}
+
+	ctx := t.Context()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := NewByocProvider(ctx, "testTenantID", "")
+			b.cdExecution = tt.cdExecution
+
+			driver := &MockGcpLogsClient{
+				lister: &MockGcpLoggingLister{},
+				tailer: &MockGcpLoggingTailer{},
+			}
+
+			stream, err := b.getLogStream(ctx, driver, tt.req)
+			if err != nil {
+				t.Errorf("getLogStream() error = %v, want nil", err)
+			}
+			if stream == nil {
+				t.Errorf("getLogStream() returned nil tailer, want non-nil")
+			}
+
+			logStream, ok := stream.(*LogStream)
+			if !ok {
+				t.Fatalf("getLogStream() returned wrong type, want *gcp.LogStream")
+			}
+
+			query := logStream.GetQuery()
+			if err := pkg.Compare([]byte(query), "testdata/"+tt.name+".query"); err != nil {
+				t.Errorf("getLogStream() query mismatch: %v", err)
+			}
+		})
 	}
 }

--- a/src/pkg/cli/client/byoc/gcp/query.go
+++ b/src/pkg/cli/client/byoc/gcp/query.go
@@ -42,7 +42,7 @@ func (q *Query) GetQuery() string {
 	return buf.String()
 }
 
-func NewLogQuery(projectId string) *Query {
+func NewLogQuery(projectId gcp.ProjectId) *Query {
 	return NewQuery(fmt.Sprintf(`(
 logName=~"logs/run.googleapis.com%%2F(stdout|stderr)$" OR
 logName="projects/%[1]s/logs/cloudbuild" OR

--- a/src/pkg/cli/client/byoc/gcp/testdata/since.query
+++ b/src/pkg/cli/client/byoc/gcp/testdata/since.query
@@ -1,0 +1,6 @@
+(
+logName=~"logs/run.googleapis.com%2F(stdout|stderr)$" OR
+logName="projects/test-project/logs/cloudbuild" OR
+logName="projects/test-project/logs/cos_containers" OR
+logName="projects/test-project/logs/docker-logs"
+) AND (timestamp >= "2024-01-01T00:00:00Z")

--- a/src/pkg/cli/client/byoc/gcp/testdata/since_and_until.query
+++ b/src/pkg/cli/client/byoc/gcp/testdata/since_and_until.query
@@ -1,0 +1,6 @@
+(
+logName=~"logs/run.googleapis.com%2F(stdout|stderr)$" OR
+logName="projects/test-project/logs/cloudbuild" OR
+logName="projects/test-project/logs/cos_containers" OR
+logName="projects/test-project/logs/docker-logs"
+) AND (timestamp >= "2024-01-01T00:00:00Z") AND (timestamp <= "2024-01-02T00:00:00Z")

--- a/src/pkg/cli/client/byoc/gcp/testdata/with_cd_exec.query
+++ b/src/pkg/cli/client/byoc/gcp/testdata/with_cd_exec.query
@@ -1,0 +1,20 @@
+(
+logName=~"logs/run.googleapis.com%2F(stdout|stderr)$" OR
+logName="projects/test-project/logs/cloudbuild" OR
+logName="projects/test-project/logs/cos_containers" OR
+logName="projects/test-project/logs/docker-logs"
+) AND (timestamp >= "2024-01-01T00:00:00Z") AND (
+(
+  resource.type = "cloud_run_job"
+  labels."run.googleapis.com/execution_name" = "test-execution-id"
+) OR (
+  resource.type = "cloud_run_job"
+) OR (
+  resource.type="build"
+  labels.build_tags =~ "__[a-zA-Z0-9-]{1,63}_"
+) OR (
+  resource.type="cloud_run_revision"
+) OR (
+  resource.type="gce_instance"
+)
+)

--- a/src/pkg/cli/client/byoc/gcp/testdata/with_etag.query
+++ b/src/pkg/cli/client/byoc/gcp/testdata/with_etag.query
@@ -1,0 +1,20 @@
+(
+logName=~"logs/run.googleapis.com%2F(stdout|stderr)$" OR
+logName="projects/test-project/logs/cloudbuild" OR
+logName="projects/test-project/logs/cos_containers" OR
+logName="projects/test-project/logs/docker-logs"
+) AND (timestamp >= "2024-01-01T00:00:00Z") AND (
+(
+  resource.type = "cloud_run_job"
+  labels."defang-etag" = "test-etag"
+) OR (
+  resource.type="build"
+  labels.build_tags =~ "__[a-zA-Z0-9-]{1,63}_test-etag"
+) OR (
+  resource.type="cloud_run_revision"
+  labels."defang-etag" = "test-etag"
+) OR (
+  resource.type="gce_instance"
+  labels."defang-etag" = "test-etag"
+)
+)

--- a/src/pkg/cli/client/byoc/gcp/testdata/with_etag_equal_cd_exec.query
+++ b/src/pkg/cli/client/byoc/gcp/testdata/with_etag_equal_cd_exec.query
@@ -1,0 +1,20 @@
+(
+logName=~"logs/run.googleapis.com%2F(stdout|stderr)$" OR
+logName="projects/test-project/logs/cloudbuild" OR
+logName="projects/test-project/logs/cos_containers" OR
+logName="projects/test-project/logs/docker-logs"
+) AND (timestamp >= "2024-01-01T00:00:00Z") AND (
+(
+  resource.type = "cloud_run_job"
+  labels."run.googleapis.com/execution_name" = "test-execution-id"
+) OR (
+  resource.type = "cloud_run_job"
+) OR (
+  resource.type="build"
+  labels.build_tags =~ "__[a-zA-Z0-9-]{1,63}_"
+) OR (
+  resource.type="cloud_run_revision"
+) OR (
+  resource.type="gce_instance"
+)
+)

--- a/src/pkg/cli/client/byoc/gcp/testdata/with_logtype_all.query
+++ b/src/pkg/cli/client/byoc/gcp/testdata/with_logtype_all.query
@@ -1,0 +1,17 @@
+(
+logName=~"logs/run.googleapis.com%2F(stdout|stderr)$" OR
+logName="projects/test-project/logs/cloudbuild" OR
+logName="projects/test-project/logs/cos_containers" OR
+logName="projects/test-project/logs/docker-logs"
+) AND (timestamp >= "2024-01-01T00:00:00Z") AND ("error") AND (
+(
+  resource.type = "cloud_run_job"
+) OR (
+  resource.type="build"
+  labels.build_tags =~ "__[a-zA-Z0-9-]{1,63}_"
+) OR (
+  resource.type="cloud_run_revision"
+) OR (
+  resource.type="gce_instance"
+)
+)

--- a/src/pkg/cli/client/byoc/gcp/testdata/with_logtype_build.query
+++ b/src/pkg/cli/client/byoc/gcp/testdata/with_logtype_build.query
@@ -1,0 +1,13 @@
+(
+logName=~"logs/run.googleapis.com%2F(stdout|stderr)$" OR
+logName="projects/test-project/logs/cloudbuild" OR
+logName="projects/test-project/logs/cos_containers" OR
+logName="projects/test-project/logs/docker-logs"
+) AND (timestamp >= "2024-01-01T00:00:00Z") AND (
+(
+  resource.type = "cloud_run_job"
+) OR (
+  resource.type="build"
+  labels.build_tags =~ "__[a-zA-Z0-9-]{1,63}_"
+)
+)

--- a/src/pkg/cli/client/byoc/gcp/testdata/with_logtype_run.query
+++ b/src/pkg/cli/client/byoc/gcp/testdata/with_logtype_run.query
@@ -1,0 +1,12 @@
+(
+logName=~"logs/run.googleapis.com%2F(stdout|stderr)$" OR
+logName="projects/test-project/logs/cloudbuild" OR
+logName="projects/test-project/logs/cos_containers" OR
+logName="projects/test-project/logs/docker-logs"
+) AND (timestamp >= "2024-01-01T00:00:00Z") AND (
+(
+  resource.type="cloud_run_revision"
+) OR (
+  resource.type="gce_instance"
+)
+)

--- a/src/pkg/cli/client/byoc/gcp/testdata/with_pattern.query
+++ b/src/pkg/cli/client/byoc/gcp/testdata/with_pattern.query
@@ -1,0 +1,6 @@
+(
+logName=~"logs/run.googleapis.com%2F(stdout|stderr)$" OR
+logName="projects/test-project/logs/cloudbuild" OR
+logName="projects/test-project/logs/cos_containers" OR
+logName="projects/test-project/logs/docker-logs"
+) AND (timestamp >= "2024-01-01T00:00:00Z") AND ("error")

--- a/src/pkg/cli/client/byoc/gcp/testdata/with_project.query
+++ b/src/pkg/cli/client/byoc/gcp/testdata/with_project.query
@@ -1,0 +1,20 @@
+(
+logName=~"logs/run.googleapis.com%2F(stdout|stderr)$" OR
+logName="projects/test-project/logs/cloudbuild" OR
+logName="projects/test-project/logs/cos_containers" OR
+logName="projects/test-project/logs/docker-logs"
+) AND (timestamp >= "2024-01-01T00:00:00Z") AND (
+(
+  resource.type = "cloud_run_job"
+  labels."defang-project" = "test-project"
+) OR (
+  resource.type="build"
+  labels.build_tags =~ "_test-project_[a-zA-Z0-9-]{1,63}_"
+) OR (
+  resource.type="cloud_run_revision"
+  labels."defang-project" = "test-project"
+) OR (
+  resource.type="gce_instance"
+  labels."defang-project" = "test-project"
+)
+)

--- a/src/pkg/clouds/gcp/logging.go
+++ b/src/pkg/clouds/gcp/logging.go
@@ -12,7 +12,7 @@ import (
 	"google.golang.org/api/iterator"
 )
 
-func (gcp Gcp) NewTailer(ctx context.Context) (*Tailer, error) {
+func (gcp Gcp) NewTailer(ctx context.Context) (Tailer, error) {
 	client, err := logging.NewClient(ctx)
 	if err != nil {
 		return nil, err
@@ -21,7 +21,7 @@ func (gcp Gcp) NewTailer(ctx context.Context) (*Tailer, error) {
 	if err != nil {
 		return nil, err
 	}
-	t := &Tailer{
+	t := &gcpLoggingTailer{
 		projectId: gcp.ProjectId,
 		tleClient: tleClient,
 		client:    client,
@@ -29,7 +29,13 @@ func (gcp Gcp) NewTailer(ctx context.Context) (*Tailer, error) {
 	return t, nil
 }
 
-type Tailer struct {
+type Tailer interface {
+	Start(ctx context.Context, query string) error
+	Next(ctx context.Context) (*loggingpb.LogEntry, error)
+	Close() error
+}
+
+type gcpLoggingTailer struct {
 	projectId string
 	tleClient loggingpb.LoggingServiceV2_TailLogEntriesClient
 	client    *logging.Client
@@ -37,7 +43,7 @@ type Tailer struct {
 	cache []*loggingpb.LogEntry
 }
 
-func (t *Tailer) Start(ctx context.Context, query string) error {
+func (t *gcpLoggingTailer) Start(ctx context.Context, query string) error {
 	req := &loggingpb.TailLogEntriesRequest{
 		ResourceNames: []string{"projects/" + t.projectId},
 		Filter:        query,
@@ -48,7 +54,7 @@ func (t *Tailer) Start(ctx context.Context, query string) error {
 	return nil
 }
 
-func (t *Tailer) Next(ctx context.Context) (*loggingpb.LogEntry, error) {
+func (t *gcpLoggingTailer) Next(ctx context.Context) (*loggingpb.LogEntry, error) {
 	if len(t.cache) == 0 {
 		resp, err := t.tleClient.Recv()
 		if err != nil {
@@ -65,7 +71,7 @@ func (t *Tailer) Next(ctx context.Context) (*loggingpb.LogEntry, error) {
 	return entry, nil
 }
 
-func (t Tailer) Close() error {
+func (t *gcpLoggingTailer) Close() error {
 	// TODO: find out how to properly close the client
 	term.Debugf("Closing log tailer")
 	e1 := t.tleClient.CloseSend()
@@ -74,7 +80,11 @@ func (t Tailer) Close() error {
 	return errors.Join(e1, e2)
 }
 
-type Lister struct {
+type Lister interface {
+	Next() (*loggingpb.LogEntry, error)
+}
+
+type gcpLoggingLister struct {
 	it     *logging.LogEntryIterator
 	client *logging.Client
 }
@@ -86,7 +96,7 @@ const (
 	OrderAscending  Order = "asc"
 )
 
-func (gcp Gcp) ListLogEntries(ctx context.Context, query string, order Order) (*Lister, error) {
+func (gcp Gcp) ListLogEntries(ctx context.Context, query string, order Order) (Lister, error) {
 	client, err := logging.NewClient(ctx)
 	if err != nil {
 		return nil, err
@@ -98,10 +108,10 @@ func (gcp Gcp) ListLogEntries(ctx context.Context, query string, order Order) (*
 		OrderBy:       fmt.Sprintf("timestamp %s", order),
 	}
 	it := client.ListLogEntries(ctx, req)
-	return &Lister{it: it, client: client}, nil
+	return &gcpLoggingLister{it: it, client: client}, nil
 }
 
-func (l *Lister) Next() (*loggingpb.LogEntry, error) {
+func (l *gcpLoggingLister) Next() (*loggingpb.LogEntry, error) {
 	entry, err := l.it.Next()
 	if err == iterator.Done {
 		term.Debugf("Closing log lister client")

--- a/src/pkg/clouds/gcp/project.go
+++ b/src/pkg/clouds/gcp/project.go
@@ -100,6 +100,10 @@ type Gcp struct {
 	ProjectId string
 }
 
+func (gcp Gcp) GetProjectID() ProjectId {
+	return ProjectId(gcp.ProjectId)
+}
+
 func (gcp Gcp) EnsureProjectExists(ctx context.Context, projectName string) (*resourcemanagerpb.Project, error) {
 	client, err := resourcemanager.NewProjectsClient(ctx)
 	if err != nil {


### PR DESCRIPTION
## Description
GCP logging does not stop after deployment due to the tailer swallows the EOF from `listToChannel` function (#1615) , we should swallow the EOF during **Listing**, but should return the EOF during **Tailing**.

Add more test cases to make sure the query logic and subscribe stopping logic is correct.

## Checklist

- [X] I have performed a self-review of my code
- [X] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

