### PR TITLE
Disambiguate stacks in interactive selector

### DIFF
--- a/src/pkg/stacks/manager_test.go
+++ b/src/pkg/stacks/manager_test.go
@@ -783,7 +783,7 @@ func TestGetStack(t *testing.T) {
 				},
 			},
 			interactiveResponses: map[string]string{
-				"stack": "existingstack",
+				"stack": "existingstack (gcp)",
 			},
 			expectedStack: &Parameters{
 				Name:     "existingstack",


### PR DESCRIPTION
## Description

I have a lot of stacks, and though I try to name them descriptively, sometimes, I forget which is which. This PR aims to add some extra info to the interactive stack selection list by printing stack provider, region and last deployed time after the name. If all of the providers or regions are the same, they won't be printed.

**With many providers and regions, everything is printed**
```
defang deploy
This project was deployed with an implicit Stack called 'beta' before Stacks were introduced.
   To learn more about Stacks, visit: https://s.defang.io/stacks
To skip this prompt, run this command with --stack=<stack_name>
Select a stack
? stack  [Use arrows to move, type to filter]
> jordan (Google Cloud Platform, us-central1, last deployed Jan 19 2026)
  jordanaws (AWS, us-west-2, last deployed Jan 19 2026)
  oneclick (AWS, us-west-2)
  production (AWS, us-west-2)
  staging (AWS, us-west-2, last deployed Jan 24 2026)
  beta (Defang Playground)
  Create new stack
```

**With the same provider, only region is printed**

```
defang deploy
This project was deployed with an implicit Stack called 'beta' before Stacks were introduced.
   To learn more about Stacks, visit: https://s.defang.io/stacks
To skip this prompt, run this command with --stack=<stack_name>
Select a stack
? stack  [Use arrows to move, type to filter]
> prod (us-east-1, last deployed Feb 3 2026)
  staging (us-west-2, last deployed Feb 5 2026)
  Create new stack
```

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Stack selection options now display provider and region information (e.g., "production (us-west-2)"), making it easier to distinguish between multiple stacks.

* **Tests**
  * Updated test expectations to validate enhanced stack selection labeling across various scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->