### PR TITLE
avoid printing mcp setup message in CI

### DIFF
--- a/src/bin/install
+++ b/src/bin/install
@@ -267,7 +267,7 @@ rm -r "$EXTRACT_DIR"
 rm "$FILENAME"
 
 echo "Installation completed. You can now use defang by typing '$BINARY_NAME' in the terminal."
-if [ -t 1 ]; then
+if [ -t 1 ] && [ "$CI" != "1" ] && [ "$CI" != "true" ]; then
     echo "Run '$BINARY_NAME mcp setup' to install the Defang MCP server."
 fi
 


### PR DESCRIPTION
## Description

Just saw this message in CI, and found it out-of-place. I don't think we should bother showing this in non-interactive environments.

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Installer output now only displays certain guidance messages when running in an interactive terminal; those messages are suppressed in non-interactive environments (e.g., CI or piped output), ensuring cleaner logs while preserving normal terminal prompts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->