### PR TITLE
Revert "Remove RemoteProjectName"

### DIFF
--- a/src/cmd/cli/command/cd.go
+++ b/src/cmd/cli/command/cd.go
@@ -30,7 +30,7 @@ func cdCommand(cmd *cobra.Command, args []string, command client.CdCommand, fabr
 	}
 
 	if len(args) == 0 {
-		projectName, _, err := session.Loader.LoadProjectName(ctx)
+		projectName, err := client.LoadProjectNameWithFallback(ctx, session.Loader, session.Provider)
 		if err != nil {
 			return err
 		}

--- a/src/cmd/cli/command/config.go
+++ b/src/cmd/cli/command/config.go
@@ -81,7 +81,7 @@ var configSetCmd = &cobra.Command{
 			return fmt.Errorf("failed to get account info from provider %q: %w", session.Stack.Provider, err)
 		}
 
-		projectName, _, err := session.Loader.LoadProjectName(ctx)
+		projectName, err := client.LoadProjectNameWithFallback(cmd.Context(), session.Loader, session.Provider)
 		if err != nil {
 			return err
 		}
@@ -199,13 +199,12 @@ var configDeleteCmd = &cobra.Command{
 			return err
 		}
 
-		ctx := cmd.Context()
-		projectName, _, err := session.Loader.LoadProjectName(ctx)
+		projectName, err := client.LoadProjectNameWithFallback(cmd.Context(), session.Loader, session.Provider)
 		if err != nil {
 			return err
 		}
 
-		if err := cli.ConfigDelete(ctx, projectName, session.Provider, names...); err != nil {
+		if err := cli.ConfigDelete(cmd.Context(), projectName, session.Provider, names...); err != nil {
 			// Show a warning (not an error) if the config was not found
 			if connect.CodeOf(err) == connect.CodeNotFound {
 				term.Warn(client.PrettyError(err))
@@ -232,7 +231,7 @@ var configListCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		projectName, _, err := session.Loader.LoadProjectName(ctx)
+		projectName, err := client.LoadProjectNameWithFallback(ctx, session.Loader, session.Provider)
 		if err != nil {
 			return err
 		}

--- a/src/pkg/agent/tools/default_tool_cli.go
+++ b/src/pkg/agent/tools/default_tool_cli.go
@@ -63,9 +63,8 @@ func (DefaultToolCLI) ComposeDown(ctx context.Context, projectName string, fabri
 	return cli.ComposeDown(ctx, projectName, fabric, provider)
 }
 
-func (DefaultToolCLI) LoadProjectName(ctx context.Context, loader client.Loader) (string, error) {
-	projectName, _, err := loader.LoadProjectName(ctx)
-	return projectName, err
+func (DefaultToolCLI) LoadProjectNameWithFallback(ctx context.Context, loader client.Loader, provider client.Provider) (string, error) {
+	return client.LoadProjectNameWithFallback(ctx, loader, provider)
 }
 
 func (DefaultToolCLI) ConfigDelete(ctx context.Context, projectName string, provider client.Provider, name string) error {

--- a/src/pkg/agent/tools/destroy.go
+++ b/src/pkg/agent/tools/destroy.go
@@ -38,8 +38,8 @@ func HandleDestroyTool(ctx context.Context, loader client.Loader, params Destroy
 	if err != nil {
 		return "", fmt.Errorf("failed to setup provider: %w", err)
 	}
-	term.Debug("Function invoked: cli.LoadProjectName")
-	projectName, err := cli.LoadProjectName(ctx, loader)
+	term.Debug("Function invoked: cli.LoadProjectNameWithFallback")
+	projectName, err := cli.LoadProjectNameWithFallback(ctx, loader, provider)
 	if err != nil {
 		return "", fmt.Errorf("failed to load project name: %w", err)
 	}

--- a/src/pkg/agent/tools/destroy_test.go
+++ b/src/pkg/agent/tools/destroy_test.go
@@ -50,8 +50,8 @@ func (m *MockDestroyCLI) ComposeDown(ctx context.Context, projectName string, gr
 	return m.ComposeDownResult, nil
 }
 
-func (m *MockDestroyCLI) LoadProjectName(ctx context.Context, loader client.Loader) (string, error) {
-	m.CallLog = append(m.CallLog, "LoadProjectName")
+func (m *MockDestroyCLI) LoadProjectNameWithFallback(ctx context.Context, loader client.Loader, provider client.Provider) (string, error) {
+	m.CallLog = append(m.CallLog, "LoadProjectNameWithFallback")
 	if m.LoadProjectNameWithFallbackError != nil {
 		return "", m.LoadProjectNameWithFallbackError
 	}
@@ -187,7 +187,7 @@ func TestHandleDestroyTool(t *testing.T) {
 				expectedCalls := []string{
 					"Connect(test-cluster)",
 					"NewProvider(aws)",
-					"LoadProjectName",
+					"LoadProjectNameWithFallback",
 					"CanIUseProvider(test-project)",
 					"ComposeDown(test-project)",
 				}

--- a/src/pkg/agent/tools/interfaces.go
+++ b/src/pkg/agent/tools/interfaces.go
@@ -25,7 +25,7 @@ type CLIInterface interface {
 	InteractiveLoginMCP(ctx context.Context, cluster string, mcpClient string) error
 	ListConfig(ctx context.Context, provider client.Provider, projectName string) (*defangv1.Secrets, error)
 	LoadProject(ctx context.Context, loader client.Loader) (*compose.Project, error)
-	LoadProjectName(ctx context.Context, loader client.Loader) (string, error)
+	LoadProjectNameWithFallback(ctx context.Context, loader client.Loader, provider client.Provider) (string, error)
 	NewProvider(ctx context.Context, providerId client.ProviderID, client client.FabricClient, stack string) client.Provider
 	PrintEstimate(mode modes.Mode, estimate *defangv1.EstimateResponse) string
 	RunEstimate(ctx context.Context, project *compose.Project, fabric *client.GrpcClient, provider client.Provider, providerId client.ProviderID, region string, mode modes.Mode) (*defangv1.EstimateResponse, error)

--- a/src/pkg/agent/tools/listConfig.go
+++ b/src/pkg/agent/tools/listConfig.go
@@ -40,8 +40,8 @@ func HandleListConfigTool(ctx context.Context, loader client.Loader, params List
 		return "", fmt.Errorf("failed to setup provider: %w", err)
 	}
 
-	term.Debug("Function invoked: cli.LoadProjectName")
-	projectName, err := cli.LoadProjectName(ctx, loader)
+	term.Debug("Function invoked: cli.LoadProjectNameWithFallback")
+	projectName, err := cli.LoadProjectNameWithFallback(ctx, loader, provider)
 	if err != nil {
 		return "", fmt.Errorf("failed to load project name: %w", err)
 	}

--- a/src/pkg/agent/tools/listConfig_test.go
+++ b/src/pkg/agent/tools/listConfig_test.go
@@ -41,8 +41,8 @@ func (m *MockListConfigCLI) NewProvider(ctx context.Context, providerId client.P
 	return nil // Mock provider
 }
 
-func (m *MockListConfigCLI) LoadProjectName(ctx context.Context, loader client.Loader) (string, error) {
-	m.CallLog = append(m.CallLog, "LoadProjectName")
+func (m *MockListConfigCLI) LoadProjectNameWithFallback(ctx context.Context, loader client.Loader, provider client.Provider) (string, error) {
+	m.CallLog = append(m.CallLog, "LoadProjectNameWithFallback")
 	if m.LoadProjectNameError != nil {
 		return "", m.LoadProjectNameError
 	}
@@ -174,7 +174,7 @@ func TestHandleListConfigTool(t *testing.T) {
 				expectedCalls := []string{
 					"Connect(test-cluster)",
 					"NewProvider(aws)",
-					"LoadProjectName",
+					"LoadProjectNameWithFallback",
 					"ListConfig(test-project)",
 				}
 				assert.Equal(t, expectedCalls, mockCLI.CallLog)

--- a/src/pkg/agent/tools/logs.go
+++ b/src/pkg/agent/tools/logs.go
@@ -61,8 +61,8 @@ func HandleLogsTool(ctx context.Context, loader client.Loader, params LogsParams
 		return "", fmt.Errorf("failed to setup provider: %w", err)
 	}
 
-	term.Debug("Function invoked: cli.LoadProjectName")
-	projectName, err := cli.LoadProjectName(ctx, loader)
+	term.Debug("Function invoked: cli.LoadProjectNameWithFallback")
+	projectName, err := cli.LoadProjectNameWithFallback(ctx, loader, provider)
 	if err != nil {
 		return "", fmt.Errorf("failed to load project name: %w", err)
 	}

--- a/src/pkg/agent/tools/removeConfig.go
+++ b/src/pkg/agent/tools/removeConfig.go
@@ -40,8 +40,8 @@ func HandleRemoveConfigTool(ctx context.Context, loader client.Loader, params Re
 	if err != nil {
 		return "", fmt.Errorf("failed to setup provider: %w", err)
 	}
-	term.Debug("Function invoked: cli.LoadProjectName")
-	projectName, err := cli.LoadProjectName(ctx, loader)
+	term.Debug("Function invoked: cli.LoadProjectNameWithFallback")
+	projectName, err := cli.LoadProjectNameWithFallback(ctx, loader, provider)
 	if err != nil {
 		return "", fmt.Errorf("failed to load project name: %w", err)
 	}

--- a/src/pkg/agent/tools/removeConfig_test.go
+++ b/src/pkg/agent/tools/removeConfig_test.go
@@ -41,8 +41,8 @@ func (m *MockRemoveConfigCLI) NewProvider(ctx context.Context, providerId client
 	return nil // Mock provider
 }
 
-func (m *MockRemoveConfigCLI) LoadProjectName(ctx context.Context, loader client.Loader) (string, error) {
-	m.CallLog = append(m.CallLog, "LoadProjectName")
+func (m *MockRemoveConfigCLI) LoadProjectNameWithFallback(ctx context.Context, loader client.Loader, provider client.Provider) (string, error) {
+	m.CallLog = append(m.CallLog, "LoadProjectNameWithFallback")
 	if m.LoadProjectNameError != nil {
 		return "", m.LoadProjectNameError
 	}
@@ -188,7 +188,7 @@ func TestHandleRemoveConfigTool(t *testing.T) {
 				expectedCalls := []string{
 					"Connect(test-cluster)",
 					"NewProvider(aws)",
-					"LoadProjectName",
+					"LoadProjectNameWithFallback",
 					"ConfigDelete(test-project, DATABASE_URL)",
 				}
 				assert.Equal(t, expectedCalls, mockCLI.CallLog)

--- a/src/pkg/agent/tools/services.go
+++ b/src/pkg/agent/tools/services.go
@@ -41,8 +41,8 @@ func HandleServicesTool(ctx context.Context, loader client.Loader, params Servic
 	if err != nil {
 		return "", fmt.Errorf("failed to setup provider: %w", err)
 	}
-	term.Debug("Function invoked: cli.LoadProjectName")
-	projectName, err := cli.LoadProjectName(ctx, loader)
+	term.Debug("Function invoked: cli.LoadProjectNameWithFallback")
+	projectName, err := cli.LoadProjectNameWithFallback(ctx, loader, provider)
 	term.Debugf("Project name loaded: %s", projectName)
 	if err != nil {
 		if strings.Contains(err.Error(), "no projects found") {

--- a/src/pkg/agent/tools/services_test.go
+++ b/src/pkg/agent/tools/services_test.go
@@ -46,7 +46,7 @@ func (m *MockCLI) NewProvider(ctx context.Context, providerId client.ProviderID,
 	return m.MockProvider
 }
 
-func (m *MockCLI) LoadProjectName(ctx context.Context, loader client.Loader) (string, error) {
+func (m *MockCLI) LoadProjectNameWithFallback(ctx context.Context, loader client.Loader, provider client.Provider) (string, error) {
 	if m.LoadProjectNameWithFallbackError != nil {
 		return "", m.LoadProjectNameWithFallbackError
 	}

--- a/src/pkg/agent/tools/setConfig.go
+++ b/src/pkg/agent/tools/setConfig.go
@@ -44,8 +44,8 @@ func HandleSetConfig(ctx context.Context, loader client.Loader, params SetConfig
 	}
 
 	if params.ProjectName == "" {
-		term.Debug("Function invoked: cli.LoadProjectName")
-		projectName, err := cliInterface.LoadProjectName(ctx, loader)
+		term.Debug("Function invoked: cli.LoadProjectNameWithFallback")
+		projectName, err := cliInterface.LoadProjectNameWithFallback(ctx, loader, provider)
 		if err != nil {
 			return "", fmt.Errorf("failed to load project name: %w", err)
 		}

--- a/src/pkg/agent/tools/setConfig_test.go
+++ b/src/pkg/agent/tools/setConfig_test.go
@@ -64,7 +64,7 @@ func (p *MockProvider) AccountInfo(context.Context) (*client.AccountInfo, error)
 	return &client.AccountInfo{}, nil
 }
 
-func (m *MockSetConfigCLI) LoadProjectName(ctx context.Context, loader client.Loader) (string, error) {
+func (m *MockSetConfigCLI) LoadProjectNameWithFallback(ctx context.Context, loader client.Loader, provider client.Provider) (string, error) {
 	m.LoadProjectNameCalled = true
 	if m.LoadProjectNameError != nil {
 		return "", m.LoadProjectNameError

--- a/src/pkg/cli/client/projectName.go
+++ b/src/pkg/cli/client/projectName.go
@@ -1,0 +1,27 @@
+package client
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/DefangLabs/defang/src/pkg/term"
+)
+
+// Deprecated: should use stacks instead of ProjectName fallback.
+func LoadProjectNameWithFallback(ctx context.Context, loader Loader, provider Provider) (string, error) {
+	var loadErr error
+	if loader != nil {
+		projectName, _, err := loader.LoadProjectName(ctx)
+		if err == nil {
+			return projectName, nil
+		}
+		term.Debug("Failed to load local project:", err)
+		loadErr = err
+	}
+	term.Debug("Trying to get the remote project name from the provider")
+	projectName, err := provider.RemoteProjectName(ctx)
+	if err != nil {
+		return "", fmt.Errorf("%w and %w", loadErr, err)
+	}
+	return projectName, nil
+}

--- a/src/pkg/cli/client/projectName_test.go
+++ b/src/pkg/cli/client/projectName_test.go
@@ -1,0 +1,62 @@
+package client
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	composeTypes "github.com/compose-spec/compose-go/v2/types"
+)
+
+func TestLoadProjectNameWithFallback(t *testing.T) {
+	ctx := t.Context()
+
+	t.Run("with project", func(t *testing.T) {
+		loader := MockLoader{Project: composeTypes.Project{Name: "test-project"}}
+		projectName, err := LoadProjectNameWithFallback(ctx, loader, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if projectName != "test-project" {
+			t.Fatalf("expected project name 'test-project', got %q", projectName)
+		}
+	})
+
+	t.Run("no local project, no fallback", func(t *testing.T) {
+		loader := MockLoader{Error: errors.New("no local project")}
+		provider := mockRemoteProjectName{
+			Error: errors.New("no remote project"),
+		}
+		projectName, err := LoadProjectNameWithFallback(ctx, loader, provider)
+		if err == nil {
+			t.Fatalf("expected error, got project name %q", projectName)
+		}
+		if expected, got := "no local project and no remote project", err.Error(); expected != got {
+			t.Fatalf("expected error message %q, got %q", expected, got)
+		}
+	})
+
+	t.Run("no local project, with fallback", func(t *testing.T) {
+		loader := MockLoader{Error: errors.New("no local project")}
+		provider := mockRemoteProjectName{
+			ProjectName: "test-project",
+		}
+		projectName, err := LoadProjectNameWithFallback(ctx, loader, provider)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if projectName != "test-project" {
+			t.Fatalf("expected project name 'test-project', got %q", projectName)
+		}
+	})
+}
+
+type mockRemoteProjectName struct {
+	Provider
+	ProjectName string
+	Error       error
+}
+
+func (m mockRemoteProjectName) RemoteProjectName(context.Context) (string, error) {
+	return m.ProjectName, m.Error
+}

--- a/src/pkg/cli/client/provider.go
+++ b/src/pkg/cli/client/provider.go
@@ -84,6 +84,8 @@ type Provider interface {
 	Preview(context.Context, *DeployRequest) (*defangv1.DeployResponse, error)
 	PutConfig(context.Context, *defangv1.PutConfigRequest) error
 	QueryLogs(context.Context, *defangv1.TailRequest) (ServerStream[defangv1.TailResponse], error)
+	// Deprecated: should use stacks instead of ProjectName fallback.
+	RemoteProjectName(context.Context) (string, error)
 	SetCanIUseConfig(*defangv1.CanIUseResponse)
 	SetUpCD(context.Context) error
 	Subscribe(context.Context, *defangv1.SubscribeRequest) (ServerStream[defangv1.SubscribeResponse], error)


### PR DESCRIPTION
Reverts DefangLabs/defang#1919

1. Deploy project to Playground (e.g. 1-click from portal)
2. `defang ps` without add'l info should imply Playground
3. `defang ps -Pdefang` should show deployed project

Step 2. was already broken in prev CLI release. Step 3. broke with #1919. 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced project name resolution logic with improved fallback mechanisms for CLI commands. Updates project name loading across multiple commands to use a more robust provider-aware resolution path, ensuring consistent behavior when project names are not explicitly provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->