### PR TITLE
chore: rename configuration files from .defangrc to .defang

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ The Defang CLI recognizes the following environment variables:
 - `TZ` - The timezone to use for log timestamps: an IANA TZ name like `UTC` or `Europe/Amsterdam`; defaults to `Local`
 - `XDG_STATE_HOME` - The directory to use for storing state; defaults to `~/.local/state`
 
-Environment variables will be loaded from a `.defangrc` file in the current directory, if it exists. This file follows
+Environment variables will be loaded from a `.defang` file in the current directory, if it exists. This file follows
 the same format as a `.env` file: `KEY=VALUE` pairs on each line, lines starting with `#` are treated as comments and ignored.
 
 ## Development

--- a/pkgs/npm/README.md
+++ b/pkgs/npm/README.md
@@ -52,5 +52,5 @@ The Defang CLI recognizes the following environment variables:
 - `TZ` - The timezone to use for log timestamps: an IANA TZ name like `UTC` or `Europe/Amsterdam`; defaults to `Local`
 - `XDG_STATE_HOME` - The directory to use for storing state; defaults to `~/.local/state`
 
-Environment variables will be loaded from a `.defangrc` file in the current directory, if it exists. This file follows
+Environment variables will be loaded from a `.defang` file in the current directory, if it exists. This file follows
 the same format as a `.env` file: `KEY=VALUE` pairs on each line, lines starting with `#` are treated as comments and ignored.

--- a/src/README.md
+++ b/src/README.md
@@ -52,5 +52,5 @@ The Defang CLI recognizes the following environment variables:
 - `TZ` - The timezone to use for log timestamps: an IANA TZ name like `UTC` or `Europe/Amsterdam`; defaults to `Local`
 - `XDG_STATE_HOME` - The directory to use for storing state; defaults to `~/.local/state`
 
-Environment variables will be loaded from a `.defangrc` file in the current directory, if it exists. This file follows
+Environment variables will be loaded from a `.defang` file in the current directory, if it exists. This file follows
 the same format as a `.env` file: `KEY=VALUE` pairs on each line, lines starting with `#` are treated as comments and ignored.

--- a/src/cmd/cli/command/cd.go
+++ b/src/cmd/cli/command/cd.go
@@ -26,7 +26,7 @@ var cdCmd = &cobra.Command{
 		}
 
 		if json {
-			os.Setenv("DEFANG_JSON", "1")
+			os.Setenv("DEFANG_JSON", "1") // FIXME: ugly way to set this globally
 			global.Verbose = true
 		}
 	},

--- a/src/cmd/cli/command/commands.go
+++ b/src/cmd/cli/command/commands.go
@@ -371,8 +371,8 @@ var RootCmd = &cobra.Command{
 			}
 		}
 
-		// Read the global flags again from any .defangrc files in the cwd
-		err = global.loadRC(global.getStackName(cmd.Flags()))
+		// Read the global flags again from any .defang files in the cwd
+		err = global.loadDotDefang(global.getStackName(cmd.Flags()))
 		if err != nil {
 			return err
 		}

