### PR TITLE
fix perfsprint lints

### DIFF
--- a/src/pkg/agent/plugins/compat_oai/generate.go
+++ b/src/pkg/agent/plugins/compat_oai/generate.go
@@ -244,11 +244,11 @@ func (g *ModelGenerator) Generate(ctx context.Context, req *ai.ModelRequest, han
 
 // concatenateContent concatenates text content into a single string
 func (g *ModelGenerator) concatenateContent(parts []*ai.Part) string {
-	content := ""
+	var b []byte
 	for _, part := range parts {
-		content += part.Text
+		b = append(b, part.Text...)
 	}
-	return content
+	return string(b)
 }
 
 // generateStream generates a streaming model response

--- a/src/pkg/cli/client/byoc/gcp/byoc.go
+++ b/src/pkg/cli/client/byoc/gcp/byoc.go
@@ -842,15 +842,18 @@ func LogEntryToString(logEntry *loggingpb.LogEntry) (string, string, error) {
 }
 
 func LogEntriesToString(logEntries []*loggingpb.LogEntry) string {
-	result := ""
+	var sb strings.Builder
 	for _, logEntry := range logEntries {
 		logTimestamp, msg, err := LogEntryToString(logEntry)
 		if err != nil {
 			continue
 		}
-		result += logTimestamp + " " + msg + "\n"
+		sb.WriteString(logTimestamp)
+		sb.WriteString(" ")
+		sb.WriteString(msg)
+		sb.WriteString("\n")
 	}
-	return result
+	return sb.String()
 }
 
 func (b *ByocGcp) query(ctx context.Context, query string) ([]*loggingpb.LogEntry, error) {

--- a/src/pkg/cli/client/byoc/parse.go
+++ b/src/pkg/cli/client/byoc/parse.go
@@ -27,11 +27,14 @@ type PulumiState struct {
 func (ps PulumiState) String() string {
 	var org, pending string
 	if len(ps.Pending) != 0 {
-		pending = " (pending"
+		var b strings.Builder
+		b.WriteString(" (pending")
 		for _, p := range ps.Pending {
-			pending += " " + strconv.Quote(p)
+			b.WriteString(" ")
+			b.WriteString(strconv.Quote(p))
 		}
-		pending += ")"
+		b.WriteString(")")
+		pending = b.String()
 	}
 	if ps.DefangOrg != "" {
 		org = " {" + string(ps.DefangOrg) + "}"


### PR DESCRIPTION
Just started seeing these warnings in my lint output:
```
make[1]: Entering directory '/Users/jordan/wk/defang/src'
src/pkg/agent/plugins/compat_oai/generate.go:249:3: concat-loop: string concatenation in a loop (perfsprint)
		content += part.Text
		^
src/pkg/cli/client/byoc/gcp/byoc.go:851:3: concat-loop: string concatenation in a loop (perfsprint)
		result += logTimestamp + " " + msg + "\n"
		^
src/pkg/cli/client/byoc/parse.go:32:4: concat-loop: string concatenation in a loop (perfsprint)
			pending += " " + strconv.Quote(p)
			^
3 issues:
* perfsprint: 3
Run 'make lint-fix' to try to fix the linting errors
make[1]: *** [Makefile:172: lint] Error 1
make[1]: Leaving directory '/Users/jordan/wk/defang/src'
make: *** [Makefile:10: pre-commit] Error 2
```

Seems like it's trying to encourage us to use string builders.

## Description

<!-- Concise description of what this PR is tackling. -->

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal string handling operations for improved performance across multiple components. These changes maintain existing functionality while reducing memory allocation overhead during string construction.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->