### PR TITLE
feat: add support for unix timestamps

### DIFF
--- a/src/cmd/cli/command/commands.go
+++ b/src/cmd/cli/command/commands.go
@@ -297,8 +297,8 @@ func SetupCommands(version string) {
 	debugCmd.Flags().String("etag", "", "deployment ID (ETag) of the service")
 	debugCmd.Flags().MarkHidden("etag")
 	debugCmd.Flags().String("deployment", "", "deployment ID of the service")
-	debugCmd.Flags().String("since", "", "start time for logs (RFC3339 format)")
-	debugCmd.Flags().String("until", "", "end time for logs (RFC3339 format)")
+	debugCmd.Flags().String("since", "", "start time for logs; duration or timestamp (unix or RFC3339)")
+	debugCmd.Flags().String("until", "", "end time for logs; duration or timestamp (unix or RFC3339)")
 	debugCmd.Flags().StringVar(&global.ModelID, "model", global.ModelID, "LLM model to use for debugging (Pro users only)")
 	RootCmd.AddCommand(debugCmd)
 

--- a/src/cmd/cli/command/compose.go
+++ b/src/cmd/cli/command/compose.go
@@ -650,8 +650,8 @@ func setupLogsFlags(cmd *cobra.Command) {
 	cmd.Flags().String("deployment", "", "deployment ID of the service (use 'latest' for the most recent deployment)")
 	cmd.Flags().Bool("follow", false, "follow log output; incompatible with --until") // NOTE: -f is already used by --file
 	cmd.Flags().BoolP("raw", "r", false, "show raw (unparsed) logs")
-	cmd.Flags().String("since", "", "show logs since duration/time")
-	cmd.Flags().String("until", "", "show logs until duration/time; incompatible with --follow")
+	cmd.Flags().String("since", "", "show logs since duration or timestamp (unix or RFC3339)")
+	cmd.Flags().String("until", "", "show logs until duration or timestamp (unix or RFC3339); incompatible with --follow")
 	cmd.Flags().Bool("utc", false, "show logs in UTC timezone (ie. TZ=UTC)")
 	cmd.Flags().Var(&logType, "type", fmt.Sprintf("show logs of type; one of %v", logs.AllLogTypes))
 	cmd.Flags().String("filter", "", "only show logs containing given text; case-insensitive")

--- a/src/pkg/timeutils/timeutils_test.go
+++ b/src/pkg/timeutils/timeutils_test.go
@@ -18,6 +18,9 @@ func TestParseTimeOrDuration(t *testing.T) {
 		{"2024-02-01T00:00:00.500Z", time.Date(2024, 2, 1, 0, 0, 0, 5e8, time.UTC)},
 		{"2024-03-01T00:00:00+07:00", time.Date(2024, 3, 1, 0, 0, 0, 0, time.FixedZone("", 7*60*60))},
 		{"00:01:02.040", time.Date(now.Year(), now.Month(), now.Day(), 0, 1, 2, 4e7, now.Location())}, // this test will fail if it's run at midnight UTC :(
+		{"1767075448030", time.UnixMilli(1767075448030)},
+		{"1767075448", time.Unix(1767075448, 0)},
+		{"1767075448.03", time.Unix(1767075448, 30000000)},
 	}
 	for _, tt := range tdt {
 		t.Run(tt.td, func(t *testing.T) {


### PR DESCRIPTION

## Description

These often appear in the cloud logs, for example AWS CloudWatch has Unix timestamp in ms. 

I used this while debugging prod alerts we got.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added appropriate tests
- [x] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced timestamp parsing to accept Unix epoch timestamps (milliseconds and seconds) in addition to duration and RFC3339 formats for log-related flags.

* **Documentation**
  * Updated help text for `--since` and `--until` flags in debug and compose commands to document newly supported timestamp formats.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->