### PR TITLE
fix(aws): only revoke default SG rules on VPC creation

### DIFF
--- a/src/pkg/clouds/aws/ecs/cfn/setup_test.go
+++ b/src/pkg/clouds/aws/ecs/cfn/setup_test.go
@@ -34,7 +34,7 @@ func TestCloudFormation(t *testing.T) {
 		t.Setenv("DOCKERHUB_USERNAME", "defanglabs2")
 		t.Setenv("DOCKERHUB_ACCESS_TOKEN", "defanglabs")
 
-		err := aws.SetUp(ctx, testContainers)
+		_, err := aws.SetUp(ctx, testContainers)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/src/pkg/clouds/driver.go
+++ b/src/pkg/clouds/driver.go
@@ -39,7 +39,7 @@ type TaskVolume struct {
 }
 
 type Driver interface {
-	SetUp(ctx context.Context, containers []Container) error
+	SetUp(ctx context.Context, containers []Container) (bool, error) // returns true if newly created
 	TearDown(ctx context.Context) error
 	Run(ctx context.Context, env map[string]string, args ...string) (TaskID, error)
 	Tail(ctx context.Context, taskID TaskID) error

--- a/src/pkg/crun/docker/run_test.go
+++ b/src/pkg/crun/docker/run_test.go
@@ -18,7 +18,7 @@ func TestRun(t *testing.T) {
 
 	d := New()
 
-	err := d.SetUp(context.Background(), []clouds.Container{{Image: "alpine:latest", Platform: d.platform}})
+	_, err := d.SetUp(context.Background(), []clouds.Container{{Image: "alpine:latest", Platform: d.platform}})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/src/pkg/crun/docker/setup.go
+++ b/src/pkg/crun/docker/setup.go
@@ -10,21 +10,21 @@ import (
 	"github.com/docker/docker/api/types/image"
 )
 
-func (d *Docker) SetUp(ctx context.Context, containers []clouds.Container) error {
+func (d *Docker) SetUp(ctx context.Context, containers []clouds.Container) (bool, error) {
 	if len(containers) != 1 {
-		return errors.New("only one container is supported with docker driver")
+		return false, errors.New("only one container is supported with docker driver")
 	}
 	task := containers[0]
 	rc, err := d.ImagePull(ctx, task.Image, image.PullOptions{Platform: task.Platform})
 	if err != nil {
-		return err
+		return false, err
 	}
 	defer rc.Close()
 	_, err = io.Copy(contextAwareWriter{ctx, os.Stderr}, rc) // FIXME: this outputs JSON to stderr
 	d.image = task.Image
 	d.memory = task.Memory
 	d.platform = task.Platform
-	return err
+	return false, err
 }
 
 type contextAwareWriter struct {

--- a/src/pkg/crun/local/local.go
+++ b/src/pkg/crun/local/local.go
@@ -32,13 +32,13 @@ func New() *Local {
 	return &Local{}
 }
 
-func (l *Local) SetUp(ctx context.Context, containers []clouds.Container) error {
+func (l *Local) SetUp(ctx context.Context, containers []clouds.Container) (bool, error) {
 	if len(containers) != 1 {
-		return errors.New("expected exactly one container")
+		return false, errors.New("expected exactly one container")
 	}
 	l.entrypoint = containers[0].EntryPoint
 	l.workDir = containers[0].WorkDir
-	return nil
+	return false, nil
 }
 
 func (l *Local) TearDown(ctx context.Context) error {

--- a/src/pkg/crun/local/local_test.go
+++ b/src/pkg/crun/local/local_test.go
@@ -16,7 +16,7 @@ func TestLocal(t *testing.T) {
 	ctx := t.Context()
 
 	t.Run("SetUp", func(t *testing.T) {
-		if err := l.SetUp(ctx, []clouds.Container{{EntryPoint: []string{"/bin/sh"}}}); err != nil {
+		if _, err := l.SetUp(ctx, []clouds.Container{{EntryPoint: []string{"/bin/sh"}}}); err != nil {
 			t.Fatal(err)
 		}
 	})

--- a/src/pkg/crun/run.go
+++ b/src/pkg/crun/run.go
@@ -59,7 +59,7 @@ func Run(ctx context.Context, args RunContainerArgs) error {
 			Platform: args.Platform,
 		},
 	}
-	if err := driver.SetUp(ctx, containers); err != nil {
+	if _, err := driver.SetUp(ctx, containers); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
## Description

this saves ~4s per subsequent up. 

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated cloud infrastructure setup methods to track whether resources were newly created, improving handling across AWS, Docker, and local runtime implementations.

* **Bug Fixes**
  * Fixed security group cleanup logic to only execute when resources are first provisioned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->