### PR TITLE
CI gate for go test coverage

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Download main branch coverage
         if: github.ref != 'refs/heads/main'
-        uses: dawidd6/action-download-artifact@v6
+        uses: dawidd6/action-download-artifact@1f8785ff7a5130826f848e7f72725c85d241860f
         with:
           workflow: go.yml
           branch: main
@@ -68,6 +68,10 @@ jobs:
           fi
           main_pct=$(grep '^total:' coverage-main/coverage.txt | awk '{print $3}' | tr -d '%')
           curr_pct=$(grep '^total:' src/coverage.txt | awk '{print $3}' | tr -d '%')
+          if [ -z "$main_pct" ] || [ -z "$curr_pct" ]; then
+            echo "ERROR: Could not parse coverage percentages (main='$main_pct', current='$curr_pct')"
+            exit 1
+          fi
           echo "Main: ${main_pct}%  Current branch: ${curr_pct}%"
           if awk "BEGIN { exit !(${curr_pct} < ${main_pct}) }"; then
             echo "ERROR: Coverage decreased from ${main_pct}% to ${curr_pct}%"


### PR DESCRIPTION
## Description

This PR extends our go.yml workflow to guard go test coverage. CI will compare total test coverage on this branch against total test coverage on main and fail if the number on this branch is lower than the number on main.

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced CI to produce and upload human-readable test coverage reports per branch.
  * Added automatic comparison against the main branch coverage baseline and fail the CI on coverage regressions.
  * Added branch name sanitization for artifact-friendly naming, improving artifact consistency and traceability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->