### PR TITLE
Standardize the file and dir mode for context test

### DIFF
--- a/src/pkg/cli/compose/context_test.go
+++ b/src/pkg/cli/compose/context_test.go
@@ -16,7 +16,6 @@ import (
 	"testing"
 
 	"github.com/DefangLabs/defang/src/pkg/cli/client"
-	"github.com/DefangLabs/defang/src/pkg/term"
 	"github.com/compose-spec/compose-go/v2/types"
 	"github.com/moby/patternmatcher/ignorefile"
 )


### PR DESCRIPTION
## Description
So the compose test would run consistently irrespective what is the default folder mode of the checked out source code.

## Checklist

- [X] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Standardized test directory permissions to ensure consistent file/directory modes before running tests.
  * Replaced hard-coded test paths with a dynamic test context to improve reliability.
  * Minor test improvements and import updates to enhance robustness and debugging of the test suite.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->