### PR TITLE
Skip userinfo call on CI

### DIFF
--- a/src/cmd/cli/command/whoami.go
+++ b/src/cmd/cli/command/whoami.go
@@ -31,10 +31,12 @@ var whoamiCmd = &cobra.Command{
 
 		token := client.GetExistingToken(global.Cluster)
 
-		userInfo, err := auth.FetchUserInfo(ctx, token)
-		if err != nil {
-			// Either the auth service is down, or we're using a Fabric JWT: skip workspace information
-			if global.HasTty {
+		var userInfo *auth.UserInfo
+		// Skip userinfo fetch in non-interactive mode (CI environments)
+		if global.HasTty {
+			userInfo, err = auth.FetchUserInfo(ctx, token)
+			if err != nil {
+				// Either the auth service is down, or we're using a Fabric JWT: skip workspace information
 				term.Warn("Workspace information unavailable:", err)
 			}
 		}


### PR DESCRIPTION
## Description
Skip the userinfo call on the CI by using `global.HasTty`.

## Linked Issues
#1834 

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the whoami command's user information fetching to better handle different execution contexts, with optimized behavior for CI environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->