### PR TITLE
chore: remove unused QueryForDebug

### DIFF
--- a/src/pkg/cli/client/byoc/do/byoc.go
+++ b/src/pkg/cli/client/byoc/do/byoc.go
@@ -596,10 +596,6 @@ func (s *subscribeStream) Close() error {
 	return nil
 }
 
-func (b *ByocDo) QueryForDebug(ctx context.Context, req *defangv1.DebugRequest) error {
-	return client.ErrNotImplemented("AI debugging is not yet supported for DO BYOC")
-}
-
 func (b *ByocDo) PrepareDomainDelegation(ctx context.Context, req client.PrepareDomainDelegationRequest) (*client.PrepareDomainDelegationResponse, error) {
 	return nil, nil // TODO: implement domain delegation for DO
 }

--- a/src/pkg/cli/client/playground.go
+++ b/src/pkg/cli/client/playground.go
@@ -149,10 +149,6 @@ func (g *PlaygroundProvider) AccountInfo(ctx context.Context) (*AccountInfo, err
 	}, nil
 }
 
-func (g *PlaygroundProvider) QueryForDebug(ctx context.Context, req *defangv1.DebugRequest) error {
-	return nil
-}
-
 func (g *PlaygroundProvider) PrepareDomainDelegation(ctx context.Context, req PrepareDomainDelegationRequest) (*PrepareDomainDelegationResponse, error) {
 	return nil, nil // Playground does not support delegate domains
 }

--- a/src/pkg/cli/client/provider.go
+++ b/src/pkg/cli/client/provider.go
@@ -81,7 +81,6 @@ type Provider interface {
 	PrepareDomainDelegation(context.Context, PrepareDomainDelegationRequest) (*PrepareDomainDelegationResponse, error)
 	Preview(context.Context, *DeployRequest) (*defangv1.DeployResponse, error)
 	PutConfig(context.Context, *defangv1.PutConfigRequest) error
-	QueryForDebug(context.Context, *defangv1.DebugRequest) error
 	QueryLogs(context.Context, *defangv1.TailRequest) (ServerStream[defangv1.TailResponse], error)
 	RemoteProjectName(context.Context) (string, error)
 	SetCanIUseConfig(*defangv1.CanIUseResponse)


### PR DESCRIPTION

## Description

new agent uses existing QueryLogs function so `QueryForDebug` is no longer used. 

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed debug query functionality from CLI provider implementations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->