### PR TITLE
Avoid loading stacks from disk after selection

### DIFF
--- a/src/pkg/stacks/selector.go
+++ b/src/pkg/stacks/selector.go
@@ -28,36 +28,14 @@ func (ss *stackSelector) SelectStack(ctx context.Context) (*StackParameters, err
 	if !ss.ec.IsSupported() {
 		return nil, errors.New("your mcp client does not support elicitations, use the 'select_stack' tool to choose a stack")
 	}
-	selectedStackName, err := ss.elicitStackSelection(ctx, ss.ec)
-	if err != nil {
-		return nil, fmt.Errorf("failed to select stack: %w", err)
-	}
-
-	if selectedStackName == CreateNewStack {
-		wizard := NewWizard(ss.ec)
-		params, err := wizard.CollectParameters(ctx)
-		if err != nil {
-			return nil, fmt.Errorf("failed to collect stack parameters: %w", err)
-		}
-		_, err = ss.sm.Create(*params)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create stack: %w", err)
-		}
-
-		selectedStackName = params.Name
-	}
-
-	return ss.sm.Load(selectedStackName)
-}
-
-func (ss *stackSelector) elicitStackSelection(ctx context.Context, ec elicitations.Controller) (string, error) {
 	stackList, err := ss.sm.List(ctx)
 	if err != nil {
-		return "", fmt.Errorf("failed to list stacks: %w", err)
+		return nil, fmt.Errorf("failed to list stacks: %w", err)
 	}
 
+	var selectedName string
 	if len(stackList) == 0 {
-		return CreateNewStack, nil
+		return ss.createStack(ctx)
 	}
 
 	stackLabels := make([]string, 0, len(stackList)+1)
@@ -77,23 +55,47 @@ func (ss *stackSelector) elicitStackSelection(ctx context.Context, ec elicitatio
 	stackLabels = append(stackLabels, CreateNewStack)
 
 	printStacksInfoMessage(stackNames)
-	selectedLabel, err := ec.RequestEnum(ctx, "Select a stack", "stack", stackLabels)
+	selectedLabel, err := ss.ec.RequestEnum(ctx, "Select a stack", "stack", stackLabels)
 	if err != nil {
-		return "", fmt.Errorf("failed to elicit stack choice: %w", err)
+		return nil, fmt.Errorf("failed to elicit stack choice: %w", err)
 	}
 
 	// If "Create new stack" was selected, return as-is
 	if selectedLabel == CreateNewStack {
-		return CreateNewStack, nil
+		return ss.createStack(ctx)
 	}
 
 	// Otherwise, map back to the actual stack name
 	selectedName, exists := labelMap[selectedLabel]
 	if !exists {
-		return "", fmt.Errorf("invalid stack selection: %s", selectedLabel)
+		return nil, fmt.Errorf("invalid stack selection: %s", selectedLabel)
 	}
 
-	return selectedName, nil
+	// find the stack with the selected name in the list of stacks
+	selectedStack := StackListItem{}
+	for _, stack := range stackList {
+		if stack.Name == selectedName {
+			selectedStack = stack
+			break
+		}
+	}
+
+	params := selectedStack.ToParameters()
+	return &params, nil
+}
+
+func (ss *stackSelector) createStack(ctx context.Context) (*StackParameters, error) {
+	wizard := NewWizard(ss.ec)
+	params, err := wizard.CollectParameters(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to collect stack parameters: %w", err)
+	}
+	_, err = ss.sm.Create(*params)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create stack: %w", err)
+	}
+
+	return params, nil
 }
 
 func printStacksInfoMessage(stacks []string) {

--- a/src/pkg/stacks/stacks.go
+++ b/src/pkg/stacks/stacks.go
@@ -152,6 +152,23 @@ type StackListItem struct {
 	DeployedAt   time.Time
 }
 
+func (sli StackListItem) ToParameters() StackParameters {
+	var providerID client.ProviderID
+	providerID.Set(sli.Provider)
+	mode, err := modes.Parse(sli.Mode)
+	if err != nil {
+		mode = modes.ModeUnspecified
+	}
+	return StackParameters{
+		Name:         sli.Name,
+		Provider:     providerID,
+		Region:       sli.Region,
+		AWSProfile:   sli.AWSProfile,
+		GCPProjectID: sli.GCPProjectID,
+		Mode:         mode,
+	}
+}
+
 func List() ([]StackListItem, error) {
 	return ListInDirectory(".")
 }


### PR DESCRIPTION
## Description

This PR fixes a bug where we were trying to load a remote stack from disk during stack selection. Fabric already gives us the stack parameters, so we don't need to load them from disk at all—regardless of whether the stack is local or remote.

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error handling and messaging in stack selection workflows with clearer failure feedback.

* **Chores**
  * Streamlined stack selection flow and consolidated stack creation process.
  * Updated stack selection prompt to display generic `--stack=<stack_name>` syntax instead of executable path.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->