### PR TITLE
fix: use shortened links for docs

### DIFF
--- a/src/cmd/cli/command/compose.go
+++ b/src/cmd/cli/command/compose.go
@@ -271,7 +271,7 @@ func confirmDeployment(targetDirectory string, existingDeployments []*defangv1.D
 		if err != nil {
 			term.Debugf("Failed to create stack %v", err)
 		} else {
-			term.Info(stacks.PostCreateMessage(stackName))
+			stacks.PrintCreateMessage(stackName)
 		}
 	}
 	return true, nil
@@ -321,7 +321,7 @@ func promptToCreateStack(ctx context.Context, targetDirectory string, params sta
 		return err
 	}
 
-	term.Info(stacks.PostCreateMessage(params.Name))
+	stacks.PrintCreateMessage(params.Name)
 
 	return nil
 }

--- a/src/cmd/cli/command/stack.go
+++ b/src/cmd/cli/command/stack.go
@@ -68,7 +68,7 @@ func makeStackNewCmd() *cobra.Command {
 				return err
 			}
 
-			term.Info(stacks.PostCreateMessage(params.Name))
+			stacks.PrintCreateMessage(params.Name)
 			return nil
 		},
 	}

--- a/src/pkg/cli/client/byoc/aws/byoc.go
+++ b/src/pkg/cli/client/byoc/aws/byoc.go
@@ -70,7 +70,7 @@ type ErrMissingAwsCreds struct {
 }
 
 func (e ErrMissingAwsCreds) Error() string {
-	return "Could not authenticate to the AWS service. Please check your AWS credentials and try again. (https://docs.defang.io/docs/providers/aws/#getting-started)"
+	return "Could not authenticate to the AWS service. Please check your AWS credentials and try again. (https://s.defang.io/aws-setup)"
 }
 
 func (e ErrMissingAwsCreds) Unwrap() error {
@@ -82,7 +82,7 @@ type ErrMissingAwsRegion struct {
 }
 
 func (e ErrMissingAwsRegion) Error() string {
-	return e.err.Error() + " (https://docs.defang.io/docs/providers/aws#region)"
+	return e.err.Error() + " (https://s.defang.io/aws#region)"
 }
 
 func (e ErrMissingAwsRegion) Unwrap() error {

--- a/src/pkg/cli/client/byoc/aws/validation.go
+++ b/src/pkg/cli/client/byoc/aws/validation.go
@@ -22,7 +22,7 @@ type QuotaClientAPI interface {
 var quotaClient QuotaClientAPI
 
 var ErrAWSNoConnection = errors.New("no connect to AWS service quotas")
-var ErrGPUQuotaZero = errors.New("no GPUs enabled. To resolve see https://docs.defang.io/docs/tutorials/deploy-with-gpu")
+var ErrGPUQuotaZero = errors.New("no GPUs enabled. To resolve see https://s.defang.io/deploy-gpu")
 var ErrNoQuotasReceived = errors.New("no service quotas received")
 
 func NewServiceQuotasClient(cfg aws.Config) *servicequotas.Client {

--- a/src/pkg/cli/client/byoc/do/byoc.go
+++ b/src/pkg/cli/client/byoc/do/byoc.go
@@ -487,7 +487,7 @@ func (b *ByocDo) TearDownCD(ctx context.Context) error {
 func (b *ByocDo) AccountInfo(ctx context.Context) (*client.AccountInfo, error) {
 	accessToken := os.Getenv("DIGITALOCEAN_TOKEN")
 	if accessToken == "" {
-		return nil, errors.New("DIGITALOCEAN_TOKEN must be set (https://docs.defang.io/docs/providers/digitalocean#getting-started)")
+		return nil, errors.New("DIGITALOCEAN_TOKEN must be set (https://s.defang.io/digitalocean#getting-started)")
 	}
 	account, _, err := b.client.Account.Get(ctx)
 	if err != nil {

--- a/src/pkg/cli/compose/validation.go
+++ b/src/pkg/cli/compose/validation.go
@@ -25,7 +25,7 @@ type ListConfigNamesFunc func(context.Context) ([]string, error)
 type ErrMissingConfig []string
 
 func (e ErrMissingConfig) Error() string {
-	return fmt.Sprintf("missing configs %q (https://docs.defang.io/docs/concepts/configuration)", ([]string)(e))
+	return fmt.Sprintf("missing configs %q (https://s.defang.io/config)", ([]string)(e))
 }
 
 var ErrDockerfileNotFound = errors.New("dockerfile not found")

--- a/src/pkg/setup/setup.go
+++ b/src/pkg/setup/setup.go
@@ -244,7 +244,7 @@ func (s *SetupClient) MigrateFromHeroku(ctx context.Context) (SetupResult, error
 
 	term.Info("Compose file written to", composeFilePath)
 	term.Info("Your application is now ready to deploy with Defang.")
-	term.Info("For next steps, visit https://docs.defang.io/docs/tutorials/migrate-from-heroku")
+	term.Info("For next steps, visit https://s.defang.io/from-heroku")
 
 	return SetupResult{Folder: "."}, nil
 }

--- a/src/pkg/stacks/selector.go
+++ b/src/pkg/stacks/selector.go
@@ -120,7 +120,7 @@ func printStacksInfoMessage(stacks []string) {
 			infoLine += "\n   To update your existing deployment, select the 'beta' Stack.\n" +
 				"Creating a new Stack will result in a separate deployment instance."
 		}
-		infoLine += "\n   To learn more about Stacks, visit: https://docs.defang.io/docs/concepts/stacks"
+		infoLine += "\n   To learn more about Stacks, visit: https://s.defang.io/stacks"
 		term.Println(infoLine)
 	}
 	term.Printf("To skip this prompt, run this command with --stack=%s\n", "<stack_name>")

--- a/src/pkg/stacks/stacks.go
+++ b/src/pkg/stacks/stacks.go
@@ -245,13 +245,13 @@ func filename(workingDirectory, stackname string) string {
 	return filepath.Join(workingDirectory, Directory, stackname)
 }
 
-func PostCreateMessage(stackName string) string {
-	return fmt.Sprintf(
-		"A stack file has been created at `.defang/%s`.\n"+
-			"This file contains the configuration for this stack.\n"+
+func PrintCreateMessage(stackName string) {
+	term.Infof("A stack file has been created at `.defang/%s`.", stackName)
+	term.Printf(
+		"This file contains the configuration for this stack.\n"+
 			"We recommend you commit this file to source control, so it can be used by everyone on your team.\n"+
 			"You can now deploy using `defang up --stack=%s`.\n"+
-			"To learn more about stacks, visit https://docs.defang.io/docs/concepts/stacks",
-		stackName, stackName,
+			"To learn more about stacks, visit https://s.defang.io/stacks\n",
+		stackName,
 	)
 }

--- a/src/testdata/extends/compose.yaml.warnings
+++ b/src/testdata/extends/compose.yaml.warnings
@@ -6,4 +6,4 @@
  ! service "map-reset": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors
  ! service "map-set": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors
  ! service "map-unset": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors
-Error: missing configs ["EMPTY_VALUE" "NEW_VALUE" "NO_VALUE" "WITH_VALUE"] (https://docs.defang.io/docs/concepts/configuration)
+Error: missing configs ["EMPTY_VALUE" "NEW_VALUE" "NO_VALUE" "WITH_VALUE"] (https://s.defang.io/config)

--- a/src/testdata/interpolate/compose.yaml.warnings
+++ b/src/testdata/interpolate/compose.yaml.warnings
@@ -1,4 +1,4 @@
  ! Environment variable "NODE_ENV" is ignored; add it to `.env` if needed
  ! Environment variable "NODE_ENV" is ignored; add it to `.env` or it may be resolved from config during deployment
  ! service "interpolate": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors
-Error: missing configs ["NODE_ENV" "POSTGRES_PASSWORD" "def"] (https://docs.defang.io/docs/concepts/configuration)
+Error: missing configs ["NODE_ENV" "POSTGRES_PASSWORD" "def"] (https://s.defang.io/config)


### PR DESCRIPTION
## Description

From https://github.com/DefangLabs/s.defang.io/commit/1c3833bec19919b178db973080151a3540238511 Needs that to deploy first. https://github.com/DefangLabs/s.defang.io/actions/runs/21273736679

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated help and documentation links throughout the CLI to use shorter, more direct URLs (docs.defang.io → s.defang.io).
  * Updated error messages to reference new documentation endpoints for AWS setup, GPU deployment, and configuration topics.

* **Bug Fixes**
  * Improved stack creation message display and formatting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->