### PR TITLE
only print Bookends on defang logs or tail

### DIFF
--- a/src/pkg/cli/tail.go
+++ b/src/pkg/cli/tail.go
@@ -55,6 +55,7 @@ type TailOptions struct {
 	Since              time.Time
 	Until              time.Time
 	Verbose            bool
+	PrintBookends      bool
 }
 
 func (to TailOptions) String() string {
@@ -142,6 +143,7 @@ func Tail(ctx context.Context, provider client.Provider, projectName string, opt
 		return dryrun.ErrDryRun
 	}
 
+	options.PrintBookends = true
 	return streamLogs(ctx, provider, projectName, options, logEntryPrintHandler)
 }
 
@@ -352,7 +354,9 @@ func receiveLogs(ctx context.Context, provider client.Provider, projectName stri
 			}
 
 			if serverStream.Err() == nil { // returns nil on EOF
-				printTailBookend(options, lastLogTime)
+				if options.PrintBookends {
+					printTailBookend(options, lastLogTime)
+				}
 				return nil
 			}
 			return serverStream.Err()
@@ -363,7 +367,7 @@ func receiveLogs(ctx context.Context, provider client.Provider, projectName stri
 			continue
 		}
 
-		if !headBookendPrinted && len(msg.Entries) > 0 {
+		if options.PrintBookends && !headBookendPrinted && len(msg.Entries) > 0 {
 			printHeadBookend(options, msg.Entries[0].Timestamp.AsTime())
 			headBookendPrinted = true
 		}


### PR DESCRIPTION
## Description

When I merged #1624, I didn't consider that `defang cd ...` commands streamed logs from cd tasks and bookends are surprising when running something like `defang cd ls` where streaming logs is more of an implementation detail than an interface.

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

