### PR TITLE
Always write debug logs to a file

### DIFF
--- a/src/cmd/cli/main.go
+++ b/src/cmd/cli/main.go
@@ -3,12 +3,16 @@ package main
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"log/slog"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"runtime/debug"
+	"sync"
 
 	"github.com/DefangLabs/defang/src/cmd/cli/command"
+	"github.com/DefangLabs/defang/src/pkg/cli/client"
 	"github.com/DefangLabs/defang/src/pkg/logs"
 	"github.com/DefangLabs/defang/src/pkg/term"
 	"github.com/DefangLabs/defang/src/pkg/track"
@@ -27,6 +31,11 @@ func main() {
 	if homeDir, err := os.UserHomeDir(); err == nil {
 		setUidGidFromFile(homeDir)
 	}
+
+	// Set up always-on debug log file; all log levels are written here.
+	// defer handles the normal-exit path; the explicit call handles os.Exit.
+	flushDebugLog := setupDebugLog()
+	defer flushDebugLog()
 
 	// Handle Ctrl+C so we can exit gracefully
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
@@ -47,6 +56,7 @@ func main() {
 		if !ok {
 			ec = 1 // should not happen since we always return ExitCode
 		}
+		flushDebugLog() // os.Exit skips defers, so flush explicitly
 		os.Exit(int(ec))
 	}
 }
@@ -55,4 +65,35 @@ func main() {
 func skipLines(buf []byte, n int) []byte {
 	lines := bytes.SplitN(buf, []byte{'\n'}, n)
 	return lines[len(lines)-1]
+}
+
+// setupDebugLog creates a temp debug log file, wires it into DefaultTerm, and
+// returns a flush function that closes and atomically renames the file to
+// debug.log. The flush function is idempotent — safe to call multiple times.
+func setupDebugLog() func() {
+	stateDir := client.StateDir
+	if err := os.MkdirAll(stateDir, 0700); err != nil {
+		return func() {}
+	}
+
+	finalPath := filepath.Join(stateDir, "debug.log")
+	f, err := os.CreateTemp(stateDir, "debug-*.log")
+	if err != nil {
+		return func() {}
+	}
+	tmpPath := f.Name()
+
+	term.SetDebugLog(f)
+
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			term.SetDebugLog(nil)
+			f.Close()
+			os.Rename(tmpPath, finalPath) //nolint:errcheck
+			if term.DoDebug() {
+				fmt.Fprintf(os.Stderr, " * Debug log written to: %s\n", finalPath)
+			}
+		})
+	}
 }

--- a/src/cmd/cli/main.go
+++ b/src/cmd/cli/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"log/slog"
 	"os"
 	"os/signal"
@@ -92,7 +91,7 @@ func setupDebugLog() func() {
 			f.Close()
 			os.Rename(tmpPath, finalPath) //nolint:errcheck
 			if term.DoDebug() {
-				fmt.Fprintf(os.Stderr, " * Debug log written to: %s\n", finalPath)
+				term.Infof("Debug log written to: %s", finalPath)
 			}
 		})
 	}

