### PR TITLE
ensure stack env vars are loaded

### DIFF
--- a/src/pkg/session/session.go
+++ b/src/pkg/session/session.go
@@ -64,6 +64,10 @@ func (sl *SessionLoader) LoadSession(ctx context.Context) (*Session, error) {
 	if err != nil {
 		return nil, err
 	}
+	err = stacks.LoadStackEnv(*stack, false)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load stack env: %w", err)
+	}
 	loader, err := sl.newLoader(stack)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create loader for stack %q: %w", stack.Name, err)
@@ -99,10 +103,10 @@ func (sl *SessionLoader) loadStack(ctx context.Context) (*stacks.StackParameters
 		stack, err := stackSelector.SelectStack(ctx, stacks.SelectStackOptions{
 			AllowCreate: sl.opts.AllowStackCreation,
 		})
-
 		if err != nil {
 			return nil, "", fmt.Errorf("failed to select stack: %w", err)
 		}
+
 		return stack, "interactive selection", nil
 	}
 

--- a/src/pkg/session/session_test.go
+++ b/src/pkg/session/session_test.go
@@ -355,6 +355,7 @@ func TestLoadSession(t *testing.T) {
 				actualValue, exists := session.Stack.Variables[key]
 				assert.True(t, exists, "expected env var %s to be set", key)
 				assert.Equal(t, expectedValue, actualValue, "env var %s has unexpected value", key)
+				assert.Equal(t, expectedValue, os.Getenv(key))
 			}
 
 			// Verify all mock expectations were met


### PR DESCRIPTION
## Description

We were failing to actually update the environment when some stack selection strategies were invoked. I thought I had a test for this, but it was flawed. This PR fixes the test and the implementation

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Stack environment variables are now properly loaded when a session is initialized, ensuring environment configurations are correctly applied.

* **Tests**
  * Enhanced test coverage to verify environment variable values are correctly loaded and accessible during session initialization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->