### PR TITLE
avoid printing zero values in table

### DIFF
--- a/src/cmd/cli/command/stack_test.go
+++ b/src/cmd/cli/command/stack_test.go
@@ -84,8 +84,8 @@ func TestStackListCmd(t *testing.T) {
 				},
 			},
 			expectOutput: "NAME        DEFAULT  PROVIDER  REGION       MODE        DEPLOYEDAT\n" +
-				"teststack1  false    aws       us-test-2    AFFORDABLE  0001-01-01 00:00:00 +0000 UTC  \n" +
-				"teststack2  false    gcp       us-central1  BALANCED    0001-01-01 00:00:00 +0000 UTC  \n",
+				"teststack1           aws       us-test-2    AFFORDABLE    \n" +
+				"teststack2           gcp       us-central1  BALANCED      \n",
 		},
 	}
 	for _, tt := range tests {

--- a/src/pkg/cli/getServices_test.go
+++ b/src/pkg/cli/getServices_test.go
@@ -91,8 +91,8 @@ func TestPrintServices(t *testing.T) {
 		if err != nil {
 			t.Fatalf("PrintServices error = %v", err)
 		}
-		expectedOutput := "\x1b[1m\nSERVICE  DEPLOYMENT  STATE          FQDN                       ENDPOINT                           HEALTHCHECKSTATUS\x1b[0m" + `
-foo      a1b2c3      NOT_SPECIFIED  test-foo.prod1.defang.dev  https://test-foo.prod1.defang.dev  unhealthy (404 Not Found)
+		expectedOutput := "\x1b[1m\nSERVICE  DEPLOYMENT  STATE  FQDN                       ENDPOINT                           HEALTHCHECKSTATUS\x1b[0m" + `
+foo      a1b2c3             test-foo.prod1.defang.dev  https://test-foo.prod1.defang.dev  unhealthy (404 Not Found)
 `
 
 		receivedLines := strings.Split(stdout.String(), "\n")
@@ -281,8 +281,8 @@ func TestPrintServiceStatesAndEndpointsAndDomainname(t *testing.T) {
 				},
 			},
 			expectedLines: []string{
-				"SERVICE   DEPLOYMENT  STATE          FQDN  ENDPOINT",
-				"service1              NOT_SPECIFIED        https://example.com",
+				"SERVICE   DEPLOYMENT  STATE  FQDN  ENDPOINT",
+				"service1                           https://example.com",
 				"",
 			},
 		},
@@ -296,8 +296,8 @@ func TestPrintServiceStatesAndEndpointsAndDomainname(t *testing.T) {
 				},
 			},
 			expectedLines: []string{
-				"SERVICE   DEPLOYMENT  STATE          FQDN  ENDPOINT",
-				"service1              NOT_SPECIFIED        https://example.com",
+				"SERVICE   DEPLOYMENT  STATE  FQDN  ENDPOINT",
+				"service1                           https://example.com",
 				"",
 			},
 		},
@@ -312,8 +312,8 @@ func TestPrintServiceStatesAndEndpointsAndDomainname(t *testing.T) {
 				},
 			},
 			expectedLines: []string{
-				"SERVICE   DEPLOYMENT  STATE          FQDN  ENDPOINT",
-				"service1              NOT_SPECIFIED        N/A",
+				"SERVICE   DEPLOYMENT  STATE  FQDN  ENDPOINT",
+				"service1                           N/A",
 				" * Run `defang cert generate` to get a TLS certificate for your service(s)",
 				"",
 			},

--- a/src/pkg/term/table.go
+++ b/src/pkg/term/table.go
@@ -62,7 +62,13 @@ func (t *Term) Table(slice any, attributes ...string) error {
 				}
 				continue
 			}
-			_, err = fmt.Fprintf(w, "%v\t", field.Interface())
+			val := field.Interface()
+			zero := reflect.Zero(field.Type()).Interface()
+			if reflect.DeepEqual(val, zero) {
+				_, err = fmt.Fprint(w, "\t")
+			} else {
+				_, err = fmt.Fprintf(w, "%v\t", val)
+			}
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
## Description

Avoid printing zero values in tables For example:

```
defang stack ls

NAME       DEFAULT  PROVIDER  REGION       MODE        DEPLOYEDAT
beta       false    defang                             0001-01-01 00:00:00 +0000 UTC            
jordan     false    gcp       us-central1              0001-01-01 00:00:00 +0000 UTC            
jordanaws  false    aws       us-west-2                0001-01-01 00:00:00 +0000 UTC            
oneclick   false    aws       us-west-2                2026-01-23 23:25:15.857768897 +0000 UTC  
staging    true     aws       us-west-2    AFFORDABLE  2026-01-24 18:36:00.82475 +0000 UTC      
```

Should be

```
defang stack ls

NAME       DEFAULT  PROVIDER  REGION       MODE        DEPLOYEDAT
beta                defang                                                                  
jordan              gcp       us-central1                                                   
jordanaws           aws       us-west-2                                                     
oneclick   true     aws       us-west-2                                                     
staging             aws       us-west-2    AFFORDABLE  2026-01-24 18:36:00.82475 +0000 UTC  
```

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Output Updates**
  * Stack list command output has been streamlined with a simplified column layout
  * Service output refined with improved table spacing and column alignment for better readability
  * Table display enhanced to present empty or unset field values more clearly

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->