### PR TITLE
fix: make UserInfo optional for WhoAmI

### DIFF
--- a/src/cmd/cli/command/commands.go
+++ b/src/cmd/cli/command/commands.go
@@ -547,42 +547,35 @@ var whoamiCmd = &cobra.Command{
 	Short:       "Show the current user",
 	Annotations: authNeededAnnotation,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		verbose := global.Verbose
+		jsonMode, _ := cmd.Flags().GetBool("json")
+
 		loader := configureLoader(cmd)
+
 		global.NonInteractive = true // don't show provider prompt
 		provider, err := newProvider(cmd.Context(), loader)
 		if err != nil {
 			term.Debug("unable to get provider:", err)
 		}
 
-		jsonMode, _ := cmd.Flags().GetBool("json")
-
 		token := cluster.GetExistingToken(global.Cluster)
+
 		userInfo, err := auth.FetchUserInfo(cmd.Context(), token)
 		if err != nil {
-			term.Warn("unable to fetch user info:", err)
+			// Either the auth service is down, or we're using a Fabric JWT: skip workspace information
+			if !jsonMode {
+				term.Warn("Workspace information unavailable:", err)
+			}
 		}
 
 		tenantSelection := getTenantSelection()
-		data, err := cli.Whoami(cmd.Context(), global.Client, provider, userInfo, tenantSelection, verbose)
+		data, err := cli.Whoami(cmd.Context(), global.Client, provider, userInfo, tenantSelection)
 		if err != nil {
 			return err
 		}
-		if verbose && userInfo != nil {
-			if tenantID := cli.ResolveWorkspaceID(userInfo, tenantSelection); tenantID != "" {
-				data.TenantID = tenantID
-			}
-		}
-		if !verbose {
+
+		if !global.Verbose {
 			data.Tenant = ""
 			data.TenantID = ""
-		}
-
-		if verbose && data.Workspace == "" && userInfo != nil {
-			// If we didn't resolve a workspace name, try to display the raw selection for transparency.
-			if tenantSelection.IsSet() {
-				data.Workspace = tenantSelection.String()
-			}
 		}
 
 		if jsonMode {
@@ -594,14 +587,14 @@ var whoamiCmd = &cobra.Command{
 			return err
 		} else {
 			cols := []string{
+				"Workspace",
+				"SubscriberTier",
 				"Name",
 				"Email",
-				"Workspace",
 				"Provider",
-				"SubscriberTier",
 				"Region",
 			}
-			if verbose {
+			if global.Verbose {
 				cols = append(cols, "Tenant", "TenantID")
 			}
 			return term.Table([]cli.ShowAccountData{data}, cols...)

--- a/src/cmd/cli/command/commands_test.go
+++ b/src/cmd/cli/command/commands_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/DefangLabs/defang/src/pkg/auth"
 	cliClient "github.com/DefangLabs/defang/src/pkg/cli/client"
 	"github.com/DefangLabs/defang/src/pkg/cli/client/byoc/aws"
 	"github.com/DefangLabs/defang/src/pkg/cli/client/byoc/gcp"
@@ -153,7 +154,12 @@ func TestCommandGates(t *testing.T) {
 		}`))
 	}))
 	t.Cleanup(userinfoServer.Close)
-	t.Setenv("DEFANG_ISSUER", userinfoServer.URL)
+
+	openAuthClient := auth.OpenAuthClient
+	t.Cleanup(func() {
+		auth.OpenAuthClient = openAuthClient
+	})
+	auth.OpenAuthClient = auth.NewClient("testclient", userinfoServer.URL)
 	t.Setenv("DEFANG_ACCESS_TOKEN", "token-123")
 
 	server := httptest.NewServer(handler)

--- a/src/cmd/cli/command/workspace_test.go
+++ b/src/cmd/cli/command/workspace_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/DefangLabs/defang/src/pkg/auth"
 	"github.com/DefangLabs/defang/src/pkg/cli"
 	"github.com/DefangLabs/defang/src/pkg/term"
 	defangv1 "github.com/DefangLabs/defang/src/protos/io/defang/v1/defangv1connect"
@@ -36,7 +37,11 @@ func setupWorkspaceTestServers(t *testing.T) (clusterURL string) {
 	}))
 	t.Cleanup(userinfoServer.Close)
 
-	t.Setenv("DEFANG_ISSUER", userinfoServer.URL)
+	openAuthClient := auth.OpenAuthClient
+	t.Cleanup(func() {
+		auth.OpenAuthClient = openAuthClient
+	})
+	auth.OpenAuthClient = auth.NewClient("testclient", userinfoServer.URL)
 	t.Setenv("DEFANG_ACCESS_TOKEN", "token-123")
 
 	return fabricServer.URL

--- a/src/pkg/auth/auth.go
+++ b/src/pkg/auth/auth.go
@@ -13,7 +13,7 @@ import (
 	"github.com/pkg/browser"
 )
 
-var openAuthClient = NewClient("defang-cli", pkg.Getenv("DEFANG_ISSUER", "https://auth.defang.io"))
+var OpenAuthClient = NewClient("defang-cli", pkg.Getenv("DEFANG_ISSUER", "https://auth.defang.io"))
 
 type ErrNoBrowser struct {
 	Err error
@@ -40,12 +40,12 @@ const (
 func StartAuthCodeFlow(ctx context.Context, mcpFlow LoginFlow, saveToken func(string), mcpClient string) (AuthCodeFlow, error) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
-	redirectUri := openAuthClient.GetPollRedirectURI()
+	redirectUri := OpenAuthClient.GetPollRedirectURI()
 
 	opts := []AuthorizeOption{
 		WithPkce(),
 	}
-	ar, err := openAuthClient.Authorize(redirectUri, CodeResponseType, opts...)
+	ar, err := OpenAuthClient.Authorize(redirectUri, CodeResponseType, opts...)
 	if err != nil {
 		return AuthCodeFlow{}, err
 	}
@@ -119,7 +119,7 @@ func pollForAuthCode(ctx context.Context, state string) (string, error) {
 	defer cancel()
 
 	for {
-		code, err := openAuthClient.Poll(ctx, state)
+		code, err := OpenAuthClient.Poll(ctx, state)
 		if err != nil {
 			if errors.Is(err, ErrPollTimeout) {
 				term.Debug("poll timed out, retrying...")
@@ -149,7 +149,7 @@ func ExchangeCodeForToken(ctx context.Context, code AuthCodeFlow, ss ...scope.Sc
 
 	term.Debugf("Generating access token with scopes %v", scopes)
 
-	token, err := openAuthClient.Exchange(code.code, code.redirectUri, code.verifier) // TODO: scope
+	token, err := OpenAuthClient.Exchange(code.code, code.redirectUri, code.verifier) // TODO: scope
 	if err != nil {
 		return "", err
 	}

--- a/src/pkg/cli/whoami.go
+++ b/src/pkg/cli/whoami.go
@@ -16,13 +16,13 @@ type ShowAccountData struct {
 	SubscriberTier defangv1.SubscriptionTier `json:"subscriberTier"`
 	Region         string                    `json:"region"`
 	Workspace      string                    `json:"workspace"`
-	Tenant         string                    `json:"tenant,omitempty"`
+	Tenant         string                    `json:"tenant,omitempty"` // this is the subdomain
 	TenantID       string                    `json:"tenantId,omitempty"`
 	Email          string                    `json:"email"`
 	Name           string                    `json:"name"`
 }
 
-func Whoami(ctx context.Context, fabric client.FabricClient, provider client.Provider, userInfo *auth.UserInfo, tenantSelection types.TenantNameOrID, includeTenantDetails bool) (ShowAccountData, error) {
+func Whoami(ctx context.Context, fabric client.FabricClient, provider client.Provider, userInfo *auth.UserInfo, tenantSelection types.TenantNameOrID) (ShowAccountData, error) {
 	resp, err := fabric.WhoAmI(ctx)
 	if err != nil {
 		return ShowAccountData{}, err
@@ -30,32 +30,29 @@ func Whoami(ctx context.Context, fabric client.FabricClient, provider client.Pro
 
 	term.Debug("User ID: " + resp.UserId)
 	showData := ShowAccountData{
-		SubscriberTier: resp.Tier,
 		Region:         resp.Region,
+		SubscriberTier: resp.Tier,
+		Tenant:         resp.Tenant,
+		TenantID:       resp.TenantId,
 		Workspace:      ResolveWorkspaceName(userInfo, tenantSelection),
-	}
-	if includeTenantDetails {
-		showData.Tenant = resp.Tenant
-		showData.TenantID = ResolveWorkspaceID(userInfo, tenantSelection)
-		if showData.TenantID == "" && resp.TenantId != "" {
-			showData.TenantID = resp.TenantId
-		}
 	}
 
 	if provider != nil {
+		// Add provider account information
 		account, err := provider.AccountInfo(ctx)
-		if err != nil {
-			return ShowAccountData{}, err
-		}
-		showData.Provider = account.Provider
-		if account.Region != "" {
+		if err == nil {
+			showData.Provider = account.Provider
 			showData.Region = account.Region
 		}
 	}
 
 	if userInfo != nil {
+		// Add information from userinfo
 		showData.Email = userInfo.User.Email
 		showData.Name = userInfo.User.Name
+		if tenantId := ResolveWorkspaceID(userInfo, tenantSelection); tenantId != "" {
+			showData.TenantID = tenantId
+		}
 	}
 
 	return showData, nil

--- a/src/pkg/cli/whoami_test.go
+++ b/src/pkg/cli/whoami_test.go
@@ -51,7 +51,7 @@ func TestWhoami(t *testing.T) {
 		},
 	}
 
-	got, err := Whoami(ctx, grpcClient, &client, userInfo, types.TenantNameOrID(requestedTenant), true)
+	got, err := Whoami(ctx, grpcClient, &client, userInfo, types.TenantNameOrID(requestedTenant))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/src/pkg/cli/workspace.go
+++ b/src/pkg/cli/workspace.go
@@ -37,36 +37,21 @@ func WorkspaceRows(info *auth.UserInfo, tenantSelection types.TenantNameOrID) []
 // ResolveWorkspaceName maps the selected tenant (flag/env/token subject) to a known workspace name when available.
 // If no selection is set, returns an empty string.
 func ResolveWorkspaceName(info *auth.UserInfo, tenantSelection types.TenantNameOrID) string {
-	if info == nil {
-		if tenantSelection.IsSet() {
-			return string(tenantSelection)
-		}
-		return ""
+	if wi := info.FindWorkspaceInfo(tenantSelection); wi != nil {
+		return wi.Name
 	}
-
-	for _, t := range info.AllTenants {
-		if tenantSelection.IsSet() && (t.ID == string(tenantSelection) || t.Name == string(tenantSelection)) {
-			return t.Name
-		}
-	}
-
+	// If we didn't resolve a workspace name, display the raw selection for transparency.
 	if tenantSelection.IsSet() {
 		return string(tenantSelection)
 	}
-
 	return ""
 }
 
 // ResolveWorkspaceID returns the workspace ID matching the provided selection (flag/env/token subject).
 // If no match is found, returns an empty string.
 func ResolveWorkspaceID(info *auth.UserInfo, tenantSelection types.TenantNameOrID) string {
-	if info == nil || !tenantSelection.IsSet() {
-		return ""
-	}
-	for _, t := range info.AllTenants {
-		if t.ID == string(tenantSelection) || t.Name == string(tenantSelection) {
-			return t.ID
-		}
+	if wi := info.FindWorkspaceInfo(tenantSelection); wi != nil {
+		return wi.ID
 	}
 	return ""
 }


### PR DESCRIPTION
Simpler version of #1725: simply ignoring the failure from the userinfo call.

Also cleaned up the tests and moved userinfo call to the auth client. There was also quite some convoluted logic around verbosity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added JSON output mode for the whoami command.
  * Display now includes Workspace and SubscriberTier in human-readable output.
  * AccountID (TenantID) is available in output; Tenant/TenantID are shown only in verbose mode.

* **Bug Fixes**
  * Improved error handling when fetching user info so the command continues gracefully on partial failures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->