### PR TITLE
Kiro to prefer MCP over CLI

### DIFF
--- a/power/POWER.md
+++ b/power/POWER.md
@@ -30,8 +30,9 @@ The Defang CLI can be installed via npm, Homebrew, Winget, or `eval "$(curl -fsS
 **IMPORTANT**:
 Ensure that the step above ## Validate tool is completed before proceeding to the steps below.
 
-Once the Defang CLI is installed, the Kiro Power should refer to the using the Defang MCP tools instead of the Defang CLI if possible.
-If the Defang MCP server is not working then use the Defang CLI. The Kiro Power should refer to the Defang CLI help documentation by using the command `defang --help` for further assistance.
+Once the Defang CLI is installed, the Kiro Power should use the Defang MCP tools instead of the Defang CLI whenever possible.
+- If the Defang MCP server is not working, use the Defang CLI instead.
+- For help with the Defang CLI, run `defang --help` to view the CLI help documentation.
 
 - Ask the user which cloud provider they want to use (AWS, GCP)
   - If AWS:


### PR DESCRIPTION
## Description
@raphaeltm was experiencing issues with the Kiro Power selecting the CLI instead of the MCP tools. While this behavior is acceptable in some cases, Kiro did not consult our documentation or the defang --help output, which caused it to generate invalid commands.

In this PR, we instruct Kiro to prefer the MCP tools over the CLI. If only the CLI is available, it should first reference defang --help to gather the necessary context before proceeding.

PLEASE FEEL FREE to change my context, if you have better suggestion. 

<!-- Concise description of what this PR is tackling. -->

## Linked Issues
#1793 
<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified validation onboarding to emphasize completing the "Validate tool" step first.
  * Instructs prioritizing Defang MCP tools when available and using the Defang CLI as a fallback if the MCP server is unavailable.
  * Added guidance to use the CLI help command (defang --help) for assistance.
  * Made minor wording adjustments for clearer sequencing and instructions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->