### PR TITLE
fix: log bookends should show stack

### DIFF
--- a/src/cmd/cli/command/compose.go
+++ b/src/cmd/cli/command/compose.go
@@ -765,6 +765,7 @@ func handleLogsCmd(cmd *cobra.Command, args []string) error {
 		Follow:        follow,
 		Limit:         limit,
 		PrintBookends: true,
+		Stack:         session.Stack.Name,
 	}
 	return cli.Tail(cmd.Context(), session.Provider, projectName, tailOptions)
 }

--- a/src/pkg/agent/tools/logs.go
+++ b/src/pkg/agent/tools/logs.go
@@ -80,6 +80,7 @@ func HandleLogsTool(ctx context.Context, loader client.Loader, params LogsParams
 		Limit:         100,
 		LogType:       logs.LogTypeAll,
 		PrintBookends: true,
+		Stack:         sc.Stack.Name,
 		Verbose:       true,
 	})
 

--- a/src/pkg/cli/tail.go
+++ b/src/pkg/cli/tail.go
@@ -52,6 +52,7 @@ type TailOptions struct {
 	Raw                bool
 	Services           []string
 	Since              time.Time
+	Stack              string // only used for display purposes
 	Until              time.Time
 	Verbose            bool
 	PrintBookends      bool
@@ -83,6 +84,9 @@ func (to TailOptions) String() string {
 	}
 	if to.Filter != "" {
 		cmd += fmt.Sprintf(" --filter=%q", to.Filter)
+	}
+	if to.Stack != "" {
+		cmd += " --stack=" + to.Stack
 	}
 	if len(to.Services) > 0 {
 		cmd += " " + strings.Join(to.Services, " ")


### PR DESCRIPTION
## Description

Show --stack in log bookends.

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added stack-scoped log filtering and retrieval capabilities. Users can now specify and retrieve logs for individual stacks when using log tailing functionality, enabling more granular control over log queries and filtering. This enhancement improves visibility into stack-specific operations and supports more efficient troubleshooting and operational monitoring activities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->