### PR TITLE
chore: expose DEFANG_PULUMI_DEBUG

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ The Defang CLI recognizes the following environment variables:
 - `DEFANG_PREFIX` - The prefix to use for all BYOC resources; defaults to `Defang`
 - `DEFANG_PROVIDER` - The name of the cloud provider to use, `auto` (default), `aws`, `digitalocean`, `gcp`, or `defang`
 - `DEFANG_PULUMI_BACKEND` - The Pulumi backend URL or `"pulumi-cloud"`; defaults to a self-hosted backend
+- `DEFANG_PULUMI_DEBUG` - If set to `true`, enables debug logging for Pulumi operations; defaults to `false`
 - `DEFANG_PULUMI_DIFF` - If set to `true`, shows the Pulumi diff during deployments; defaults to `false`
 - `DEFANG_PULUMI_DIR` - Run Pulumi from this folder, instead of spawning a cloud task; requires `--debug` (BYOC only)
 - `DEFANG_PULUMI_VERSION` - Override the version of the Pulumi image to use (`aws` provider only)

--- a/pkgs/npm/README.md
+++ b/pkgs/npm/README.md
@@ -44,6 +44,7 @@ The Defang CLI recognizes the following environment variables:
 - `DEFANG_PREFIX` - The prefix to use for all BYOC resources; defaults to `Defang`
 - `DEFANG_PROVIDER` - The name of the cloud provider to use, `auto` (default), `aws`, `digitalocean`, `gcp`, or `defang`
 - `DEFANG_PULUMI_BACKEND` - The Pulumi backend URL or `"pulumi-cloud"`; defaults to a self-hosted backend
+- `DEFANG_PULUMI_DEBUG` - If set to `true`, enables debug logging for Pulumi operations; defaults to `false`
 - `DEFANG_PULUMI_DIFF` - If set to `true`, shows the Pulumi diff during deployments; defaults to `false`
 - `DEFANG_PULUMI_DIR` - Run Pulumi from this folder, instead of spawning a cloud task; requires `--debug` (BYOC only)
 - `DEFANG_PULUMI_VERSION` - Override the version of the Pulumi image to use (`aws` provider only)

--- a/src/README.md
+++ b/src/README.md
@@ -44,6 +44,7 @@ The Defang CLI recognizes the following environment variables:
 - `DEFANG_PREFIX` - The prefix to use for all BYOC resources; defaults to `Defang`
 - `DEFANG_PROVIDER` - The name of the cloud provider to use, `auto` (default), `aws`, `digitalocean`, `gcp`, or `defang`
 - `DEFANG_PULUMI_BACKEND` - The Pulumi backend URL or `"pulumi-cloud"`; defaults to a self-hosted backend
+- `DEFANG_PULUMI_DEBUG` - If set to `true`, enables debug logging for Pulumi operations; defaults to `false`
 - `DEFANG_PULUMI_DIFF` - If set to `true`, shows the Pulumi diff during deployments; defaults to `false`
 - `DEFANG_PULUMI_DIR` - Run Pulumi from this folder, instead of spawning a cloud task; requires `--debug` (BYOC only)
 - `DEFANG_PULUMI_VERSION` - Override the version of the Pulumi image to use (`aws` provider only)

