### PR TITLE
Retry setting the policies on service account up to 3 times

### DIFF
--- a/src/pkg/clouds/gcp/iam.go
+++ b/src/pkg/clouds/gcp/iam.go
@@ -289,6 +289,7 @@ func (gcp Gcp) EnsurePrincipalHasServiceAccountRoles(ctx context.Context, princi
 		}
 	}
 
+checkPolicy:
 	for start := time.Now(); time.Since(start) < 5*time.Minute; {
 		vp, err := client.GetIamPolicy(ctx, &iampb.GetIamPolicyRequest{Resource: resource})
 		if err != nil {
@@ -301,7 +302,7 @@ func (gcp Gcp) EnsurePrincipalHasServiceAccountRoles(ctx context.Context, princi
 				if err := pkg.SleepWithContext(ctx, 3*time.Second); err != nil {
 					return err
 				}
-				continue
+				continue checkPolicy
 			}
 		}
 		return nil


### PR DESCRIPTION
## Description
Retry setting policies up to 3 times in case a new service account is still not visible

## Linked Issues
Fixes https://github.com/DefangLabs/defang-mvp/issues/2633

## Checklist

- [X] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of GCP IAM operations with automatic retries (up to 3 attempts) and short delays between attempts.
  * Added polling with timeouts to ensure eventual consistency after policy changes.
  * Enhanced error propagation so transient failures (including wait/sleep errors) are reported instead of being silenced.
  * Abort with clear error after exhausting retries to make failures observable.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->