### PR TITLE
avoid offering to create stack unless deploying

### DIFF
--- a/src/cmd/cli/command/cd.go
+++ b/src/cmd/cli/command/cd.go
@@ -36,7 +36,7 @@ var cdCmd = &cobra.Command{
 func cdCommand(cmd *cobra.Command, args []string, command client.CdCommand, fabric client.FabricClient) error {
 	ctx := cmd.Context()
 	loader := configureLoader(cmd)
-	provider, err := newProviderChecked(ctx, loader)
+	provider, err := newProviderChecked(ctx, loader, false)
 	if err != nil {
 		return err
 	}
@@ -104,7 +104,7 @@ var cdTearDownCmd = &cobra.Command{
 		force, _ := cmd.Flags().GetBool("force")
 
 		loader := configureLoader(cmd)
-		provider, err := newProviderChecked(cmd.Context(), loader)
+		provider, err := newProviderChecked(cmd.Context(), loader, false)
 		if err != nil {
 			return err
 		}
@@ -122,7 +122,7 @@ var cdListCmd = &cobra.Command{
 		remote, _ := cmd.Flags().GetBool("remote")
 		all, _ := cmd.Flags().GetBool("all")
 
-		provider, err := newProviderChecked(cmd.Context(), nil)
+		provider, err := newProviderChecked(cmd.Context(), nil, false)
 		if err != nil {
 			return err
 		}
@@ -156,7 +156,7 @@ var cdPreviewCmd = &cobra.Command{
 			return err
 		}
 
-		provider, err := newProviderChecked(cmd.Context(), loader)
+		provider, err := newProviderChecked(cmd.Context(), loader, false)
 		if err != nil {
 			return err
 		}
@@ -183,7 +183,7 @@ var cdInstallCmd = &cobra.Command{
 	Hidden:      true, // users shouldn't have to run this manually, because it's done on deploy
 	RunE: func(cmd *cobra.Command, args []string) error {
 		loader := configureLoader(cmd)
-		provider, err := newProviderChecked(cmd.Context(), loader)
+		provider, err := newProviderChecked(cmd.Context(), loader, false)
 		if err != nil {
 			return err
 		}

--- a/src/cmd/cli/command/commands_test.go
+++ b/src/cmd/cli/command/commands_test.go
@@ -368,7 +368,7 @@ func TestNewProvider(t *testing.T) {
 		mockEC := &mockElicitationsController{}
 		mockSM := NewMockStackManager(t, client.ProviderAWS, "us-test-2")
 
-		p, err := newProvider(ctx, mockEC, mockSM)
+		p, err := newProvider(ctx, mockEC, mockSM, false)
 		if err != nil {
 			t.Fatalf("getProvider() failed: %v", err)
 		}
@@ -403,7 +403,7 @@ func TestNewProvider(t *testing.T) {
 
 		mockEC := &mockElicitationsController{}
 		mockSM := NewMockStackManager(t, client.ProviderAWS, "us-test-2")
-		p, err := newProvider(ctx, mockEC, mockSM)
+		p, err := newProvider(ctx, mockEC, mockSM, false)
 		if err != nil {
 			t.Errorf("getProvider() failed: %v", err)
 		}
@@ -439,7 +439,7 @@ func TestNewProvider(t *testing.T) {
 
 		mockEC := &mockElicitationsController{}
 		mockSM := NewMockStackManager(t, client.ProviderAWS, "us-test-2")
-		p, err := newProvider(ctx, mockEC, mockSM)
+		p, err := newProvider(ctx, mockEC, mockSM, false)
 		if err != nil {
 			t.Errorf("getProvider() failed: %v", err)
 		}
@@ -744,7 +744,7 @@ func TestGetStack(t *testing.T) {
 			var output bytes.Buffer
 
 			// Call the function under test
-			stack, whence, err := getStack(ctx, ec, sm)
+			stack, whence, err := getStack(ctx, ec, sm, true)
 
 			// Check error expectations
 			if tc.expectedError != "" {

--- a/src/cmd/cli/command/compose.go
+++ b/src/cmd/cli/command/compose.go
@@ -96,7 +96,7 @@ func makeComposeUpCmd() *cobra.Command {
 				}, loadErr)
 			}
 
-			provider, err := newProviderChecked(ctx, loader)
+			provider, err := newProviderChecked(ctx, loader, true)
 			if err != nil {
 				return err
 			}
@@ -452,7 +452,7 @@ func makeComposeDownCmd() *cobra.Command {
 			}
 
 			loader := configureLoader(cmd)
-			provider, err := newProviderChecked(cmd.Context(), loader)
+			provider, err := newProviderChecked(cmd.Context(), loader, false)
 			if err != nil {
 				return err
 			}
@@ -582,7 +582,7 @@ func makeComposeConfigCmd() *cobra.Command {
 				return fmt.Errorf("failed to create stack manager: %w", err)
 			}
 
-			provider, err := newProvider(ctx, ec, sm)
+			provider, err := newProvider(ctx, ec, sm, false)
 			if err != nil {
 				return err
 			}
@@ -611,7 +611,7 @@ func makeComposePsCmd() *cobra.Command {
 			long, _ := cmd.Flags().GetBool("long")
 
 			loader := configureLoader(cmd)
-			provider, err := newProviderChecked(cmd.Context(), loader)
+			provider, err := newProviderChecked(cmd.Context(), loader, false)
 			if err != nil {
 				return err
 			}
@@ -736,7 +736,7 @@ func handleLogsCmd(cmd *cobra.Command, args []string) error {
 	}
 
 	loader := configureLoader(cmd)
-	provider, err := newProviderChecked(cmd.Context(), loader)
+	provider, err := newProviderChecked(cmd.Context(), loader, false)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Description

Lio and I noticed it was awkward that we offer to let you create a stack during interactive stack selection when you aren't deploying. This PR changes that. The quickest way to ship seemed to be adding a boolean parameter to `newProvider` and `newProviderChecked`. Set it `false` everywhere except for when called by `ComposeUp`. I think we could improve this, but I would like to refactor `newProvider`, `newProviderChecked` and `getStack` into a new struct that will be responsible for selecting a stack and deriving the appropriate provider—that will take a little more thought than I have time for at the moment, though. 

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for interactive stack creation during stack selection operations (currently disabled by default).

* **Refactor**
  * Reorganized stack selection logic to centralize stack management behavior and improve flexibility in choosing between selecting existing stacks or creating new ones.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->