### PR TITLE
include Default column when listing stacks

### DIFF
--- a/src/cmd/cli/command/stack.go
+++ b/src/cmd/cli/command/stack.go
@@ -120,7 +120,7 @@ func makeStackListCmd() *cobra.Command {
 				return err
 			}
 
-			columns := []string{"Name", "Provider", "Region", "Mode", "DeployedAt"}
+			columns := []string{"Name", "Default", "Provider", "Region", "Mode", "DeployedAt"}
 			return term.Table(stacks, columns...)
 		},
 	}

--- a/src/cmd/cli/command/stack_test.go
+++ b/src/cmd/cli/command/stack_test.go
@@ -83,9 +83,9 @@ func TestStackListCmd(t *testing.T) {
 					Mode:     modes.ModeBalanced,
 				},
 			},
-			expectOutput: "NAME        PROVIDER  REGION       MODE        DEPLOYEDAT\n" +
-				"teststack1  aws       us-test-2    AFFORDABLE  0001-01-01 00:00:00 +0000 UTC  \n" +
-				"teststack2  gcp       us-central1  BALANCED    0001-01-01 00:00:00 +0000 UTC  \n",
+			expectOutput: "NAME        DEFAULT  PROVIDER  REGION       MODE        DEPLOYEDAT\n" +
+				"teststack1  false    aws       us-test-2    AFFORDABLE  0001-01-01 00:00:00 +0000 UTC  \n" +
+				"teststack2  false    gcp       us-central1  BALANCED    0001-01-01 00:00:00 +0000 UTC  \n",
 		},
 	}
 	for _, tt := range tests {

--- a/src/pkg/stacks/manager.go
+++ b/src/pkg/stacks/manager.go
@@ -70,6 +70,7 @@ func (sm *manager) List(ctx context.Context) ([]ListItem, error) {
 		remote, exists := stackMap[local.Parameters.Name]
 		if exists {
 			local.DeployedAt = remote.DeployedAt
+			local.Default = remote.Default
 			stackMap[local.Parameters.Name] = local
 		} else {
 			stackMap[local.Parameters.Name] = ListItem{
@@ -120,6 +121,7 @@ func (sm *manager) ListRemote(ctx context.Context) ([]ListItem, error) {
 		stackParams = append(stackParams, ListItem{
 			Parameters: *params,
 			DeployedAt: timeutils.AsTime(stack.GetLastDeployedAt(), time.Time{}),
+			Default:    stack.GetIsDefault(),
 		})
 	}
 

--- a/src/pkg/stacks/stacks.go
+++ b/src/pkg/stacks/stacks.go
@@ -144,6 +144,7 @@ func CreateInDirectory(workingDirectory string, params Parameters) (string, erro
 // for shell printing for converting to string format of StackParameters
 type ListItem struct {
 	Parameters
+	Default    bool
 	DeployedAt time.Time
 }
 


### PR DESCRIPTION
## Description

Add a default column to the stacks list table

```
defang stack ls --project-name=html-css-js

NAME       DEFAULT  PROVIDER  REGION     MODE  DEPLOYEDAT
beta       true     gcp                        2026-01-21 01:03:39.264424 +0000 UTC  
jordanaws  false    aws       us-west-2        2026-01-20 04:01:13.191839 +0000 UTC  
```

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Stack list view now includes a "Default" column to show which stack is marked as the default configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->