### PR TITLE
Improve post MCP installation message

### DIFF
--- a/src/bin/install
+++ b/src/bin/install
@@ -268,7 +268,9 @@ rm "$FILENAME"
 
 echo "Installation completed. You can now use defang by typing '$BINARY_NAME' in the terminal."
 if [ -t 1 ] && [ "$CI" != "1" ] && [ "$CI" != "true" ]; then
+    echo "The Defang MCP server can be used with the coding agent of your choice."
     echo "Run '$BINARY_NAME mcp setup' to install the Defang MCP server."
+    echo "Alternatively, you can use Defang's built-in agent by running '$BINARY_NAME'."
 fi
 
 # Unset the variables and functions to avoid polluting the user's environment


### PR DESCRIPTION
## Description
Currently, the CLI prints the message:
“Run defang mcp setup to install the Defang MCP server.”
This leaves users a bit confused about what to do next. Adding more context would help better guide them through the next steps.
<!-- Concise description of what this PR is tackling. -->

## Linked Issues
#1746 
<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced post-installation instructions to guide users on using the Defang MCP server with their choice of coding agents or the built-in agent option.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->