### PR TITLE
fix: by default, skip build if image is given

### DIFF
--- a/src/cmd/cli/command/compose.go
+++ b/src/cmd/cli/command/compose.go
@@ -222,12 +222,13 @@ func makeComposeUpCmd() *cobra.Command {
 	}
 	composeUpCmd.Flags().BoolP("detach", "d", false, "run in detached mode")
 	composeUpCmd.Flags().Bool("force", false, "force a build of the image even if nothing has changed")
+	composeUpCmd.Flags().MarkDeprecated("force", "superseded by --build") // but keep for backwards compatibility
 	composeUpCmd.Flags().Bool("utc", false, "show logs in UTC timezone (ie. TZ=UTC)")
-	composeUpCmd.Flags().Bool("tail", false, "tail the service logs after updating") // obsolete, but keep for backwards compatibility
+	composeUpCmd.Flags().Bool("tail", false, "tail the service logs after updating") // no-op, but keep for backwards compatibility
 	_ = composeUpCmd.Flags().MarkHidden("tail")
 	composeUpCmd.Flags().VarP(&global.Stack.Mode, "mode", "m", fmt.Sprintf("deployment mode; one of %v", modes.AllDeploymentModes()))
-	composeUpCmd.Flags().Bool("build", true, "build the image before starting the service") // docker-compose compatibility
-	composeUpCmd.Flags().Bool("wait", true, "wait for services to be running|healthy")      // docker-compose compatibility
+	composeUpCmd.Flags().Bool("build", false, "build images before starting services") // docker-compose compatibility
+	composeUpCmd.Flags().Bool("wait", true, "wait for services to be running|healthy") // docker-compose compatibility
 	_ = composeUpCmd.Flags().MarkHidden("wait")
 	composeUpCmd.Flags().Int("wait-timeout", -1, "maximum duration to wait for the project to be running|healthy") // docker-compose compatibility
 	return composeUpCmd
@@ -542,7 +543,7 @@ func makeComposeDownCmd() *cobra.Command {
 	}
 	composeDownCmd.Flags().BoolP("detach", "d", false, "run in detached mode")
 	composeDownCmd.Flags().Bool("utc", false, "show logs in UTC timezone (ie. TZ=UTC)")
-	composeDownCmd.Flags().Bool("tail", false, "tail the service logs after deleting") // obsolete, but keep for backwards compatibility
+	composeDownCmd.Flags().Bool("tail", false, "tail the service logs after deleting") // no-op, but keep for backwards compatibility
 	_ = composeDownCmd.Flags().MarkHidden("tail")
 	return composeDownCmd
 }
@@ -697,7 +698,7 @@ func setupLogsFlags(cmd *cobra.Command) {
 	cmd.Flags().StringP("name", "n", "", "name of the service (backwards compat)")
 	cmd.Flags().MarkHidden("name")
 	cmd.Flags().String("etag", "", "deployment ID (ETag) of the service")
-	cmd.Flags().MarkHidden("etag")
+	cmd.Flags().MarkDeprecated("etag", "superseded by --deployment") // but keep for backwards compatibility
 	cmd.Flags().String("deployment", "", "deployment ID of the service (use 'latest' for the most recent deployment)")
 	cmd.Flags().Bool("follow", false, "follow log output; incompatible with --until") // NOTE: -f is already used by --file
 	cmd.Flags().BoolP("raw", "r", false, "show raw (unparsed) logs")


### PR DESCRIPTION
## Description

In https://github.com/DefangLabs/defang/pull/1718 the conditional build logic was changed with the intent to skip builds if images are given (Ekai's scenario, a.o.), but the default for the `--build` flag was still `true`, so it would still build, even when both image and build were given in the Compose file.

This PR changes the default, also marks the (non-standard) `--force` flag as deprecated (which implies hidden from help/docs). 

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Compose Command Updates**
  * The --build flag now defaults to false, changing default startup/build behavior.
  * The --wait flag is now hidden from help output.
  * Tail-related flag behavior is labeled as a no-op (no functional change).

* **Deprecations**
  * The --force flag is marked deprecated but remains functional for backward compatibility.
  * The --etag flag is deprecated in favor of a new --deployment option.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->