--- a/src/cmd/cli/command/globals_test.go
+++ b/src/cmd/cli/command/globals_test.go
@@ -17,9 +17,9 @@ func Test_readGlobals(t *testing.T) {
 
 	testConfig := GlobalConfig{}
 
-	t.Run("OS env beats any .defangrc file", func(t *testing.T) {
+	t.Run("OS env beats any .defang file", func(t *testing.T) {
 		t.Setenv("VALUE", "from OS env")
-		err := testConfig.loadRC("test")
+		err := testConfig.loadDotDefang("test")
 		if err != nil {
 			t.Fatalf("%v", err)
 		}
@@ -29,30 +29,30 @@ func Test_readGlobals(t *testing.T) {
 		os.Unsetenv("VALUE")
 	})
 
-	t.Run(".defangrc.test beats .defangrc", func(t *testing.T) {
-		err := testConfig.loadRC("test")
+	t.Run(".defang.test beats .defang", func(t *testing.T) {
+		err := testConfig.loadDotDefang("test")
 		if err != nil {
 			t.Fatalf("%v", err)
 		}
-		if v := os.Getenv("VALUE"); v != "from .defangrc.test" {
-			t.Errorf("expected VALUE to be 'from .defangrc.test', got '%s'", v)
+		if v := os.Getenv("VALUE"); v != "from .defang.test" {
+			t.Errorf("expected VALUE to be 'from .defang.test', got '%s'", v)
 		}
 		os.Unsetenv("VALUE")
 	})
 
-	t.Run(".defangrc used if no stack", func(t *testing.T) {
-		err := testConfig.loadRC("")
+	t.Run(".defang used if no stack", func(t *testing.T) {
+		err := testConfig.loadDotDefang("")
 		if err != nil {
 			t.Fatalf("%v", err)
 		}
-		if v := os.Getenv("VALUE"); v != "from .defangrc" {
-			t.Errorf("expected VALUE to be 'from .defangrc', got '%s'", v)
+		if v := os.Getenv("VALUE"); v != "from .defang" {
+			t.Errorf("expected VALUE to be 'from .defang', got '%s'", v)
 		}
 		os.Unsetenv("VALUE")
 	})
 
 	t.Run("incorrect stackname used if no stack", func(t *testing.T) {
-		err := testConfig.loadRC("non-existent-stack")
+		err := testConfig.loadDotDefang("non-existent-stack")
 		if err == nil {
 			t.Fatalf("this test should fail for non-existent stack: %v", err)
 		}
@@ -60,9 +60,9 @@ func Test_readGlobals(t *testing.T) {
 }
 
 func Test_configurationPrecedence(t *testing.T) {
-	// Test various combinations of flags, environment variables, and .defangrc files
+	// Test various combinations of flags, environment variables, and .defang files
 	// no matter the order they are applied, or combination, the final configuration should be correct.
-	// The precedence should be: flags > env vars > .defangrc files
+	// The precedence should be: flags > env vars > .defang files
 
 	// make a default config for comparison and copying
 	defaultConfig := GlobalConfig{
@@ -245,7 +245,7 @@ func Test_configurationPrecedence(t *testing.T) {
 			expected: defaultConfig,
 		},
 		{
-			name:         "default defangrc name, when no env vars or flags",
+			name:         "default .defang name, when no env vars or flags",
 			createRCFile: true,
 			rcStack: stack{
 				stackname: "",
@@ -280,7 +280,7 @@ func Test_configurationPrecedence(t *testing.T) {
 			},
 		},
 		{
-			name:         "default defangrc name and no values, when no env vars or flags",
+			name:         "default .defang name and no values, when no env vars or flags",
 			createRCFile: true,
 			rcStack: stack{
 				stackname: "",
@@ -339,9 +339,9 @@ func Test_configurationPrecedence(t *testing.T) {
 			if tt.createRCFile {
 				var path string
 				if tt.rcStack.stackname != "" {
-					path = filepath.Join(tempDir, ".defangrc."+tt.rcStack.stackname)
+					path = filepath.Join(tempDir, ".defang."+tt.rcStack.stackname)
 				} else {
-					path = filepath.Join(tempDir, ".defangrc")
+					path = filepath.Join(tempDir, ".defang")
 				}
 
 				f, err := os.Create(path)
@@ -363,7 +363,7 @@ func Test_configurationPrecedence(t *testing.T) {
 				// Unseting env vars set for this test is handled by t.Setenv automatically
 				// t.tempDir() will clean up created files
 
-				// Unset all RC env vars created by loadRC since it uses os.Setenv
+				// Unset all RC env vars created by loadDotDefang since it uses os.Setenv
 				for _, rcEnv := range rcEnvs {
 					os.Unsetenv(rcEnv)
 				}
@@ -372,7 +372,7 @@ func Test_configurationPrecedence(t *testing.T) {
 			t.Chdir(tempDir)
 
 			// simulates the actual loading sequence
-			err := testConfig.loadRC(tt.rcStack.stackname)
+			err := testConfig.loadDotDefang(tt.rcStack.stackname)
 			if err != nil {
 				t.Fatalf("failed to load RC file: %v", err)
 			}

--- a/src/cmd/cli/command/testdata/.defang
+++ b/src/cmd/cli/command/testdata/.defang
@@ -1,0 +1,1 @@
+VALUE=from .defang

--- a/src/cmd/cli/command/testdata/.defang.test
+++ b/src/cmd/cli/command/testdata/.defang.test
@@ -1,0 +1,1 @@
+VALUE=from .defang.test

--- a/src/cmd/cli/command/testdata/.defangrc
+++ b/src/cmd/cli/command/testdata/.defangrc
@@ -1,1 +1,0 @@
-VALUE=from .defangrc

--- a/src/cmd/cli/command/testdata/.defangrc.test
+++ b/src/cmd/cli/command/testdata/.defangrc.test
@@ -1,1 +1,0 @@
-VALUE=from .defangrc.test

--- a/src/pkg/stacks/stacks.go
+++ b/src/pkg/stacks/stacks.go
@@ -77,7 +77,7 @@ func List() ([]StackListItem, error) {
 
 	var stacks []StackListItem
 	for _, file := range files {
-		if strings.HasPrefix(file.Name(), ".defangrc.") {
+		if strings.HasPrefix(file.Name(), ".defang.") {
 			content, err := os.ReadFile(file.Name())
 			if err != nil {
 				term.Warnf("Skipping unreadable stack file %s: %v\n", file.Name(), err)
@@ -88,7 +88,7 @@ func List() ([]StackListItem, error) {
 				term.Warnf("Skipping invalid stack file %s: %v\n", file.Name(), err)
 				continue
 			}
-			params.Name = strings.TrimPrefix(file.Name(), ".defangrc.")
+			params.Name = strings.TrimPrefix(file.Name(), ".defang.")
 
 			stacks = append(stacks, StackListItem{
 				Name:     params.Name,
@@ -157,5 +157,5 @@ func Remove(name string) error {
 }
 
 func filename(stackname string) string {
-	return ".defangrc." + stackname
+	return ".defang." + stackname
 }

--- a/src/pkg/stacks/stacks_test.go
+++ b/src/pkg/stacks/stacks_test.go
@@ -49,7 +49,7 @@ func TestCreate(t *testing.T) {
 				Mode:     modes.ModeAffordable,
 			},
 			expectErr:        false,
-			expectedFilename: ".defangrc.teststack",
+			expectedFilename: ".defang.teststack",
 		},
 		{
 			name: "missing stack name",
@@ -77,7 +77,7 @@ func TestCreate(t *testing.T) {
 				Name: "a",
 			},
 			expectErr:        false,
-			expectedFilename: ".defangrc.a",
+			expectedFilename: ".defang.a",
 		},
 		{
 			name: "hyphen not ok",
@@ -98,7 +98,7 @@ func TestCreate(t *testing.T) {
 
 			// Cleanup created file if no error expected
 			if !tt.expectErr {
-				os.Remove(".defangrc." + tt.parameters.Name)
+				os.Remove(".defang." + tt.parameters.Name)
 			}
 
 			if filename != tt.expectedFilename {
@@ -123,8 +123,8 @@ func TestList(t *testing.T) {
 	t.Run("stacks present", func(t *testing.T) {
 		t.Chdir(t.TempDir())
 		// Create dummy stack files
-		os.Create(".defangrc.stack1")
-		os.Create(".defangrc.stack2")
+		os.Create(".defang.stack1")
+		os.Create(".defang.stack2")
 
 		stacks, err := List()
 		if err != nil {
@@ -140,7 +140,7 @@ func TestRemove(t *testing.T) {
 	t.Run("remove existing stack", func(t *testing.T) {
 		t.Chdir(t.TempDir())
 		// Create dummy stack file
-		stackFile := ".defangrc.stack_to_remove"
+		stackFile := ".defang.stack_to_remove"
 		os.Create(stackFile)
 
 		err := Remove("stack_to_remove")
@@ -157,7 +157,7 @@ func TestRemove(t *testing.T) {
 		err := Remove("non_existing_stack")
 		// expect an error when trying to remove a non-existing stack
 		assert.Error(t, err)
-		assert.ErrorContains(t, err, "remove .defangrc.non_existing_stack: no such file or directory")
+		assert.ErrorContains(t, err, "remove .defang.non_existing_stack: no such file or directory")
 	})
 }
 


### PR DESCRIPTION
## Description

RC files stand for "run commands" and is for running general shell commands, so not really what we're trying to do with `.defangrc`. We're more like `.env`, so suggest to drop the "rc".

