### PR TITLE
fix(aws): ignore logs query limit until TS changes

### DIFF
--- a/src/pkg/clouds/aws/cw/logs.go
+++ b/src/pkg/clouds/aws/cw/logs.go
@@ -247,9 +247,9 @@ func filterLogEvents(ctx context.Context, cw FilterLogEventsAPI, lgi LogGroupInp
 			return nil
 		}
 		if limit > 0 {
-			if len(events) < int(limit) {
+			if len(events) < int(limit) { // this handles len(events) == 0 as well
 				limit -= int32(len(events)) // #nosec G115 - always safe because len(events) < limit
-			} else if len(events) > 0 && time.UnixMilli(*events[len(events)-1].Timestamp).Equal(start) {
+			} else if lastTS := events[len(events)-1].Timestamp; lastTS != nil && time.UnixMilli(*lastTS).Equal(start) {
 				// If the last event timestamp is equal to the start time, we risk getting stuck in a loop
 				// where the agent keeps asking for logs since the last timestamp, but ends up fetching the same logs
 				// over and over. To avoid this, we ignore the limit and keep going, until the timestamp changes.


### PR DESCRIPTION
## Description

If the last event timestamp is equal to the start time, we risk getting stuck in a loop where the agent keeps asking for logs since the last timestamp, but ends up fetching the same logs over and over. 

This can happen with CodeBuild logs, which are very bursty, ie. there's 100s of log lines with the exact ms timestamp, so the `--since` shown in the bookend is the exact one that was used to fetch the logs.

To avoid this, we ignore the limit and keep going, until the timestamp changes.

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CloudWatch log pagination to prevent potential infinite loops when fetching events; added safer progress handling when event timestamps stall and refined termination conditions to ensure retrieval completes reliably.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->