### PR TITLE
ensure beta stack back compat

### DIFF
--- a/src/pkg/cli/client/grpc.go
+++ b/src/pkg/cli/client/grpc.go
@@ -104,7 +104,8 @@ func (g GrpcClient) DelegateSubdomainZone(ctx context.Context, req *defangv1.Del
 }
 
 func (g GrpcClient) DeleteSubdomainZone(ctx context.Context, req *defangv1.DeleteSubdomainZoneRequest) error {
-	// see the comment in GetDelegateSubdomainZone for explanation
+	// Normalize "beta" to "" for backward compatibility with pre-stack projects.
+	// See the comment in GetDelegateSubdomainZone for explanation.
 	if req.Stack == "beta" {
 		req.Stack = ""
 	}


### PR DESCRIPTION
## Description

Projects which were deployed before stacks were introduced, were
deployed with the implicit stack name "beta", but this stack name was
excluded from the delegate subdomain. Now that stacks are explicit,
we want them to appear in the delegate, but we need to preserve
backwards compatibility with stacks named "beta". This backwards-
compatibility is implemented by sending a Stack name of "" in
place of "beta", so that fabric will treat these stacks as if there
was no explicit stack, and fabric will not include a stack suffix in the
delegate subdomain

## Linked Issues
* https://github.com/DefangLabs/defang-mvp/pull/2522 Fabric-side implementation

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved backward compatibility for subdomain zone operations by normalizing legacy "beta" stack identifiers so delete and delegate-retrieval requests behave correctly across stack configurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->