### PR TITLE
Only push release tags

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -147,7 +147,7 @@ increment-major-version:
 
 .PHONY: push-tags
 push-tags:
-	git push origin refs/tags/v*
+	git push origin 'refs/tags/v*'
 
 .PHONY: patch-release
 patch-release: pull test no-diff increment-patch-version push-tags


### PR DESCRIPTION
## Description

Update the release tasks to print the tag when making it, and only push the release tags

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Release tagging now computes and echoes the new version tag before creating it.
  * Added a dedicated push-tags step to push v* tags to the remote as part of releases.
  * Release targets updated to invoke the push-tags step to centralize tag publishing and simplify release flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->