### PR TITLE
automatically update the nix vendor hash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,8 @@ update-nix-vendor-hash:
 	$(MAKE) nix-run 2>&1 | grep -o 'sha256-[A-Za-z0-9+/=]\+' | tail -n1 | xargs -I {} sed -i.bak -E 's|(vendorHash = ")[^"]+(")|vendorHash = "{}"|' pkgs/defang/cli.nix
 	rm pkgs/defang/cli.nix.bak
 	git add pkgs/defang/cli.nix
+	@echo cli.nix vendorHash has been updated; commit and push
+	@false
 
 .PHONY: nix-run
 nix-run:


### PR DESCRIPTION
this make task is run in pre-push hooks, so this should reduce CI churn because of out-of-sync nix vendor hashes

## Description

<!-- Concise description of what this PR is tackling. -->

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Nix-based CLI execution for improved environment consistency.
  * Introduced automated vendor dependency management with built-in recovery mechanisms.

* **Chores**
  * Enhanced build and test workflows with improved Nix integration and dependency validation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->