### PR TITLE
Fix DeleteParameters for AWS

### DIFF
--- a/src/pkg/clouds/aws/secrets.go
+++ b/src/pkg/clouds/aws/secrets.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"slices"
 	"sort"
+	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
@@ -46,16 +47,19 @@ func (a *Aws) DeleteSecrets(ctx context.Context, names ...string) error {
 	svc := NewSsmFromConfig(cfg)
 
 	// SSM DeleteParameters only allows up to 10 parameters at a time, so we need to chunk the input
+	var o ssm.DeleteParametersOutput
 	for chunk := range slices.Chunk(names, 10) {
-		o, err := svc.DeleteParameters(ctx, &ssm.DeleteParametersInput{
+		out, err := svc.DeleteParameters(ctx, &ssm.DeleteParametersInput{
 			Names: chunk, // works because getSecretID is a no-op
 		})
 		if err != nil {
 			return err
 		}
-		if len(o.InvalidParameters) > 0 && len(o.DeletedParameters) == 0 {
-			return &types.ParameterNotFound{}
-		}
+		o.InvalidParameters = append(o.InvalidParameters, out.InvalidParameters...)
+		o.DeletedParameters = append(o.DeletedParameters, out.DeletedParameters...)
+	}
+	if len(o.InvalidParameters) > 0 && len(o.DeletedParameters) == 0 {
+		return &types.ParameterNotFound{Message: ptr.String(strings.Join(o.InvalidParameters, ", "))}
 	}
 	return nil
 }


### PR DESCRIPTION
## Description

DeleteParameters takes max 10 names at a time. https://docs.aws.amazon.com/cli/latest/reference/ssm/delete-parameters.html#options

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error messages when secret deletion fails, now providing clearer and more descriptive feedback about which parameters could not be removed.
  * Improved bulk secret deletion operations through optimized batch processing, delivering better reliability and performance for managing large-scale deletion requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->