### PR TITLE
avoid failing compose config on failure to load stack

### DIFF
--- a/src/cmd/cli/command/compose.go
+++ b/src/cmd/cli/command/compose.go
@@ -547,7 +547,7 @@ func makeComposeConfigCmd() *cobra.Command {
 				CheckAccountInfo: false,
 			})
 			if err != nil {
-				term.Warn("Failed to load stack", err)
+				term.Warn("unable to load stack:", err, "- some information may not be up-to-date")
 			}
 
 			_, err = session.Provider.AccountInfo(ctx)


### PR DESCRIPTION
## Description

This PR solves a regression where we are exiting early with an error after failing to load a stack during `defang compose config`. In this case, we want to only warn about the error, then continue.

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The compose command now handles session load failures more gracefully: it logs a warning and continues execution instead of aborting, allowing subsequent operations (like account info retrieval) to run when possible.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->