### PR TITLE
check on the AWS_SECRET_ACCESS_KEY in env

### DIFF
--- a/src/pkg/cli/client/byoc/aws/byoc.go
+++ b/src/pkg/cli/client/byoc/aws/byoc.go
@@ -123,9 +123,11 @@ func NewByocProvider(ctx context.Context, tenantName types.TenantLabel, stack st
 		AWSSecretAccessKey := os.Getenv("AWS_SECRET_ACCESS_KEY")
 		switch {
 		case AWSAccessKeyID != "" && AWSSecretAccessKey != "":
-			term.Warnf("Both AWS_ACCESS_KEY_ID and AWS_PROFILE (%q) are set; AWS_ACCESS_KEY_ID takes precedence and AWS_PROFILE will be ignored", awsProfileName)
+			term.Warnf("Both AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY and AWS_PROFILE (%q) are set; access keys take precedence and AWS_PROFILE will be ignored", awsProfileName)
 		case AWSAccessKeyID != "" && AWSSecretAccessKey == "":
-			term.Warnf("Both AWS_PROFILE and AWS_ACCESS_KEY_ID set but AWS_SECRET_ACCESS_KEY is invalid; using AWS_PROFILE (%q) instead", awsProfileName)
+			term.Warnf("Partial credentials found in env, missing: AWS_SECRET_ACCESS_KEY; using AWS_PROFILE (%q) instead", awsProfileName)
+		case AWSAccessKeyID == "" && AWSSecretAccessKey != "":
+			term.Warnf("Partial credentials found in env, missing: AWS_ACCESS_KEY_ID; using AWS_PROFILE (%q) instead", awsProfileName)
 		}
 	}
 

--- a/src/pkg/cli/client/byoc/aws/byoc_test.go
+++ b/src/pkg/cli/client/byoc/aws/byoc_test.go
@@ -191,7 +191,10 @@ func TestAWSEnv_ConflictingAWSCredentials(t *testing.T) {
 	envVars := []string{
 		"AWS_PROFILE",
 		"AWS_ACCESS_KEY_ID",
-		"AWS_SECRET_ACCESS_KEY"}
+		"AWS_SECRET_ACCESS_KEY",
+		"AWS_CONFIG_FILE",
+		"AWS_SHARED_CREDENTIALS_FILE",
+	}
 
 	for _, envVar := range envVars {
 		t.Setenv(envVar, "")
@@ -266,7 +269,7 @@ aws_secret_access_key = wJalrXUtnFEMI/KDEFANG/bPxRfiCYEXAMPLEKEY
 			configFiles:    false,
 			expectedError:  true,
 			expectWarning:  true,
-			warningContain: "Both AWS_PROFILE and AWS_ACCESS_KEY_ID set but AWS_SECRET_ACCESS_KEY is invalid",
+			warningContain: "Partial credentials found in env, missing: AWS_SECRET_ACCESS_KEY",
 		},
 		// With config files
 		{
@@ -299,7 +302,7 @@ aws_secret_access_key = wJalrXUtnFEMI/KDEFANG/bPxRfiCYEXAMPLEKEY
 			},
 			configFiles:    true,
 			expectWarning:  true,
-			warningContain: "Both AWS_PROFILE and AWS_ACCESS_KEY_ID set but AWS_SECRET_ACCESS_KEY is invalid",
+			warningContain: "Partial credentials found in env, missing: AWS_SECRET_ACCESS_KEY",
 		},
 		{
 			name: "AWS_PROFILE with both AWS keys, with config files",
@@ -310,7 +313,7 @@ aws_secret_access_key = wJalrXUtnFEMI/KDEFANG/bPxRfiCYEXAMPLEKEY
 			},
 			configFiles:    true,
 			expectWarning:  true,
-			warningContain: "AWS_ACCESS_KEY_ID takes precedence",
+			warningContain: "access keys take precedence",
 		},
 		// Edge cases
 		{
@@ -358,7 +361,7 @@ aws_secret_access_key = wJalrXUtnFEMI/KDEFANG/bPxRfiCYEXAMPLEKEY
 			configFiles:    true,
 			expectedError:  true,
 			expectWarning:  true,
-			warningContain: "Both AWS_PROFILE and AWS_ACCESS_KEY_ID set but AWS_SECRET_ACCESS_KEY is invalid",
+			warningContain: "Partial credentials found in env, missing: AWS_SECRET_ACCESS_KEY",
 		},
 	}
 
@@ -370,6 +373,10 @@ aws_secret_access_key = wJalrXUtnFEMI/KDEFANG/bPxRfiCYEXAMPLEKEY
 				// Point AWS SDK to our fake config files
 				t.Setenv("AWS_CONFIG_FILE", configPath)
 				t.Setenv("AWS_SHARED_CREDENTIALS_FILE", credentialsPath)
+			} else {
+				// Point AWS SDK to non-existent files to prevent finding real credentials
+				t.Setenv("AWS_CONFIG_FILE", filepath.Join(tmpDir, "nonexistent_config"))
+				t.Setenv("AWS_SHARED_CREDENTIALS_FILE", filepath.Join(tmpDir, "nonexistent_credentials"))
 			}
 
 			// Set test env vars


### PR DESCRIPTION
## Description
Consider checking the AWS_SECRET_ACCESS_KEY for this case:
```
$ AWS_PROFILE=defang-lab AWS_ACCESS_KEY_ID=asdf defang cd ls -Paws -v 
 ! Both AWS_ACCESS_KEY_ID and AWS_PROFILE ("defang-lab") are set; AWS_ACCESS_KEY_ID takes precedence and AWS_PROFILE will be ignored
 * Using the "beta" stack on aws from --provider flag
 - crewai/jordanaws
 - d/awsuswest2
 - html-css-js/beta
 - html-css-js/jordanaws
 - html-css-js/test2
For help with warnings, check our FAQ at https://s.defang.io/warnings
```

We should warn that the `AWS_PROFILE` will be used because `AWS_SECRET_ACCESS_KEY` is invalid or not set. The AWS SDK will pick the profile instead.
<!-- Concise description of what this PR is tackling. -->

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved AWS credential handling: clearer warnings when AWS_PROFILE, AWS_ACCESS_KEY_ID, and AWS_SECRET_ACCESS_KEY conflict, and explicit precedence/partial-credential messages so users know which credentials will be used.
* **Tests**
  * Strengthened tests to isolate AWS environment variables and avoid accidental use of real credential/config files, ensuring reliable behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->