### PR TITLE
Impersonate defang-upload service account when accessing cd bucket obj

### DIFF
--- a/pkgs/defang/cli.nix
+++ b/pkgs/defang/cli.nix
@@ -7,7 +7,7 @@ buildGo124Module {
   pname = "defang-cli";
   version = "git";
   src = lib.cleanSource ../../src;
-  vendorHash = "sha256-VYJjG99g66S8V6GzqdZngnHESaVkQ4C6Tl2VsFMVCLA="; # TODO: use fetchFromGitHub
+  vendorHash = "sha256-FVvyBFjLAzdvK81z6YmhaSoVpR5OkRyThFU4RwEqjGo="; # TODO: use fetchFromGitHub
 
   subPackages = [ "cmd/cli" ];
 

--- a/src/pkg/cli/client/byoc/gcp/byoc.go
+++ b/src/pkg/cli/client/byoc/gcp/byoc.go
@@ -41,8 +41,9 @@ import (
 var _ client.Provider = (*ByocGcp)(nil)
 
 const (
-	DefangCDProjectName = "defang-cd"
-	UploadPrefix        = "uploads/"
+	DefangCDProjectName            = "defang-cd"
+	DefangUploadServiceAccountName = "defang-upload"
+	UploadPrefix                   = "uploads/"
 )
 
 var (
@@ -165,7 +166,7 @@ func (b *ByocGcp) SetUpCD(ctx context.Context) error {
 		b.cdServiceAccount = path.Base(cdServiceAccount)
 	}
 	//   3.2 Give CD service account roles needed
-	if err := b.driver.EnsureServiceAccountHasRoles(ctx, "serviceAccount:"+b.cdServiceAccount, []string{
+	if err := b.driver.EnsurePrincipalHasRoles(ctx, "serviceAccount:"+b.cdServiceAccount, []string{
 		"roles/run.admin",                       // For creating and running cloudrun jobs and services (admin needed for `setIamPolicy` permission)
 		"roles/iam.serviceAccountAdmin",         // For creating service accounts
 		"roles/iam.serviceAccountUser",          // For impersonating service accounts
@@ -188,18 +189,18 @@ func (b *ByocGcp) SetUpCD(ctx context.Context) error {
 		return err
 	}
 	//   3.2 Give CD role access to CD bucket
-	if err := b.driver.EnsureServiceAccountHasBucketRoles(ctx, b.bucket, b.cdServiceAccount, []string{"roles/storage.admin"}); err != nil {
+	if err := b.driver.EnsurePrincipalHasBucketRoles(ctx, b.bucket, "serviceAccount:"+b.cdServiceAccount, []string{"roles/storage.admin"}); err != nil {
 		return err
 	}
 
 	// 4 Setup service account for upload and give ability to create signed URLs using it to current user
-	if uploadServiceAccount, err := b.driver.EnsureServiceAccountExists(ctx, "defang-upload", "defang upload", "Service account for defang cli to generate pre-signed URL to upload artifacts"); err != nil {
+	if uploadServiceAccount, err := b.driver.EnsureServiceAccountExists(ctx, DefangUploadServiceAccountName, "defang upload", "Service account for defang cli to generate pre-signed URL to upload artifacts"); err != nil {
 		return err
 	} else {
 		b.uploadServiceAccount = path.Base(uploadServiceAccount)
 	}
 	//  4.1 Give upload service account access to cd bucket
-	if err := b.driver.EnsureServiceAccountHasBucketRoles(ctx, b.bucket, b.uploadServiceAccount, []string{"roles/storage.objectUser"}); err != nil {
+	if err := b.driver.EnsurePrincipalHasBucketRoles(ctx, b.bucket, "serviceAccount:"+b.uploadServiceAccount, []string{"roles/storage.objectUser"}); err != nil {
 		return err
 	}
 	//  4.2 Give current principal the token creator role on the upload service account
@@ -947,10 +948,13 @@ func (b *ByocGcp) GetProjectUpdate(ctx context.Context, projectName string) (*de
 
 	// Path to the state file, Defined at: https://github.com/DefangLabs/defang-mvp/blob/main/pulumi/cd/byoc/aws/index.ts#L89
 	path := fmt.Sprintf("projects/%s/%s/project.pb", projectName, b.PulumiStack)
-	term.Debug("Getting services from bucket:", bucketName, path)
-	pbBytes, err := b.driver.GetBucketObject(ctx, bucketName, path)
+
+	// Current user might not have object viewer access to the bucket, use the upload service account to get the object
+	uploadSA := b.driver.GetServiceAccountEmail(DefangUploadServiceAccountName)
+	term.Debug("Getting services from bucket:", bucketName, path, uploadSA)
+	pbBytes, err := b.driver.GetBucketObjectWithServiceAccount(ctx, bucketName, path, uploadSA)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get project bucket object, try bootstrap the project with a deployment: %w", err)
 	}
 
 	projUpdate := defangv1.ProjectUpdate{}

--- a/src/pkg/clouds/gcp/storage.go
+++ b/src/pkg/clouds/gcp/storage.go
@@ -14,7 +14,9 @@ import (
 	"github.com/DefangLabs/defang/src/pkg/term"
 	"github.com/google/uuid"
 
+	"google.golang.org/api/impersonate"
 	"google.golang.org/api/iterator"
+	"google.golang.org/api/option"
 )
 
 func (gcp Gcp) EnsureBucketExists(ctx context.Context, prefix string) (string, error) {
@@ -40,6 +42,10 @@ func (gcp Gcp) EnsureBucketExists(ctx context.Context, prefix string) (string, e
 	if err := bucket.Create(ctx, gcp.ProjectId, &storage.BucketAttrs{
 		Location:     gcp.Region,
 		StorageClass: "STANDARD", // No minimum storage duration
+		// Uniform bucket-level access must be enabled to grant Workload Identity Federation entities access to Cloud Storage resources.
+		// We need Workload Identity Federation for githbub actions to be able access the build bucket
+		// https://docs.cloud.google.com/storage/docs/uniform-bucket-level-access#should-you-use
+		UniformBucketLevelAccess: storage.UniformBucketLevelAccess{Enabled: true},
 	}); err != nil {
 		return "", fmt.Errorf("failed to create bucket %q: %w", newBucketName, err)
 	}
@@ -54,22 +60,19 @@ func (gcp Gcp) GetBucketWithPrefix(ctx context.Context, prefix string) (string, 
 	}
 	defer client.Close()
 
-	// List all buckets in the specified project
+	// List all buckets matching the prefix in the specified project
 	it := client.Buckets(ctx, gcp.ProjectId)
 	it.Prefix = prefix
-	for {
-		attrs, err := it.Next()
-		if err == iterator.Done {
-			break
-		}
-		if err != nil {
-			return "", fmt.Errorf("bucket iterator error: %w", err)
-		}
 
-		return attrs.Name, nil
+	// Return the first matching bucket
+	attrs, err := it.Next()
+	if err == iterator.Done {
+		return "", nil
 	}
-
-	return "", nil
+	if err != nil {
+		return "", fmt.Errorf("bucket iterator error: %w", err)
+	}
+	return attrs.Name, nil
 }
 
 func (gcp Gcp) CreateUploadURL(ctx context.Context, bucketName, objectName, serviceAccount string) (string, error) {
@@ -137,7 +140,26 @@ func (gcp Gcp) GetBucketObject(ctx context.Context, bucketName, objectName strin
 		return nil, fmt.Errorf("unable to get bucket object, failed to create storage client: %w", err)
 	}
 	defer client.Close()
+	return gcp.getBucketObject(ctx, bucketName, objectName, client)
+}
 
+func (gcp Gcp) GetBucketObjectWithServiceAccount(ctx context.Context, bucketName, objectName, serviceAccount string) ([]byte, error) {
+	ts, err := impersonate.CredentialsTokenSource(ctx, impersonate.CredentialsConfig{
+		TargetPrincipal: serviceAccount,
+		Scopes:          []string{"https://www.googleapis.com/auth/cloud-platform"},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("unable to get bucket object, failed to create impersonated token source for service account %v: %w", serviceAccount, err)
+	}
+	client, err := storage.NewClient(ctx, option.WithTokenSource(ts))
+	if err != nil {
+		return nil, fmt.Errorf("unable to get bucket object, failed to create storage client: %w", err)
+	}
+	defer client.Close()
+	return gcp.getBucketObject(ctx, bucketName, objectName, client)
+}
+
+func (gcp Gcp) getBucketObject(ctx context.Context, bucketName, objectName string, client *storage.Client) ([]byte, error) {
 	bucket := client.Bucket(bucketName)
 	r, err := bucket.Object(objectName).NewReader(ctx)
 	if err != nil {


### PR DESCRIPTION
## Description
Impersonate the defang-upload service account when accesssing the defang cd bucket object, as account owner does not have object.viewer permission by default.

## Linked Issues
Fixes: 
https://github.com/DefangLabs/defang-mvp/issues/2451

## Checklist

- [X] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

