### PR TITLE
Fix nil pointer error in preview test

### DIFF
--- a/src/pkg/cli/preview_test.go
+++ b/src/pkg/cli/preview_test.go
@@ -46,7 +46,7 @@ func TestPreviewStops(t *testing.T) {
 				deploymentStatus: tt.err,
 			}
 
-			err := Preview(t.Context(), project, fabric, provider, ComposeUpParams{Mode: modes.ModeUnspecified})
+			err := Preview(t.Context(), project, fabric, provider, ComposeUpParams{Mode: modes.ModeUnspecified, Project: project})
 			if err != nil {
 				if err.Error() != tt.wantError {
 					t.Errorf("got error: %v, want: %v", err, tt.wantError)
@@ -68,7 +68,7 @@ func TestPreviewStops(t *testing.T) {
 
 		provider := &mockDeployProvider{}
 
-		err := Preview(ctx, project, fabric, provider, ComposeUpParams{Mode: modes.ModeUnspecified})
+		err := Preview(ctx, project, fabric, provider, ComposeUpParams{Mode: modes.ModeUnspecified, Project: project})
 		if err != nil {
 			t.Errorf("got error: %v, want nil", err)
 		}


### PR DESCRIPTION
## Description
Fix this error:
```
--- FAIL: TestPreviewStops (0.00s)                                                                             
    --- FAIL: TestPreviewStops/CD_task_fails (0.00s)                                                           
panic: runtime error: invalid memory address or nil pointer dereference [recovered, repanicked]
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x12a7bfd]
                                                                                                               
goroutine 174 [running]:                                                                                       
testing.tRunner.func1.2({0x157fe80, 0x2b5af40})                                                                
        /home/edw/.local/go/src/testing/testing.go:1872 +0x237         
testing.tRunner.func1()                                                                                        
        /home/edw/.local/go/src/testing/testing.go:1875 +0x35b                 
panic({0x157fe80?, 0x2b5af40?})                                                                                
        /home/edw/.local/go/src/runtime/panic.go:783 +0x132                                    
github.com/DefangLabs/defang/src/pkg/cli/compose.ValidateServiceDockerfiles(0x0?)
        /home/edw/defang/defang/src/pkg/cli/compose/dockerfile_validator.go:137 +0x1d
github.com/DefangLabs/defang/src/pkg/cli.ComposeUp({0x1b4cbe0, 0xc000b21090}, {0x1b6bf80, 0xc0000da460}, {0x1b6ffe0, 0xc000c72100}, {{0x0, 0x0}, 0x0, 0x0, ...})
        /home/edw/defang/defang/src/pkg/cli/composeUp.go:45 +0xad
github.com/DefangLabs/defang/src/pkg/cli.Preview({0x1b4cbe0, 0xc000b21090}, 0x55ff8d?, {0x1b6bf80?, 0xc0000da460?}, {0x1b6ffe0, 0xc000c72100}, {{0x0, 0x0}, 0x0, ...})
        /home/edw/defang/defang/src/pkg/cli/preview.go:12 +0x85
github.com/DefangLabs/defang/src/pkg/cli.TestPreviewStops.func1(0xc000f82540)
        /home/edw/defang/defang/src/pkg/cli/preview_test.go:49 +0xf1   
testing.tRunner(0xc000f82540, 0xc0008b8660)
        /home/edw/.local/go/src/testing/testing.go:1934 +0xea
created by testing.(*T).Run in goroutine 173                                                                   
        /home/edw/.local/go/src/testing/testing.go:1997 +0x465   
FAIL    github.com/DefangLabs/defang/src/pkg/cli        78.937s
```
## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for preview functionality with improved project context handling in test scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->