### PR TITLE
fix: make info/warn go to stderr on --json

### DIFF
--- a/src/cmd/cli/command/hint.go
+++ b/src/cmd/cli/command/hint.go
@@ -42,7 +42,7 @@ func prettyExecutable(def string) string {
 }
 
 func printDefangHint(hint string, cmds ...string) {
-	if pkg.GetenvBool("DEFANG_HIDE_HINTS") || !global.HasTty {
+	if pkg.GetenvBool("DEFANG_HIDE_HINTS") || !global.HasTty || global.Json {
 		return
 	}
 

--- a/src/cmd/cli/command/whoami.go
+++ b/src/cmd/cli/command/whoami.go
@@ -16,7 +16,6 @@ var whoamiCmd = &cobra.Command{
 	Annotations: authNeededAnnotation,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := cmd.Context()
-		jsonMode, _ := cmd.Flags().GetBool("json")
 
 		global.NonInteractive = true // don't show provider prompt
 
@@ -25,9 +24,7 @@ var whoamiCmd = &cobra.Command{
 			CheckAccountInfo: false, // because we do it inside cli.Whoami
 		})
 		if err != nil {
-			if !jsonMode {
-				term.Warnf("Provider account information not available: %v", err)
-			}
+			term.Warnf("Provider account information not available: %v", err)
 		} else {
 			provider = session.Provider
 		}
@@ -37,7 +34,7 @@ var whoamiCmd = &cobra.Command{
 		userInfo, err := auth.FetchUserInfo(ctx, token)
 		if err != nil {
 			// Either the auth service is down, or we're using a Fabric JWT: skip workspace information
-			if !jsonMode && global.HasTty {
+			if global.HasTty {
 				term.Warn("Workspace information unavailable:", err)
 			}
 		}

--- a/src/pkg/term/colorizer.go
+++ b/src/pkg/term/colorizer.go
@@ -216,24 +216,31 @@ func (t *Term) Debugf(format string, v ...any) (int, error) {
 	return output(t.err, DebugColor, ensureNewline(ensurePrefix(fmt.Sprintf(format, v...), " - ")))
 }
 
+func (t *Term) outOrErr() *termenv.Output {
+	if t.json {
+		return t.err
+	}
+	return t.out
+}
+
 func (t *Term) Info(v ...any) (int, error) {
-	return output(t.out, InfoColor, ensurePrefix(fmt.Sprintln(v...), " * "))
+	return output(t.outOrErr(), InfoColor, ensurePrefix(fmt.Sprintln(v...), " * "))
 }
 
 func (t *Term) Infof(format string, v ...any) (int, error) {
-	return output(t.out, InfoColor, ensureNewline(ensurePrefix(fmt.Sprintf(format, v...), " * ")))
+	return output(t.outOrErr(), InfoColor, ensureNewline(ensurePrefix(fmt.Sprintf(format, v...), " * ")))
 }
 
 func (t *Term) Warn(v ...any) (int, error) {
 	msg := ensurePrefix(fmt.Sprintln(v...), " ! ")
 	t.warnings = append(t.warnings, msg)
-	return output(t.out, WarnColor, msg)
+	return output(t.outOrErr(), WarnColor, msg)
 }
 
 func (t *Term) Warnf(format string, v ...any) (int, error) {
 	msg := ensureNewline(ensurePrefix(fmt.Sprintf(format, v...), " ! "))
 	t.warnings = append(t.warnings, msg)
-	return output(t.out, WarnColor, msg)
+	return output(t.outOrErr(), WarnColor, msg)
 }
 
 func (t *Term) Error(v ...any) (int, error) {


### PR DESCRIPTION
## Description

Also skip CLI hints when `--json` is given.

This allows us to do `defang whoami --json | jq` etc. for many commands, since typically only the JSON output would go to stdout, allowing easy parsing without `grep`/`tail`/`head` hacks. 

## Linked Issues

Builds upon #1885 

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Hints are now suppressed when JSON output format is active.
  * Warning messages display more consistently across different scenarios.
  * Output handling improved to route messages appropriately based on output mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->