### PR TITLE
fix(aws): panic in logging code

### DIFF
--- a/src/pkg/cli/client/byoc/aws/byoc.go
+++ b/src/pkg/cli/client/byoc/aws/byoc.go
@@ -27,10 +27,12 @@ import (
 	"github.com/DefangLabs/defang/src/pkg/http"
 	"github.com/DefangLabs/defang/src/pkg/logs"
 	"github.com/DefangLabs/defang/src/pkg/term"
+	"github.com/DefangLabs/defang/src/pkg/timeutils"
 	"github.com/DefangLabs/defang/src/pkg/types"
 	defangv1 "github.com/DefangLabs/defang/src/protos/io/defang/v1"
 	awssdk "github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
 	cwTypes "github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
 	"github.com/aws/aws-sdk-go-v2/service/route53"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
@@ -661,76 +663,79 @@ func (b *ByocAws) QueryLogs(ctx context.Context, req *defangv1.TailRequest) (cli
 	var err error
 	cw, err := ecs.NewCloudWatchLogsClient(ctx, b.driver.Region) // assume all log groups are in the same region
 	if err != nil {
-		return nil, err
+		return nil, AnnotateAwsError(err)
 	}
 
-	etag := req.Etag
-	// if etag == "" && req.Service == "cd" {
-	// 	etag = awsecs.GetTaskID(b.cdTaskArn); TODO: find the last CD task
-	// }
 	// How to tail multiple tasks/services at once?
 	//  * No Etag, no service:	tail all tasks/services
 	//  * Etag, no service: 	tail all tasks/services with that Etag
 	//  * No Etag, service:		tail all tasks/services with that service name
 	//  * Etag, service:		tail that task/service
 	var tailStream ecs.LiveTailStream
-	var start, end time.Time
-	if req.Since.IsValid() {
-		start = req.Since.AsTime()
-	}
-	if req.Until.IsValid() {
-		end = req.Until.AsTime()
-	}
+	etag := req.Etag
 	if etag != "" && !pkg.IsValidRandomID(etag) { // Assume invalid "etag" is the task ID of the CD task
-		b.cdTaskArn, err = b.driver.GetTaskArn(etag) // only fails on missing task ID
-		if err != nil {
-			return nil, err
-		}
-		if req.Follow {
-			tailStream, err = b.driver.TailTaskID(ctx, cw, etag)
-		} else {
-			tailStream, err = b.driver.QueryTaskID(ctx, cw, etag, start, end, req.Limit)
-		}
+		tailStream, err = b.queryCdLogs(ctx, cw, req)
 		etag = "" // no need to filter events by etag because we only show logs from the specified task ID
 	} else {
-		var service string
-		if len(req.Services) == 1 {
-			service = req.Services[0]
-		}
-		lgis := b.getLogGroupInputs(etag, req.Project, service, req.Pattern, logs.LogType(req.LogType))
-		if req.Follow {
-			tailStream, err = ecs.QueryAndTailLogGroups(
-				ctx,
-				cw,
-				start,
-				end,
-				lgis...,
-			)
-		} else {
-			evtsChan, errsChan := ecs.QueryLogGroups(
-				ctx,
-				cw,
-				start,
-				end,
-				req.Limit,
-				lgis...,
-			)
-			if evtsChan == nil {
-				var errs []error
-				for err = range errsChan {
-					errs = append(errs, err)
-				}
-				return nil, AnnotateAwsError(errors.Join(errs...))
-			}
-			// TODO: any errors from errsChan should be reported but get dropped
-			tailStream = ecs.NewStaticLogStream(evtsChan, func() {})
-		}
+		tailStream, err = b.queryLogs(ctx, cw, req)
 	}
-
 	if err != nil {
 		return nil, AnnotateAwsError(err)
 	}
-	return newByocServerStream(tailStream, etag, req.GetServices(), b), nil
+	return newByocServerStream(tailStream, etag, req.Services, b), nil
+}
+
+func (b *ByocAws) queryCdLogs(ctx context.Context, cw *cloudwatchlogs.Client, req *defangv1.TailRequest) (ecs.LiveTailStream, error) {
+	var err error
+	b.cdTaskArn, err = b.driver.GetTaskArn(req.Etag) // only fails on missing task ID
+	if err != nil {
+		return nil, err
+	}
+	if req.Follow {
+		return b.driver.TailTaskID(ctx, cw, req.Etag)
+	} else {
+		start := timeutils.AsTime(req.Since, time.Time{})
+		end := timeutils.AsTime(req.Until, time.Time{})
+		return b.driver.QueryTaskID(ctx, cw, req.Etag, start, end, req.Limit)
+	}
+}
+
+func (b *ByocAws) queryLogs(ctx context.Context, cw *cloudwatchlogs.Client, req *defangv1.TailRequest) (ecs.LiveTailStream, error) {
+	start := timeutils.AsTime(req.Since, time.Time{})
+	end := timeutils.AsTime(req.Until, time.Time{})
+
+	var service string
+	if len(req.Services) == 1 {
+		service = req.Services[0]
+	}
+	lgis := b.getLogGroupInputs(req.Etag, req.Project, service, req.Pattern, logs.LogType(req.LogType))
+	if req.Follow {
+		return ecs.QueryAndTailLogGroups(
+			ctx,
+			cw,
+			start,
+			end,
+			lgis...,
+		)
+	} else {
+		evtsChan, errsChan := ecs.QueryLogGroups(
+			ctx,
+			cw,
+			start,
+			end,
+			req.Limit,
+			lgis...,
+		)
+		if evtsChan == nil {
+			var errs []error
+			for err := range errsChan {
+				errs = append(errs, err)
+			}
+			return nil, errors.Join(errs...)
+		}
+		// TODO: any errors from errsChan should be reported but get dropped
+		return ecs.NewStaticLogStream(evtsChan, func() {}), nil
+	}
 }
 
 func (b *ByocAws) makeLogGroupARN(name string) string {

--- a/src/pkg/timeutils/timeutils.go
+++ b/src/pkg/timeutils/timeutils.go
@@ -3,6 +3,8 @@ package timeutils
 import (
 	"strings"
 	"time"
+
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 // ParseTimeOrDuration parses a time string or duration string (e.g. 1h30m) and returns a time.Time.
@@ -32,4 +34,11 @@ func ParseTimeOrDuration(str string, now time.Time) (time.Time, error) {
 		return time.Time{}, err
 	}
 	return now.Add(-dur), nil // - because we want to go back in time
+}
+
+func AsTime(ts *timestamppb.Timestamp, def time.Time) time.Time {
+	if !ts.IsValid() { // handles nil too
+		return def
+	}
+	return ts.AsTime()
 }


### PR DESCRIPTION
## Description

Happened during `defang up`
```
[signal SIGSEGV: segmentation violation code=0x2 addr=0x18 pc=0x1026f9040]

goroutine 446 [running]:
github.com/DefangLabs/defang/src/pkg/cli/client/byoc/aws.(*byocServerStream).Close(0x140001c6500?)
        /Users/llunesu/dev/defang/src/pkg/cli/client/byoc/aws/stream.go:47 +0x20
github.com/DefangLabs/defang/src/pkg/cli.streamLogs.func1()
        /Users/llunesu/dev/defang/src/pkg/cli/tail.go:225 +0x50
created by github.com/DefangLabs/defang/src/pkg/cli.streamLogs in goroutine 1
        /Users/llunesu/dev/defang/src/pkg/cli/tail.go:223 +0x4c8
```

There were some `if` branches that would continue with no stream and `err` set to `nil`.

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