--- a/src/pkg/cli/compose/context.go
+++ b/src/pkg/cli/compose/context.go
@@ -446,9 +446,8 @@ func createArchive(ctx context.Context, root string, dockerfile string, contentT
 
 	doProgress := term.StdoutCanColor() && term.IsTerminal()
 	err := walkContextFolder(root, dockerfile, writeIgnoreFileYes, func(path string, de os.DirEntry, slashPath string) error {
-		if term.DoDebug() {
-			term.Debug("Adding", slashPath)
-		} else if doProgress {
+		term.Debug("Adding", slashPath)
+		if doProgress {
 			term.Printf("%4d %s\r", fileCount, slashPath)
 			defer term.ClearLine()
 		}

--- a/src/pkg/cli/compose/loader.go
+++ b/src/pkg/cli/compose/loader.go
@@ -120,7 +120,7 @@ func (l *Loader) loadProject(ctx context.Context, suppressWarn bool) (*Project, 
 
 	if term.DoDebug() {
 		b, _ := yaml.Marshal(project)
-		term.Println(string(b))
+		term.Debug(string(b))
 	}
 
 	l.cached = project

--- a/src/pkg/cli/compose/loader.go
+++ b/src/pkg/cli/compose/loader.go
@@ -118,10 +118,8 @@ func (l *Loader) loadProject(ctx context.Context, suppressWarn bool) (*Project, 
 		return nil, err
 	}
 
-	if term.DoDebug() {
-		b, _ := yaml.Marshal(project)
-		term.Debug(string(b))
-	}
+	b, _ := yaml.Marshal(project)
+	term.Debug(string(b))
 
 	l.cached = project
 	return project, nil

--- a/src/pkg/cli/composeUp.go
+++ b/src/pkg/cli/composeUp.go
@@ -203,12 +203,12 @@ func ComposeUp(ctx context.Context, fabric client.FabricClient, provider client.
 		term.Warn("Unable to update deployment history; deployment will proceed anyway.")
 	}
 
-	if term.DoDebug() {
-		term.Debugf("Project: %s", project.Name)
-		for _, serviceInfo := range resp.Services {
-			if b, err := MarshalPretty(serviceInfo.Service.Name, serviceInfo); err == nil {
-				term.Debug(string(b))
-			}
+	term.Debugf("Project: %s", project.Name)
+	for _, serviceInfo := range resp.Services {
+		if b, err := MarshalPretty(serviceInfo.Service.Name, serviceInfo); err != nil {
+			term.Debugf("MarshalPretty error: %v", err)
+		} else {
+			term.Debug(string(b))
 		}
 	}
 	return resp, project, nil

--- a/src/pkg/cli/composeUp.go
+++ b/src/pkg/cli/composeUp.go
@@ -204,9 +204,11 @@ func ComposeUp(ctx context.Context, fabric client.FabricClient, provider client.
 	}
 
 	if term.DoDebug() {
-		term.Println("Project:", project.Name)
+		term.Debugf("Project: %s", project.Name)
 		for _, serviceInfo := range resp.Services {
-			PrintObject(serviceInfo.Service.Name, serviceInfo)
+			if b, err := MarshalPretty(serviceInfo.Service.Name, serviceInfo); err == nil {
+				term.Debug(string(b))
+			}
 		}
 	}
 	return resp, project, nil

--- a/src/pkg/cli/generate.go
+++ b/src/pkg/cli/generate.go
@@ -39,11 +39,7 @@ func GenerateWithAI(ctx context.Context, client client.FabricClient, args Genera
 	if term.DoDebug() {
 		// Print the files that were generated
 		for _, file := range response.Files {
-			term.Printc(term.DebugColor, file.Name+"\n```")
-			term.Printc(term.DebugColor, file.Content)
-			term.Printc(term.DebugColor, "```")
-			term.Println("")
-			term.Println("")
+			term.Debugf("%s\n```\n%s\n```\n", file.Name, file.Content)
 		}
 	}
 

--- a/src/pkg/cli/generate.go
+++ b/src/pkg/cli/generate.go
@@ -36,11 +36,9 @@ func GenerateWithAI(ctx context.Context, client client.FabricClient, args Genera
 		return nil, err
 	}
 
-	if term.DoDebug() {
-		// Print the files that were generated
-		for _, file := range response.Files {
-			term.Debugf("%s\n```\n%s\n```\n", file.Name, file.Content)
-		}
+	// file.Content can be large; skip string formatting when debug output won't be captured
+	for _, file := range response.Files {
+		term.Debugf("%s\n```\n%s\n```\n", file.Name, file.Content)
 	}
 
 	// Write each file to disk

--- a/src/pkg/logs/slog.go
+++ b/src/pkg/logs/slog.go
@@ -66,9 +66,6 @@ func (h *termHandler) Handle(ctx context.Context, r slog.Record) error {
 }
 
 func (h *termHandler) Enabled(ctx context.Context, level slog.Level) bool {
-	if level == slog.LevelDebug {
-		return h.t.DoDebug()
-	}
 	return true
 }
 

--- a/src/pkg/term/colorizer.go
+++ b/src/pkg/term/colorizer.go
@@ -23,6 +23,8 @@ type Term struct {
 	hasDarkBg  bool
 
 	warnings []string
+
+	debugLog io.Writer // always-on file writer for all log levels; nil until set
 }
 
 var DefaultTerm = NewTerm(os.Stdin, os.Stdout, os.Stderr)
@@ -83,6 +85,16 @@ func (t *Term) ForceColor(color bool) {
 
 func (t *Term) SetDebug(debug bool) {
 	t.debug = debug
+}
+
+func (t *Term) SetDebugLog(w io.Writer) {
+	t.debugLog = w
+}
+
+func (t *Term) teeLog(msg string) {
+	if t.debugLog != nil {
+		fmt.Fprint(t.debugLog, msg)
+	}
 }
 
 func (t *Term) SetJSON(json bool) {
@@ -211,17 +223,19 @@ func (t *Term) Printf(format string, v ...any) (int, error) {
 }
 
 func (t *Term) Debug(v ...any) (int, error) {
-	if !t.debug {
+	if t.debugLog == nil {
 		return 0, nil
 	}
-	return output(t.err, DebugColor, ensurePrefix(debugPrefix, fmt.Sprintln(v...)))
+	msg := ensurePrefix(debugPrefix, fmt.Sprintln(v...))
+	return fmt.Fprint(t.debugLog, msg)
 }
 
 func (t *Term) Debugf(format string, v ...any) (int, error) {
-	if !t.debug {
+	if t.debugLog == nil {
 		return 0, nil
 	}
-	return output(t.err, DebugColor, ensureNewline(ensurePrefix(debugPrefix, fmt.Sprintf(format, v...))))
+	msg := ensureNewline(ensurePrefix(debugPrefix, fmt.Sprintf(format, v...)))
+	return fmt.Fprint(t.debugLog, msg)
 }
 
 func (t *Term) outOrErr() *termenv.Output {
@@ -232,32 +246,41 @@ func (t *Term) outOrErr() *termenv.Output {
 }
 
 func (t *Term) Info(v ...any) (int, error) {
-	return output(t.outOrErr(), InfoColor, ensurePrefix(infoPrefix, fmt.Sprintln(v...)))
+	msg := ensurePrefix(infoPrefix, fmt.Sprintln(v...))
+	t.teeLog(msg)
+	return output(t.outOrErr(), InfoColor, msg)
 }
 
 func (t *Term) Infof(format string, v ...any) (int, error) {
-	return output(t.outOrErr(), InfoColor, ensureNewline(ensurePrefix(infoPrefix, fmt.Sprintf(format, v...))))
+	msg := ensureNewline(ensurePrefix(infoPrefix, fmt.Sprintf(format, v...)))
+	t.teeLog(msg)
+	return output(t.outOrErr(), InfoColor, msg)
 }
 
 func (t *Term) Warn(v ...any) (int, error) {
 	msg := ensurePrefix(warnPrefix, fmt.Sprintln(v...))
 	t.warnings = append(t.warnings, msg)
+	t.teeLog(msg)
 	return output(t.outOrErr(), WarnColor, msg)
 }
 
 func (t *Term) Warnf(format string, v ...any) (int, error) {
 	msg := ensureNewline(ensurePrefix(warnPrefix, fmt.Sprintf(format, v...)))
 	t.warnings = append(t.warnings, msg)
+	t.teeLog(msg)
 	return output(t.outOrErr(), WarnColor, msg)
 }
 
 func (t *Term) Error(v ...any) (int, error) {
-	return output(t.err, ErrorColor, fmt.Sprintln(v...))
+	msg := fmt.Sprintln(v...)
+	t.teeLog(msg)
+	return output(t.err, ErrorColor, msg)
 }
 
 func (t *Term) Errorf(format string, v ...any) (int, error) {
-	line := ensureNewline(fmt.Sprintf(format, v...))
-	return output(t.err, ErrorColor, line)
+	msg := ensureNewline(fmt.Sprintf(format, v...))
+	t.teeLog(msg)
+	return output(t.err, ErrorColor, msg)
 }
 
 // Deprecated: use proper error handling instead
@@ -370,6 +393,10 @@ func ForceColor(color bool) {
 
 func SetDebug(debug bool) {
 	DefaultTerm.SetDebug(debug)
+}
+
+func SetDebugLog(w io.Writer) {
+	DefaultTerm.SetDebugLog(w)
 }
 
 func SetJSON(json bool) {

--- a/src/pkg/term/colorizer_test.go
+++ b/src/pkg/term/colorizer_test.go
@@ -74,9 +74,10 @@ func TestAddingPrefix(t *testing.T) {
 	t.Cleanup(func() {
 		DefaultTerm = defaultTerm
 	})
-	var stdout, stderr bytes.Buffer
+	var stdout, stderr, debugLog bytes.Buffer
 	DefaultTerm = NewTerm(os.Stdin, &stdout, &stderr)
 	DefaultTerm.SetDebug(true)
+	DefaultTerm.SetDebugLog(&debugLog)
 
 	Debug("Hello, World!")
 	Debugf("Hello, %s!", "World")
@@ -110,16 +111,28 @@ func TestAddingPrefix(t *testing.T) {
 		}
 	}
 
-	expectedErr := []string{
-		" - Hello, World!",
-		" - Hello, World!",
-		" - Hello, World!",
-		" - Hello, World!",
+	if stderr.String() != "" {
+		t.Errorf("Expected stderr to be empty (debug goes to log file), got %q", stderr.String())
 	}
-	gotErr := strings.Split(strings.TrimRight(stderr.String(), "\n"), "\n")
-	for i, line := range gotErr {
-		if line != expectedErr[i] {
-			t.Errorf("Expected line %v in stderr to be %q, got %q", i, expectedErr[i], line)
+
+	expectedLog := []string{
+		" - Hello, World!",
+		" - Hello, World!",
+		" - Hello, World!",
+		" - Hello, World!",
+		" * Hello, World!",
+		" * Hello, World!",
+		" * Hello, World!",
+		" * Hello, World!",
+		" ! Hello, World!",
+		" ! Hello, World!",
+		" ! Hello, World!",
+		" ! Hello, World!",
+	}
+	gotLog := strings.Split(strings.TrimRight(debugLog.String(), "\n"), "\n")
+	for i, line := range gotLog {
+		if line != expectedLog[i] {
+			t.Errorf("Expected line %v in debug log to be %q, got %q", i, expectedLog[i], line)
 		}
 	}
 }


### PR DESCRIPTION
## Description

This PR modifies the behaviour of `--debug`. Instead of printing debug logs to stdout when `--debug` is set, we will _always_ write all logs (including debug logs) to `~/.local/state/defang/debug.log`. debug logs will _never_ be printed to stdout. But if `--debug` is set, we will print a message before process exit to indicate where debug logs can be read.

```
defang whoami
 * Using the "beta" stack on auto from fallback stack

WORKSPACE  SUBSCRIBERTIER  NAME       EMAIL                         PROVIDER  REGION
smallsurf  PERSONAL        smallsurf  jordan+smallsurf@stephens.io  defang    us-west-2  
```

```
defang whoami --debug
 * Using the "beta" stack on auto from fallback stack

WORKSPACE  SUBSCRIBERTIER  NAME       EMAIL                         PROVIDER  REGION
smallsurf  PERSONAL        smallsurf  jordan+smallsurf@stephens.io  defang    us-west-2  
 * Debug log written to: /Users/jordan/.local/state/defang/debug.log
```

```
cat /Users/jordan/.local/state/defang/debug.log
 - Using tenant "personal tenant" for cluster "fabric-prod1.defang.dev:443"
 - Reading access token from file /Users/jordan/.local/state/defang/fabric-prod1.defang.dev
 - Using tenant "personal tenant" for cluster "fabric-prod1.defang.dev:443"
 - Reading access token from file /Users/jordan/.local/state/defang/fabric-prod1.defang.dev
 - fabricClient 9qfd8z49ns90 /io.defang.v1.FabricController/WhoAmI null
 - fabricClient igbv8sp0pn5p /io.defang.v1.FabricController/GetVersion null
 - Fabric: v0.6.0-1499-gefeb4779 CLI: f734447c-dirty CLI-Min: v3.1.0
 - fabricClient s76zuqbbdgee /io.defang.v1.FabricController/CheckToS null
 - tracking event "WHOAMI INVOKED": [{args []} {err <nil>} {non-interactive false} {provider auto} {CalledAs  whoami} {version f734447c-dirty}]
 - fabricClient tkzbe6jvx5uc /io.defang.v1.FabricController/Track {"anon_id":"7af0de15-0001-4ab2-af8b-d2be914e04b9","event":"WHOAMI INVOKED","properties":{"CalledAs":" whoami","args":"[]","err":"\u003cnil\u003e","non-interactive":"false","provider":"auto","version":"f734447c-dirty"},"os":"darwin","arch":"arm64"}
 - fabricClient p44s22od8p8c /io.defang.v1.FabricController/GetDefaultStack {"project":"nextjs"}
 - Creating auto provider
 * Using the "beta" stack on auto from fallback stack
 - Reading access token from file /Users/jordan/.local/state/defang/fabric-prod1.defang.dev
 - [DEBUG] GET https://auth.defang.io/userinfo
 - fabricClient eoqied3mwvv1 /io.defang.v1.FabricController/WhoAmI null
 - User ID: 4a0e5c21-a508-5397-9d54-d9a908becc08
```

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Debug logs are now automatically and persistently captured to debug.log for comprehensive post-execution diagnostics and troubleshooting without requiring manual intervention.
  * All diagnostic output is continuously recorded throughout execution, providing complete visibility into application behavior and system health.

* **Improvements**
  * Refined debug message formatting for improved clarity and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->