--- a/src/pkg/cli/client/byoc/aws/byoc.go
+++ b/src/pkg/cli/client/byoc/aws/byoc.go
@@ -375,17 +375,21 @@ func (b *ByocAws) environment(projectName string) (map[string]string, error) {
 		"DEFANG_JSON":                os.Getenv("DEFANG_JSON"),
 		"DEFANG_ORG":                 b.TenantName,
 		"DEFANG_PREFIX":              b.Prefix,
+		"DEFANG_PULUMI_DEBUG":        os.Getenv("DEFANG_PULUMI_DEBUG"),
 		"DEFANG_PULUMI_DIFF":         os.Getenv("DEFANG_PULUMI_DIFF"),
 		"DEFANG_STATE_URL":           defangStateUrl,
 		"NODE_NO_WARNINGS":           "1",
 		"NPM_CONFIG_UPDATE_NOTIFIER": "false",
 		"PRIVATE_DOMAIN":             byoc.GetPrivateDomain(projectName),
 		"PROJECT":                    projectName,                 // may be empty
-		pulumiBackendKey:             pulumiBackendValue,          // TODO: make secret
 		"PULUMI_CONFIG_PASSPHRASE":   byoc.PulumiConfigPassphrase, // TODO: make secret
 		"PULUMI_COPILOT":             "false",
 		"PULUMI_SKIP_UPDATE_CHECK":   "true",
 		"STACK":                      b.PulumiStack,
+		pulumiBackendKey:             pulumiBackendValue, // TODO: make secret
+	}
+	if targets := os.Getenv("DEFANG_PULUMI_TARGETS"); targets != "" {
+		env["DEFANG_PULUMI_TARGETS"] = targets
 	}
 
 	if !term.StdoutCanColor() {

--- a/src/pkg/cli/client/byoc/do/byoc.go
+++ b/src/pkg/cli/client/byoc/do/byoc.go
@@ -651,113 +651,32 @@ func (b *ByocDo) environment(projectName, delegateDomain string, mode defangv1.D
 		return nil, err
 	}
 	env := []*godo.AppVariableDefinition{
-		{
-			Key:   "DEFANG_MODE",
-			Value: strings.ToLower(mode.String()),
-		},
-		{
-			Key:   "DEFANG_PREFIX",
-			Value: b.Prefix,
-		},
-		{
-			Key:   "DEFANG_DEBUG",
-			Value: os.Getenv("DEFANG_DEBUG"),
-		},
-		{
-			Key:   "DEFANG_JSON",
-			Value: os.Getenv("DEFANG_JSON"),
-		},
-		{
-			Key:   "DEFANG_ORG",
-			Value: b.TenantName,
-		},
-		{
-			Key:   "DOMAIN",
-			Value: b.GetProjectDomain(projectName, delegateDomain),
-		},
-		{
-			Key:   "PRIVATE_DOMAIN",
-			Value: byoc.GetPrivateDomain(projectName),
-		},
-		{
-			Key:   "PROJECT",
-			Value: projectName,
-		},
-		{
-			Key:   pulumiBackendKey,
-			Value: pulumiBackendValue,
-			Type:  godo.AppVariableType_Secret,
-		},
-		{
-			Key:   "DEFANG_STATE_URL",
-			Value: defangStateUrl,
-		},
-		{
-			Key:   "PULUMI_CONFIG_PASSPHRASE",
-			Value: byoc.PulumiConfigPassphrase,
-			Type:  godo.AppVariableType_Secret,
-		},
-		{
-			Key:   "DEFANG_PULUMI_DIFF",
-			Value: os.Getenv("DEFANG_PULUMI_DIFF"),
-		},
-		{
-			Key:   "STACK",
-			Value: b.PulumiStack,
-		},
-		{
-			Key:   "NODE_NO_WARNINGS",
-			Value: "1",
-		},
-		{
-			Key:   "NPM_CONFIG_UPDATE_NOTIFIER",
-			Value: "false",
-		},
-		{
-			Key:   "PULUMI_COPILOT",
-			Value: "false",
-		},
-		{
-			Key:   "PULUMI_SKIP_UPDATE_CHECK",
-			Value: "true",
-		},
-		{
-			Key:   "DIGITALOCEAN_TOKEN",
-			Value: os.Getenv("DIGITALOCEAN_TOKEN"),
-			Type:  godo.AppVariableType_Secret,
-		},
-		{
-			Key:   "SPACES_ACCESS_KEY_ID",
-			Value: os.Getenv("SPACES_ACCESS_KEY_ID"),
-			Type:  godo.AppVariableType_Secret,
-		},
-		{
-			Key:   "SPACES_SECRET_ACCESS_KEY",
-			Value: os.Getenv("SPACES_SECRET_ACCESS_KEY"),
-			Type:  godo.AppVariableType_Secret,
-		},
-		{
-			Key:   "REGION",
-			Value: region.String(),
-		},
-		{
-			Key:   "DEFANG_BUILD_REPO",
-			Value: b.buildRepo,
-		},
-		{
-			Key:   "AWS_REGION", // Needed for CD S3 functions; FIXME: remove this
-			Value: region.String(),
-		},
-		{
-			Key:   "AWS_ACCESS_KEY_ID", // Needed for CD S3 functions; FIXME: remove this
-			Value: os.Getenv("SPACES_ACCESS_KEY_ID"),
-			Type:  godo.AppVariableType_Secret,
-		},
-		{
-			Key:   "AWS_SECRET_ACCESS_KEY", // Needed for CD S3 functions; FIXME: remove this
-			Value: os.Getenv("SPACES_SECRET_ACCESS_KEY"),
-			Type:  godo.AppVariableType_Secret,
-		},
+		{Key: "AWS_ACCESS_KEY_ID", Value: os.Getenv("SPACES_ACCESS_KEY_ID"), Type: godo.AppVariableType_Secret},         // Needed for CD S3 functions; FIXME: remove this
+		{Key: "AWS_REGION", Value: region.String()},                                                                     // Needed for CD S3 functions; FIXME: remove this
+		{Key: "AWS_SECRET_ACCESS_KEY", Value: os.Getenv("SPACES_SECRET_ACCESS_KEY"), Type: godo.AppVariableType_Secret}, // Needed for CD S3 functions; FIXME: remove this
+		{Key: "DEFANG_BUILD_REPO", Value: b.buildRepo},
+		{Key: "DEFANG_DEBUG", Value: os.Getenv("DEFANG_DEBUG")},
+		{Key: "DEFANG_JSON", Value: os.Getenv("DEFANG_JSON")},
+		{Key: "DEFANG_MODE", Value: strings.ToLower(mode.String())},
+		{Key: "DEFANG_ORG", Value: b.TenantName},
+		{Key: "DEFANG_PREFIX", Value: b.Prefix},
+		{Key: "DEFANG_PULUMI_DEBUG", Value: os.Getenv("DEFANG_PULUMI_DEBUG")},
+		{Key: "DEFANG_PULUMI_DIFF", Value: os.Getenv("DEFANG_PULUMI_DIFF")},
+		{Key: "DEFANG_STATE_URL", Value: defangStateUrl},
+		{Key: "DIGITALOCEAN_TOKEN", Value: os.Getenv("DIGITALOCEAN_TOKEN"), Type: godo.AppVariableType_Secret},
+		{Key: "DOMAIN", Value: b.GetProjectDomain(projectName, delegateDomain)},
+		{Key: "NODE_NO_WARNINGS", Value: "1"},
+		{Key: "NPM_CONFIG_UPDATE_NOTIFIER", Value: "false"},
+		{Key: "PRIVATE_DOMAIN", Value: byoc.GetPrivateDomain(projectName)},
+		{Key: "PROJECT", Value: projectName},
+		{Key: "PULUMI_CONFIG_PASSPHRASE", Value: byoc.PulumiConfigPassphrase, Type: godo.AppVariableType_Secret},
+		{Key: "PULUMI_COPILOT", Value: "false"},
+		{Key: "PULUMI_SKIP_UPDATE_CHECK", Value: "true"},
+		{Key: "REGION", Value: region.String()},
+		{Key: "SPACES_ACCESS_KEY_ID", Value: os.Getenv("SPACES_ACCESS_KEY_ID"), Type: godo.AppVariableType_Secret},
+		{Key: "SPACES_SECRET_ACCESS_KEY", Value: os.Getenv("SPACES_SECRET_ACCESS_KEY"), Type: godo.AppVariableType_Secret},
+		{Key: "STACK", Value: b.PulumiStack},
+		{Key: pulumiBackendKey, Value: pulumiBackendValue, Type: godo.AppVariableType_Secret},
 	}
 	if !term.StdoutCanColor() {
 		env = append(env, &godo.AppVariableDefinition{Key: "NO_COLOR", Value: "1"})

--- a/src/pkg/cli/client/byoc/gcp/byoc.go
+++ b/src/pkg/cli/client/byoc/gcp/byoc.go
@@ -361,16 +361,17 @@ func (b *ByocGcp) runCdCommand(ctx context.Context, cmd cdCommand) (string, erro
 		"DEFANG_MODE":              strings.ToLower(cmd.mode.String()),
 		"DEFANG_ORG":               "defang",
 		"DEFANG_PREFIX":            b.Prefix,
+		"DEFANG_PULUMI_DEBUG":      os.Getenv("DEFANG_PULUMI_DEBUG"),
 		"DEFANG_PULUMI_DIFF":       os.Getenv("DEFANG_PULUMI_DIFF"),
 		"DEFANG_STATE_URL":         defangStateUrl,
 		"GCP_PROJECT":              b.driver.ProjectId,
 		"PROJECT":                  cmd.project,
-		pulumiBackendKey:           pulumiBackendValue,          // TODO: make secret
 		"PULUMI_CONFIG_PASSPHRASE": byoc.PulumiConfigPassphrase, // TODO: make secret
 		"PULUMI_COPILOT":           "false",
 		"PULUMI_SKIP_UPDATE_CHECK": "true",
 		"REGION":                   b.driver.Region,
 		"STACK":                    b.PulumiStack,
+		pulumiBackendKey:           pulumiBackendValue, // TODO: make secret
 	}
 
 	if !term.StdoutCanColor() {


### PR DESCRIPTION
## Description

This is another `DEFANG_PULUMI_*` that needs to travel from dev machine to CD task. Perhaps we can consider forwarding all `DEFANG_PULUMI_*` or even `DEFANG_*`?
