### PR TITLE
Parse the codebuild log etag and service name

### DIFF
--- a/src/pkg/cli/client/byoc/aws/stream_test.go
+++ b/src/pkg/cli/client/byoc/aws/stream_test.go
@@ -77,8 +77,8 @@ func TestStreamToLogEvent(t *testing.T) {
 				Message:            ptrString("#12 [7/7] RUN python manage.py collectstatic --noinput\n"),
 			},
 			wantResp: &defangv1.TailResponse{
-				Service: "cd",
-				Host:    "codebuild",
+				Service: "django-image",
+				Host:    "fb1d2a8e-9553-497e-85e4-91a57f8b6ba6",
 				Entries: []*defangv1.LogEntry{
 					{
 						Timestamp: timestamppb.New(time.Unix(1761883446, int64(12000000))),
@@ -143,7 +143,7 @@ func TestStreamToLogEvent(t *testing.T) {
 		},
 	}
 
-	var byocServiceStream = newByocServerStream(nil, testEtag, []string{"cd", "app", "django"}, nil)
+	var byocServiceStream = newByocServerStream(nil, testEtag, []string{"cd", "app", "django", "django-image"}, nil)
 
 	for _, td := range testdata {
 		tailResp := byocServiceStream.parseEvents([]cw.LogEvent{*td.event})


### PR DESCRIPTION
## Description
Use <service>-image as the service name when displaying aws code build logs.
codebuild id is used as host, matching our old behaviour of using task id as the host for kaniko.

## Checklist

- [X] I have performed a self-review of my code
- [X] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Corrected CodeBuild log stream parsing to properly extract and utilize service identity, host information, and metadata tags from log stream paths, enabling accurate log entry categorization and routing.

## Tests
* Updated test suite to validate support for additional service configurations in CodeBuild log stream processing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->