### PR TITLE
avoid printing env vars conflict warnings if there is no conflict

### DIFF
--- a/src/pkg/stacks/stacks.go
+++ b/src/pkg/stacks/stacks.go
@@ -227,7 +227,7 @@ func LoadStackEnv(params Parameters, overload bool) error {
 
 	paramsMap := params.ToMap()
 	for key, value := range paramsMap {
-		if currentEnv[key] != value && !overload {
+		if envValue, ok := currentEnv[key]; ok && envValue != value && !overload {
 			term.Warnf("The variable %q is set in both the stack and the environment. The value from the environment will be used.\n", key)
 		}
 		if _, ok := currentEnv[key]; !ok || overload {


### PR DESCRIPTION
## Description

To reduce noise, lets avoid printing this warning if the value in the environment and the value in the stack are the same

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Environment values are now preserved and applied using their actual values rather than as simple presence flags.
  * Conflict detection now warns only when environment-provided values differ from stack values, reducing false positives.
  * Improved application logic for when environment variables are set or overridden, with clearer warning text reflecting value sources.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->