### PR TITLE
chore: replace GCP streams with iter.Seq2

### DIFF
--- a/src/pkg/cli/client/byoc/aws/byoc.go
+++ b/src/pkg/cli/client/byoc/aws/byoc.go
@@ -713,7 +713,7 @@ func (b *ByocAws) QueryLogs(ctx context.Context, req *defangv1.TailRequest) (ite
 		if err != nil {
 			return nil, AnnotateAwsError(err)
 		}
-		logSeq = cw.Flatten(cdSeq)
+		logSeq = pkg.Flatten(cdSeq)
 		// No need to filter events by etag because we only show logs from the specified task ID
 	} else {
 		logSeq, err = b.queryOrTailLogs(ctx, cwClient, req)
@@ -785,7 +785,7 @@ func (b *ByocAws) queryOrTailLogs(ctx context.Context, cwClient cw.LogsClient, r
 		if err != nil {
 			return nil, err
 		}
-		return cw.Flatten(logSeq), nil
+		return pkg.Flatten(logSeq), nil
 	} else {
 		logSeq, err := cw.QueryLogGroups(
 			ctx,

--- a/src/pkg/cli/client/byoc/aws/byoc_test.go
+++ b/src/pkg/cli/client/byoc/aws/byoc_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/DefangLabs/defang/src/pkg"
 	"github.com/DefangLabs/defang/src/pkg/cli/client/byoc"
 	"github.com/DefangLabs/defang/src/pkg/clouds/aws"
 	"github.com/DefangLabs/defang/src/pkg/clouds/aws/cw"
@@ -693,7 +694,7 @@ func TestQueryCdLogs(t *testing.T) {
 			require.NoError(t, err)
 
 			// Flatten and collect
-			logSeq := cw.Flatten(batchSeq)
+			logSeq := pkg.Flatten(batchSeq)
 			events := collectEvents(t, logSeq)
 			assert.Len(t, events, tt.wantCount)
 		})

--- a/src/pkg/cli/client/byoc/gcp/byoc.go
+++ b/src/pkg/cli/client/byoc/gcp/byoc.go
@@ -586,17 +586,17 @@ func (b *ByocGcp) Subscribe(ctx context.Context, req *defangv1.SubscribeRequest)
 
 	now := time.Now()
 	subscribeStream.query.AddSince(now) // Do no query historical events
-	return subscribeStream.Follow(now)
+	return subscribeStream.Follow(ctx, now)
 }
 
 func (b *ByocGcp) QueryLogs(ctx context.Context, req *defangv1.TailRequest) (iter.Seq2[*defangv1.TailResponse, error], error) {
 	logStream := b.getLogStream(ctx, b.driver, req)
 	if req.Follow {
-		return logStream.Follow(req.Since.AsTime())
+		return logStream.Follow(ctx, req.Since.AsTime())
 	} else if req.Since.IsValid() {
-		return logStream.Head(req.Limit), nil
+		return logStream.Head(ctx, req.Limit), nil
 	}
-	return logStream.Tail(req.Limit), nil
+	return logStream.Tail(ctx, req.Limit), nil
 }
 
 func (b *ByocGcp) getLogStream(ctx context.Context, gcpLogsClient GcpLogsClient, req *defangv1.TailRequest) *LogStream {

--- a/src/pkg/clouds/gcp/logging.go
+++ b/src/pkg/clouds/gcp/logging.go
@@ -4,90 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
+	"iter"
 
 	logging "cloud.google.com/go/logging/apiv2"
 	"cloud.google.com/go/logging/apiv2/loggingpb"
 	"github.com/DefangLabs/defang/src/pkg/term"
 	"google.golang.org/api/iterator"
 )
-
-func (gcp Gcp) NewTailer(ctx context.Context) (Tailer, error) {
-	client, err := logging.NewClient(ctx)
-	if err != nil {
-		return nil, err
-	}
-	tleClient, err := client.TailLogEntries(ctx)
-	if err != nil {
-		return nil, err
-	}
-	t := &gcpLoggingTailer{
-		projectId: gcp.ProjectId,
-		tleClient: tleClient,
-		client:    client,
-	}
-	return t, nil
-}
-
-type Tailer interface {
-	Start(ctx context.Context, query string) error
-	Next(ctx context.Context) (*loggingpb.LogEntry, error)
-	Close() error
-}
-
-type gcpLoggingTailer struct {
-	projectId string
-	tleClient loggingpb.LoggingServiceV2_TailLogEntriesClient
-	client    *logging.Client
-
-	cache []*loggingpb.LogEntry
-}
-
-func (t *gcpLoggingTailer) Start(ctx context.Context, query string) error {
-	req := &loggingpb.TailLogEntriesRequest{
-		ResourceNames: []string{"projects/" + t.projectId},
-		Filter:        query,
-	}
-	if err := t.tleClient.Send(req); err != nil {
-		return fmt.Errorf("failed to send tail log entries request: %w", err)
-	}
-	return nil
-}
-
-func (t *gcpLoggingTailer) Next(ctx context.Context) (*loggingpb.LogEntry, error) {
-	if len(t.cache) == 0 {
-		resp, err := t.tleClient.Recv()
-		if err != nil {
-			return nil, err
-		}
-		t.cache = resp.GetEntries()
-		if len(t.cache) == 0 {
-			return nil, errors.New("no log entries found")
-		}
-	}
-
-	entry := t.cache[0]
-	t.cache = t.cache[1:]
-	return entry, nil
-}
-
-func (t *gcpLoggingTailer) Close() error {
-	// TODO: find out how to properly close the client
-	term.Debugf("Closing log tailer")
-	e1 := t.tleClient.CloseSend()
-	term.Debugf("Closing log tailer client")
-	e2 := t.client.Close()
-	return errors.Join(e1, e2)
-}
-
-type Lister interface {
-	Next() (*loggingpb.LogEntry, error)
-}
-
-type gcpLoggingLister struct {
-	it     *logging.LogEntryIterator
-	client *logging.Client
-}
 
 type Order string
 
@@ -96,7 +19,9 @@ const (
 	OrderAscending  Order = "asc"
 )
 
-func (gcp Gcp) ListLogEntries(ctx context.Context, query string, order Order) (Lister, error) {
+// ListLogEntries returns an iterator over log entries matching the query.
+// The underlying client is closed when iteration completes or is stopped.
+func (gcp Gcp) ListLogEntries(ctx context.Context, query string, order Order) (iter.Seq2[[]*loggingpb.LogEntry, error], error) {
 	client, err := logging.NewClient(ctx)
 	if err != nil {
 		return nil, err
@@ -108,17 +33,66 @@ func (gcp Gcp) ListLogEntries(ctx context.Context, query string, order Order) (L
 		OrderBy:       fmt.Sprintf("timestamp %s", order),
 	}
 	it := client.ListLogEntries(ctx, req)
-	return &gcpLoggingLister{it: it, client: client}, nil
+	return func(yield func([]*loggingpb.LogEntry, error) bool) {
+		defer func() {
+			term.Debugf("Closing log lister client")
+			client.Close()
+		}()
+		for {
+			entry, err := it.Next()
+			if err == iterator.Done {
+				return
+			}
+			if err != nil {
+				yield(nil, err)
+				return
+			}
+			if !yield([]*loggingpb.LogEntry{entry}, nil) {
+				return
+			}
+		}
+	}, nil
 }
 
-func (l *gcpLoggingLister) Next() (*loggingpb.LogEntry, error) {
-	entry, err := l.it.Next()
-	if err == iterator.Done {
-		term.Debugf("Closing log lister client")
-		if err := l.client.Close(); err != nil {
-			return nil, err
-		}
-		return nil, io.EOF
+// TailLogEntries establishes a log tail stream and sends the filter request eagerly.
+// The returned iterator yields log entries as they arrive. The underlying stream
+// and client are closed when iteration completes or is stopped.
+func (gcp Gcp) TailLogEntries(ctx context.Context, query string) (iter.Seq2[[]*loggingpb.LogEntry, error], error) {
+	client, err := logging.NewClient(ctx)
+	if err != nil {
+		return nil, err
 	}
-	return entry, err
+	tleClient, err := client.TailLogEntries(ctx)
+	if err != nil {
+		client.Close()
+		return nil, err
+	}
+
+	req := &loggingpb.TailLogEntriesRequest{
+		ResourceNames: []string{"projects/" + gcp.ProjectId},
+		Filter:        query,
+	}
+	if err := tleClient.Send(req); err != nil {
+		tleClient.CloseSend()
+		client.Close()
+		return nil, fmt.Errorf("failed to send tail log entries request: %w", err)
+	}
+
+	return func(yield func([]*loggingpb.LogEntry, error) bool) {
+		defer func() {
+			term.Debugf("Closing log tailer")
+			e1 := tleClient.CloseSend()
+			term.Debugf("Closing log tailer client")
+			e2 := client.Close()
+			if err := errors.Join(e1, e2); err != nil {
+				term.Debugf("Error closing log tailer: %v", err)
+			}
+		}()
+		for {
+			resp, err := tleClient.Recv()
+			if !yield(resp.GetEntries(), err) {
+				return
+			}
+		}
+	}, nil
 }

--- a/src/pkg/test_utils.go
+++ b/src/pkg/test_utils.go
@@ -1,0 +1,48 @@
+package pkg
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/pmezard/go-difflib/difflib"
+)
+
+func Compare(actual []byte, goldenFile string) error {
+	// Replace the absolute path in context to make the golden file portable
+	absPath, _ := filepath.Abs(goldenFile)
+	actual = bytes.ReplaceAll(actual, []byte(filepath.Dir(absPath)), []byte{'.'})
+
+	golden, err := os.ReadFile(goldenFile)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return fmt.Errorf("failed to read golden file: %w", err)
+		}
+		return os.WriteFile(goldenFile, actual, 0644)
+	} else {
+		if err := Diff(string(actual), string(golden)); err != nil {
+			return fmt.Errorf("%s %w", goldenFile, err)
+		}
+	}
+	return nil
+}
+
+func Diff(actualRaw, goldenRaw string) error {
+	if actualRaw == goldenRaw {
+		return nil
+	}
+
+	// Show the diff (but only the lines that differ to avoid overwhelming output)
+	diff, _ := difflib.GetUnifiedDiffString(difflib.UnifiedDiff{
+		A:        difflib.SplitLines(goldenRaw),
+		B:        difflib.SplitLines(actualRaw),
+		FromFile: "Expected",
+		FromDate: "",
+		ToFile:   "Actual",
+		ToDate:   "",
+		Context:  1,
+	})
+
+	return fmt.Errorf("mismatch:\n%s", diff)
+}


### PR DESCRIPTION
## Description

Applying the existing `iter.Seq2` pattern to GCP logging. 

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

