### PR TITLE
Try to find a usable delegation set before creating one

### DIFF
--- a/src/pkg/cli/client/byoc/gcp/byoc.go
+++ b/src/pkg/cli/client/byoc/gcp/byoc.go
@@ -356,9 +356,9 @@ func (b *ByocGcp) runCdCommand(ctx context.Context, cmd cdCommand) (string, erro
 		return "", err
 	}
 	env := map[string]string{
-		"DEFANG_DEBUG": os.Getenv("DEFANG_DEBUG"), // TODO: use the global DoDebug flag
-		"DEFANG_JSON":  os.Getenv("DEFANG_JSON"),
-		"DEFANG_MODE":  strings.ToLower(cmd.mode.String()),
+		"DEFANG_DEBUG":             os.Getenv("DEFANG_DEBUG"), // TODO: use the global DoDebug flag
+		"DEFANG_JSON":              os.Getenv("DEFANG_JSON"),
+		"DEFANG_MODE":              strings.ToLower(cmd.mode.String()),
 		"DEFANG_ORG":               string(b.TenantLabel),
 		"DEFANG_PREFIX":            b.Prefix,
 		"DEFANG_PULUMI_DEBUG":      os.Getenv("DEFANG_PULUMI_DEBUG"),

--- a/src/pkg/clouds/aws/route53.go
+++ b/src/pkg/clouds/aws/route53.go
@@ -62,6 +62,47 @@ func GetDelegationSetByZone(ctx context.Context, zoneId *string, r53 Route53API)
 	return resp.DelegationSet, nil
 }
 
+func ListReusableDelegationSets(ctx context.Context, r53 Route53API) ([]types.DelegationSet, error) {
+	var delegationSets []types.DelegationSet
+	var nextMarker *string
+	for {
+		params := &route53.ListReusableDelegationSetsInput{
+			Marker: nextMarker,
+		}
+		resp, err := r53.ListReusableDelegationSets(ctx, params)
+		if err != nil {
+			return nil, err
+		}
+		delegationSets = append(delegationSets, resp.DelegationSets...)
+		if !resp.IsTruncated {
+			break
+		}
+		nextMarker = resp.NextMarker
+	}
+	return delegationSets, nil
+}
+
+func ListHostedZonesByDelegationSet(ctx context.Context, delegationSetId *string, r53 Route53API) ([]types.HostedZone, error) {
+	var hostedZones []types.HostedZone
+	var nextMarker *string
+	for {
+		params := &route53.ListHostedZonesInput{
+			DelegationSetId: delegationSetId,
+			Marker:          nextMarker,
+		}
+		resp, err := r53.ListHostedZones(ctx, params)
+		if err != nil {
+			return nil, err
+		}
+		hostedZones = append(hostedZones, resp.HostedZones...)
+		if !resp.IsTruncated {
+			break
+		}
+		nextMarker = resp.NextMarker
+	}
+	return hostedZones, nil
+}
+
 func GetHostedZonesByName(ctx context.Context, domain string, r53 Route53API) ([]*types.HostedZone, error) {
 	var nextHostedZoneId *string
 	var zones []*types.HostedZone


### PR DESCRIPTION
## Description
Try to reuse an existing delegation set if available instead of creating new one.

## Linked Issues
fixes https://github.com/DefangLabs/defang-mvp/issues/2559

## Checklist

- [X] I have performed a self-review of my code
- [X] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * DNS delegation sets can now be reused when available, optimizing resource allocation and reducing unnecessary creation.
  * Enhanced conflict detection for DNS name servers across multiple domains during configuration.

* **Bug Fixes**
  * Added non-fatal error handling with improved logging to preserve deployment progress when conflicts are detected.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->