### PR TITLE
feat: allow project/stack syntax for cd commands

### DIFF
--- a/src/cmd/cli/command/commands.go
+++ b/src/cmd/cli/command/commands.go
@@ -1217,6 +1217,14 @@ func configureLoader(cmd *cobra.Command) *compose.Loader {
 		panic(err)
 	}
 
+	if slash := strings.Index(projectName, "/"); slash != -1 {
+		// Compose project names cannot have slashes; use the part after the slash as the "stack" name
+		stackName := projectName[slash+1:]
+		term.Debugf("Setting DEFANG_SUFFIX=%q", stackName)
+		os.Setenv("DEFANG_SUFFIX", stackName)
+		projectName = projectName[:slash]
+	}
+
 	// Avoid common mistakes
 	var prov client.ProviderID
 	if prov.Set(projectName) == nil && !cmd.Flag("provider").Changed {


### PR DESCRIPTION
## Description

This is to fix the weekly clean-up cron job:
* `defang cd ls -a` shows projects and their stacks as `project/beta` etc
* this PR allows `defang cd down --project-name project/beta` to destroy stack beta of the project. 
Note that `--stack` would not work since there's no stack file when you do `defang cd …`

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for project names containing slashes. The system now automatically parses the portion after the slash as the stack name while treating the preceding portion as the project identifier.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->