### PR TITLE
Document token regeneration steps in smoketests.yml

### DIFF
--- a/.github/workflows/smoketests.yml
+++ b/.github/workflows/smoketests.yml
@@ -19,6 +19,20 @@ jobs:
       - name: Trigger Workflow
         uses: actions/github-script@v7
         with:
+          # If this token is expired, you can regenerate by following these steps:
+          # 1. Navigate to https://github.com/settings/personal-access-tokens/new
+          # 2. Fill out the form with the following values:
+          #   * Token name: defang-mvp-workflow-dispatch-token
+          #   * Description: This token will be used by a workflow in the `DefangLabs/defang` repository to trigger a workflow run in the `DefangLabs/defang-mvp` repository.
+          #   * Resource Owner: Defang Labs
+          #   * Expiration: 366 days
+          #   * Repositories:
+          #     * DefangLabs/defang-mvp
+          #   * Repository Permissions:
+          #     * Actions (read and write access)
+          #     * Metadata (read only)
+          # 3. Click "Generate token"
+          # 4. Copy the new token into the `DEFANG_MVP_ACTIONS_DISPATCH_TOKEN` secret in the `smoketest` environment
           github-token: ${{ secrets.DEFANG_MVP_ACTIONS_DISPATCH_TOKEN }}
           script: |
             await github.rest.actions.createWorkflowDispatch({


### PR DESCRIPTION
Added comments for regenerating GitHub token used in workflow.

## Description

<!-- Concise description of what this PR is tackling. -->

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal workflow documentation with configuration guidance.

**Note:** This release contains no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->