### PR TITLE
fix: don't prompt in CI

### DIFF
--- a/src/cmd/cli/command/compose.go
+++ b/src/cmd/cli/command/compose.go
@@ -244,7 +244,7 @@ func confirmDeployment(targetDirectory string, existingDeployments []*defangv1.D
 			return false
 		}
 		// Old deployments may not have a region or account ID, so we check for empty values too
-		return (dep.ProviderAccountId == accountInfo.AccountID || dep.ProviderAccountId == "") && (dep.Region == accountInfo.Region || dep.Region == "") // TODO: compare stackName
+		return (dep.ProviderAccountId == accountInfo.AccountID || dep.ProviderAccountId == "") && (dep.Region == accountInfo.Region || dep.Region == "") // already filtered by stack
 	})
 	if samePlace {
 		return true, nil


### PR DESCRIPTION

## Description

Check non-interactive flag before prompting. 

## Linked Issues

Fixes #1814

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Display existing deployments before prompting so you can review current targets prior to confirming.
  * Automatically confirm deployment steps when running in non-interactive/automated environments to avoid blocking CI or scripted workflows.
  * Streamlined confirmation flow to reduce redundant prompts and improve clarity during deployment operations, making approvals faster and less error-prone.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->