### PR TITLE
warn about conflicting provider env var

### DIFF
--- a/src/pkg/stacks/stacks.go
+++ b/src/pkg/stacks/stacks.go
@@ -227,7 +227,11 @@ func LoadStackEnv(params Parameters, overload bool) error {
 	paramsMap := params.ToMap()
 	for key, value := range paramsMap {
 		if envValue, ok := currentEnv[key]; ok && envValue != value && !overload {
-			term.Warnf("The variable %q is set in both the stack and the environment. The value from the environment will be used.\n", key)
+			if key == "DEFANG_PROVIDER" {
+				term.Warnf("The variable DEFANG_PROVIDER is set to %q in the environment, but the stack specifies %q. The value from the stack will be used.\n", envValue, value)
+			} else {
+				term.Warnf("The variable %q is set to %q in the environment, but the stack specifies %q. The value from the environment will be used.\n", key, envValue, value)
+			}
 		}
 		if _, ok := currentEnv[key]; !ok || overload {
 			err := os.Setenv(key, value)


### PR DESCRIPTION
## Description

Lio reported:

> I set `DEFANG_PROVIDER` to `gcp` and do `defang ls` . I pick stack `beta` (only choice), I get warning that `DEFANG_PROVIDER` is set in two places but env gets used (which is gcp) but then it proceeds to show aws stuff
For example:
```
$ DEFANG_PROVIDER=gcp defang ls
This project was deployed with an implicit Stack called ‘beta’ before Stacks were introduced.
   To update your existing deployment, select the ‘beta’ Stack.
Creating a new Stack will result in a separate deployment instance.
   To learn more about Stacks, visit: https://docs.defang.io/docs/concepts/stacks
To skip this prompt, run this command with --stack=<stack_name>
Select a stack
? stack beta (deployed Jan 16 2026)
! The variable “DEFANG_PROVIDER” is set in both the stack and the environment. The value from the environment will be used.
 * Using the “beta” stack on aws from interactive selection
# ...
```
So this warning is wrong. We actually ignore the environment variable in this case. `DEFANG_PROVIDER` is the only stack variable which can not be overridden by the environment, so this PR updates this warning logic to handle`DEFANG_PROVIDER` specifically.

## Linked Issues

* Fixes #1824

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved warning messages when stack configuration values conflict with environment settings. Messages now provide clearer guidance about which value takes precedence, with specialized messaging for certain configuration variables.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->