### PR TITLE
feat: add workspace select command

### DIFF
--- a/src/cmd/cli/command/globals.go
+++ b/src/cmd/cli/command/globals.go
@@ -115,7 +115,7 @@ func NewGlobalConfig() *GlobalConfig {
 
 	hastty := term.IsTerminal() && !pkg.GetenvBool("CI")
 
-	tenant := types.TenantNameOrID("")
+	tenant := client.GetCurrentTenant()
 	if fromEnv, ok := os.LookupEnv("DEFANG_WORKSPACE"); ok {
 		tenant = types.TenantNameOrID(fromEnv)
 	} else if fromEnv, ok := os.LookupEnv("DEFANG_ORG"); ok {

--- a/src/pkg/cli/client/state.go
+++ b/src/pkg/cli/client/state.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/DefangLabs/defang/src/pkg/types"
 	"github.com/google/uuid"
 )
 
@@ -20,6 +21,7 @@ var (
 type State struct {
 	AnonID          string
 	TermsAcceptedAt time.Time
+	Tenant          types.TenantNameOrID
 }
 
 func initState(path string) State {
@@ -62,4 +64,14 @@ func AcceptTerms() error {
 
 func TermsAccepted() bool {
 	return state.termsAccepted()
+}
+
+func SetCurrentTenant(tenant types.TenantNameOrID) error {
+	state.Tenant = tenant
+	return state.write(statePath)
+}
+
+func GetCurrentTenant() types.TenantNameOrID {
+	state = initState(statePath)
+	return state.Tenant
 }


### PR DESCRIPTION
## Description

Using our (existing) state file for tracking the current workspace. 

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added workspace selection functionality to switch between workspaces with persistent storage of the selected workspace across sessions
  * CLI now remembers your current workspace selection

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->