### PR TITLE
Add stack url to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The Defang Command-Line Interface [(CLI)](https://docs.defang.io/docs/getting-st
 
 ### Deploying with Defang
 
-If you already have a Docker Compose file, create a new stack and then deploy it. For example:
+If you already have a Docker Compose file, create a new [stack](https://docs.defang.io/docs/concepts/stacks) and then deploy it. For example:
 
 ```shell
 $ defang stack new


### PR DESCRIPTION
## Description
Since the concept "stacks" is new to defang users, it be a good idea to link them to our docs when mentioning stacks so they can read more about it. I don't think the readme gives enough information about stacks to the user.

<!-- Concise description of what this PR is tackling. -->

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added appropriate tests
- [x] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Deploying with Defang example to include a hyperlink to the stack documentation for easier reference.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->