### PR TITLE
CLI will error if invalid stackname provided

### DIFF
--- a/src/cmd/cli/command/commands.go
+++ b/src/cmd/cli/command/commands.go
@@ -371,7 +371,11 @@ var RootCmd = &cobra.Command{
 		}
 
 		// Read the global flags again from any .defangrc files in the cwd
-		global.loadRC(global.getStackName(cmd.Flags()))
+		err = global.loadRC(global.getStackName(cmd.Flags()))
+		if err != nil {
+			return err
+		}
+
 		err = global.syncFlagsWithEnv(cmd.Flags())
 		if err != nil {
 			return err

--- a/src/cmd/cli/command/globals.go
+++ b/src/cmd/cli/command/globals.go
@@ -1,6 +1,7 @@
 package command
 
 import (
+	"fmt"
 	"os"
 	"strconv"
 
@@ -253,20 +254,24 @@ They will NOT override environment variables that are already set, since
 godotenv.Load respects existing environment variables. Stack-specific RC files
 are considered required when specified, while the general RC file is optional.
 */
-func (r *GlobalConfig) loadRC(stackName string) {
+func (r *GlobalConfig) loadRC(stackName string) error {
 	if stackName != "" {
+		// If a stack name is provided, load the stack-specific RC file but return error if it fails or does not exist
 		rcfile := ".defangrc." + stackName
 		if err := godotenv.Load(rcfile); err != nil {
-			term.Debugf("could not load %s: %v", rcfile, err)
+			return fmt.Errorf("could not load %s: %v", rcfile, err)
 		} else {
 			term.Debugf("loaded globals from %s", rcfile)
 		}
 	}
+	// If no stack name is provided, trying load the general .defangrc file
+	// An error here is non-fatal since the file is optional
 	const rcfile = ".defangrc"
 	if err := godotenv.Load(rcfile); err != nil {
-		term.Debugf("could not load %s: %v", rcfile, err)
+		term.Debugf("could not load %s, continuing without applying a rc file: %v", rcfile, err)
 	} else {
 		term.Debugf("loaded globals from %s", rcfile)
 	}
 
+	return nil
 }


### PR DESCRIPTION
## Description
The CLI will error if an invalid stack name is provided because the loadRC function requires stack-specific configuration files to exist when explicitly referenced. This prevents users be from being unaware we will not fail back on to a default if they specify it.

Also docstring formatting was not respected before, this fixes it.
<!-- Concise description of what this PR is tackling. -->

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

