### PR TITLE
Improves AWS profile configuration instructions

### DIFF
--- a/power/steering/deploying-to-aws.md
+++ b/power/steering/deploying-to-aws.md
@@ -25,7 +25,13 @@ The following information will be needed to create a stack:
 
 - Stack name: must be alphanumeric and must not start with a number
 - Region: for example: `us-west-2`
-- AWS Profile: the AWS profile with which the user should authenticate to AWS. First, verify the AWS CLI is installed and configured by running `aws`. You can list available profiles with `aws configure list-profiles`, and once the profiles are retrieved; prompt the user to select one. If the AWS CLI is not installed or configured, direct the user to the [installation guide](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html). Once the AWS CLI has been successfully installed, guide the user to configure an AWS Profile by running `aws configure` and entering their credentials. Then restart the stack creation process.
+- AWS Profile: the AWS profile with which the user should authenticate to AWS.
+  - First, verify the AWS CLI is installed and configured by running `aws`.
+  - List available profiles with `aws configure list-profiles` and prompt the user to select one.
+  - If the AWS CLI is not installed or configured:
+    - Direct the user to the [installation guide](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html).
+    - Once installed, guide the user to configure an AWS Profile by running `aws configure` and entering their credentials.
+    - Restart the stack creation process.
 - Deployment Mode: The deployment mode is the primary parameter for managing the cost and resiliency of your application's deployment. The following deployment modes are available: `affordable`, `balanced`, and `high_availability`. The default is `affordable`. Learn more at https://docs.defang.io/docs/concepts/deployment-modes
 
 If a new stack is created, make sure to select it before it can be used.


### PR DESCRIPTION
## Description
This pull request updates the AWS profile setup instructions in the `power/steering/deploying-to-aws.md` documentation to provide clearer guidance for users who have not yet configured the AWS CLI. The changes clarify the process of selecting an AWS profile and instruct users on how to configure one if needed.

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded AWS Profile guidance for stack creation: checks that the AWS CLI is installed, shows how to list and select an AWS profile, and guides users who lack the CLI to installation instructions. Adds steps to run aws configure to set credentials and advises restarting the stack creation process after setup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->