### PR TITLE
restore defang compose ls

### DIFF
--- a/src/cmd/cli/command/commands.go
+++ b/src/cmd/cli/command/commands.go
@@ -292,7 +292,7 @@ func SetupCommands(version string) {
 	RootCmd.AddCommand(logsCmd)
 
 	// Deployments Command
-	var deploymentsCmd = makeDeploymentsCmd()
+	var deploymentsCmd = makeDeploymentsCmd("deployments")
 	RootCmd.AddCommand(deploymentsCmd)
 
 	// MCP Command

--- a/src/cmd/cli/command/compose.go
+++ b/src/cmd/cli/command/compose.go
@@ -811,8 +811,8 @@ services:
 	composeCmd.AddCommand(makeComposeDownCmd())
 	composeCmd.AddCommand(makeComposePsCmd())
 	composeCmd.AddCommand(makeLogsCmd())
-	deploymentsCmd := makeDeploymentsCmd()
-	composeCmd.AddCommand(deploymentsCmd)
+	composeLsCmd := makeDeploymentsCmd("ls")
+	composeCmd.AddCommand(composeLsCmd)
 	composeTailCmd := makeTailCmd()
 	composeTailCmd.Hidden = true
 	composeCmd.AddCommand(composeTailCmd)

--- a/src/cmd/cli/command/deployments.go
+++ b/src/cmd/cli/command/deployments.go
@@ -1,15 +1,17 @@
 package command
 
 import (
+	"slices"
+
 	"github.com/DefangLabs/defang/src/pkg/cli"
 	defangv1 "github.com/DefangLabs/defang/src/protos/io/defang/v1"
 	"github.com/spf13/cobra"
 )
 
-func makeDeploymentsCmd() *cobra.Command {
+func makeDeploymentsCmd(use string) *cobra.Command {
 	deploymentsCmd := &cobra.Command{
-		Use:         "deployments",
-		Aliases:     []string{"deployment", "deploys", "deps", "dep", "ls", "list"},
+		Use:         use,
+		Aliases:     slices.Compact([]string{"deployments", use, "ls", "deployment", "deploys", "deps", "dep", "ls", "list"}),
 		Annotations: authNeededAnnotation,
 		Args:        cobra.NoArgs,
 		Short:       "List all active deployments",


### PR DESCRIPTION
## Description

Create an alias `defang compose ls` for the `defang ls` command.

## Linked Issues

* Fixes #1831

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deployments command enhanced with an "ls" alias and added flags: --utc, --limit (-l) and --all (-a).

* **Bug Fixes**
  * Fixes initialization order so UTC mode and project settings are applied before listing deployments, preventing incorrect history listings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->