### PR TITLE
trigger workflow dispatch in defang-mvp on merges to main

### DIFF
--- a/.github/workflows/smoketests.yml
+++ b/.github/workflows/smoketests.yml
@@ -20,7 +20,6 @@ jobs:
       - name: Trigger Workflow
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.DEFANG_MVP_ACTIONS_DISPATCH_TOKEN }}
           script: |
             await github.rest.actions.createWorkflowDispatch({
               owner: 'DefangLabs',


### PR DESCRIPTION
## Description

This PR adds a github actions workflow which triggers cli smoketests in the `defang-mvp` repo. The team will be notified of failures in slack.

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

