### PR TITLE
Use auth portal for better gcp and aws oauth UX

### DIFF
--- a/pkgs/defang/cli.nix
+++ b/pkgs/defang/cli.nix
@@ -7,7 +7,7 @@ buildGo124Module {
   pname = "defang-cli";
   version = "git";
   src = lib.cleanSource ../../src;
-  vendorHash = "sha256-mQ0YcinZlzeygghBGcbC2EdntqtOFMAWBbwkHOLAyq4=";
+  vendorHash = "sha256-s7glqopZLTUZIMvYVhyBW9TmnZ8ijL6vMT75CQKzLcc=";
 
   subPackages = [ "cmd/cli" ];
 

--- a/src/go.mod
+++ b/src/go.mod
@@ -59,6 +59,7 @@ require (
 	github.com/spf13/pflag v1.0.6
 	github.com/stretchr/testify v1.11.1
 	go.yaml.in/yaml/v4 v4.0.0-rc.4
+	golang.org/x/crypto v0.45.0
 	golang.org/x/mod v0.29.0
 	golang.org/x/oauth2 v0.30.0
 	golang.org/x/sys v0.40.0
@@ -136,7 +137,6 @@ require (
 	go.opentelemetry.io/contrib/detectors/gcp v1.35.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.61.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v1.40.0 // indirect
-	golang.org/x/crypto v0.45.0 // indirect
 	golang.org/x/net v0.47.0 // indirect
 	google.golang.org/genai v1.30.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20250528174236-200df99c418a // indirect

--- a/src/pkg/auth/auth.go
+++ b/src/pkg/auth/auth.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/url"
+	"path"
 	"strings"
 	"time"
 
@@ -37,6 +39,10 @@ const (
 	McpFlow LoginFlow = true
 )
 
+func GetAuthorizeUrl(authType string, parts ...string) string {
+	return fmt.Sprintf("%s/%s/%s", OpenAuthClient.issuer, authType, path.Join(parts...))
+}
+
 func StartAuthCodeFlow(ctx context.Context, mcpFlow LoginFlow, saveToken func(string), mcpClient string) (AuthCodeFlow, error) {
 	redirectUri := OpenAuthClient.GetPollRedirectURI()
 
@@ -49,7 +55,7 @@ func StartAuthCodeFlow(ctx context.Context, mcpFlow LoginFlow, saveToken func(st
 	}
 
 	// Create a shortened authorize URL by only including the variable parts (state and code_challenge)
-	authorizeUrl := fmt.Sprintf("%s/cli/%s/%s", OpenAuthClient.issuer, ar.state, ar.challenge)
+	authorizeUrl := GetAuthorizeUrl("cli", ar.state, ar.challenge)
 
 	term.Println("Please visit the following URL to log in: (Right click the URL or press ENTER to open browser)")
 	n, _ := term.Printf("  %s", authorizeUrl)
@@ -94,27 +100,46 @@ func StartAuthCodeFlow(ctx context.Context, mcpFlow LoginFlow, saveToken func(st
 	return AuthCodeFlow{code: code, redirectUri: redirectUri, verifier: ar.verifier}, nil
 }
 
-func pollForAuthCode(ctx context.Context, state string) (string, error) {
+func Poll(ctx context.Context, key string) ([]byte, error) {
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Minute)
 	defer cancel()
 
 	for {
-		code, err := OpenAuthClient.Poll(ctx, state)
+		result, err := OpenAuthClient.Poll(ctx, key)
 		if err != nil {
 			if errors.Is(err, ErrPollTimeout) {
 				term.Debug("poll timed out, retrying...")
-				continue // retry
+				continue
 			}
 			var unexpectedError ErrUnexpectedStatus
 			if errors.As(err, &unexpectedError) && unexpectedError.StatusCode >= 500 {
 				term.Debugf("received server error: %s, retrying...", unexpectedError.Status)
-				continue // retry
+				continue
 			}
-			return "", err
+			return nil, err
 		}
-
-		return code, nil
+		return result, nil
 	}
+}
+
+func pollForAuthCode(ctx context.Context, state string) (string, error) {
+	body, err := Poll(ctx, state)
+	if err != nil {
+		return "", err
+	}
+	// Parse the response body as form-urlencoded
+	query, err := url.ParseQuery(string(body))
+	if err != nil {
+		return "", fmt.Errorf("failed to parse response: %w", err)
+	}
+	if errorMsg := query.Get("error"); errorMsg != "" {
+		return "", fmt.Errorf("authentication failed: %s", query.Get("error_description"))
+	}
+	code := query.Get("code")
+	if code == "" {
+		return "", errors.New("no code received from auth server")
+	}
+	return code, nil
 }
 
 func ExchangeCodeForToken(ctx context.Context, code AuthCodeFlow, ss ...scope.Scope) (string, error) {

--- a/src/pkg/auth/auth_test.go
+++ b/src/pkg/auth/auth_test.go
@@ -1,0 +1,222 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestGetAuthorizeUrl(t *testing.T) {
+	orig := OpenAuthClient
+	OpenAuthClient = NewClient("test-client", "https://example.com")
+	t.Cleanup(func() { OpenAuthClient = orig })
+
+	tests := []struct {
+		name     string
+		authType string
+		parts    []string
+		want     string
+	}{
+		{
+			name:     "cli with state and challenge",
+			authType: "cli",
+			parts:    []string{"abc123", "xyz789"},
+			want:     "https://example.com/cli/abc123/xyz789",
+		},
+		{
+			name:     "gcp with public key",
+			authType: "gcp",
+			parts:    []string{"pubkeyABC="},
+			want:     "https://example.com/gcp/pubkeyABC=",
+		},
+		{
+			name:     "aws with multiple parts",
+			authType: "aws",
+			parts:    []string{"cross", "us-east-1", "state123", "challengeXYZ"},
+			want:     "https://example.com/aws/cross/us-east-1/state123/challengeXYZ",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GetAuthorizeUrl(tt.authType, tt.parts...)
+			if got != tt.want {
+				t.Errorf("GetAuthorizeUrl() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPoll(t *testing.T) {
+	t.Run("success returns body", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodPost {
+				t.Errorf("expected POST, got %s", r.Method)
+			}
+			state := r.URL.Query().Get("state")
+			w.Write([]byte("code=mycode&state=" + state)) //nolint:errcheck
+		}))
+		t.Cleanup(server.Close)
+
+		orig := OpenAuthClient
+		OpenAuthClient = NewClient("test", server.URL)
+		t.Cleanup(func() { OpenAuthClient = orig })
+
+		body, err := Poll(t.Context(), "mystate")
+		if err != nil {
+			t.Fatalf("Poll() error = %v", err)
+		}
+		const want = "code=mycode&state=mystate"
+		if string(body) != want {
+			t.Errorf("Poll() body = %q, want %q", string(body), want)
+		}
+	})
+
+	t.Run("5xx retries until context cancelled", func(t *testing.T) {
+		calls := 0
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			calls++
+			http.Error(w, "internal error", http.StatusInternalServerError)
+		}))
+		t.Cleanup(server.Close)
+
+		orig := OpenAuthClient
+		OpenAuthClient = NewClient("test", server.URL)
+		t.Cleanup(func() { OpenAuthClient = orig })
+
+		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		defer cancel()
+
+		_, err := Poll(ctx, "state")
+		if err == nil {
+			t.Error("expected error after context cancellation")
+		}
+		if calls < 1 {
+			t.Error("expected server to be called at least once")
+		}
+	})
+
+	t.Run("408 retries until context cancelled", func(t *testing.T) {
+		calls := 0
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			calls++
+			w.WriteHeader(http.StatusRequestTimeout)
+		}))
+		t.Cleanup(server.Close)
+
+		orig := OpenAuthClient
+		OpenAuthClient = NewClient("test", server.URL)
+		t.Cleanup(func() { OpenAuthClient = orig })
+
+		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		defer cancel()
+
+		_, err := Poll(ctx, "state")
+		if err == nil {
+			t.Error("expected error after context cancellation")
+		}
+		if calls < 2 {
+			t.Errorf("expected at least 2 calls for timeout retries, got %d", calls)
+		}
+	})
+
+	t.Run("4xx does not retry", func(t *testing.T) {
+		calls := 0
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			calls++
+			http.Error(w, "bad request", http.StatusBadRequest)
+		}))
+		t.Cleanup(server.Close)
+
+		orig := OpenAuthClient
+		OpenAuthClient = NewClient("test", server.URL)
+		t.Cleanup(func() { OpenAuthClient = orig })
+
+		_, err := Poll(t.Context(), "state")
+		if err == nil {
+			t.Error("expected error for 4xx response")
+		}
+		if calls != 1 {
+			t.Errorf("expected exactly 1 call (no retry for 4xx), got %d", calls)
+		}
+	})
+}
+
+func TestPollForAuthCode(t *testing.T) {
+	t.Run("success extracts code", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte("code=myauthcode&state=mystate")) //nolint:errcheck
+		}))
+		t.Cleanup(server.Close)
+
+		orig := OpenAuthClient
+		OpenAuthClient = NewClient("test", server.URL)
+		t.Cleanup(func() { OpenAuthClient = orig })
+
+		code, err := pollForAuthCode(t.Context(), "mystate")
+		if err != nil {
+			t.Fatalf("pollForAuthCode() error = %v", err)
+		}
+		if code != "myauthcode" {
+			t.Errorf("pollForAuthCode() = %q, want %q", code, "myauthcode")
+		}
+	})
+
+	t.Run("error field returns descriptive error", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte("error=access_denied&error_description=User+denied+access")) //nolint:errcheck
+		}))
+		t.Cleanup(server.Close)
+
+		orig := OpenAuthClient
+		OpenAuthClient = NewClient("test", server.URL)
+		t.Cleanup(func() { OpenAuthClient = orig })
+
+		_, err := pollForAuthCode(t.Context(), "state")
+		if err == nil {
+			t.Fatal("expected error for auth error response")
+		}
+		if !strings.Contains(err.Error(), "User denied access") {
+			t.Errorf("expected 'User denied access' in error, got: %v", err)
+		}
+	})
+
+	t.Run("missing code field returns error", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte("state=somestate")) //nolint:errcheck
+		}))
+		t.Cleanup(server.Close)
+
+		orig := OpenAuthClient
+		OpenAuthClient = NewClient("test", server.URL)
+		t.Cleanup(func() { OpenAuthClient = orig })
+
+		_, err := pollForAuthCode(t.Context(), "state")
+		if err == nil {
+			t.Fatal("expected error for missing code field")
+		}
+	})
+
+	t.Run("url-encoded code value is decoded", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// code value contains special chars, URL-encoded
+			w.Write([]byte("code=my%2Bcode%3D&state=s")) //nolint:errcheck
+		}))
+		t.Cleanup(server.Close)
+
+		orig := OpenAuthClient
+		OpenAuthClient = NewClient("test", server.URL)
+		t.Cleanup(func() { OpenAuthClient = orig })
+
+		code, err := pollForAuthCode(t.Context(), "s")
+		if err != nil {
+			t.Fatalf("pollForAuthCode() error = %v", err)
+		}
+		if code != "my+code=" {
+			t.Errorf("pollForAuthCode() = %q, want %q", code, "my+code=")
+		}
+	})
+}

--- a/src/pkg/auth/auth_test.go
+++ b/src/pkg/auth/auth_test.go
@@ -79,7 +79,7 @@ func TestPoll(t *testing.T) {
 		calls := 0
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			calls++
-			http.Error(w, "internal error", http.StatusInternalServerError)
+			http.Error(w, "timeout", http.StatusRequestTimeout)
 		}))
 		t.Cleanup(server.Close)
 
@@ -87,15 +87,15 @@ func TestPoll(t *testing.T) {
 		OpenAuthClient = NewClient("test", server.URL)
 		t.Cleanup(func() { OpenAuthClient = orig })
 
-		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
 		defer cancel()
 
 		_, err := Poll(ctx, "state")
 		if err == nil {
 			t.Error("expected error after context cancellation")
 		}
-		if calls < 1 {
-			t.Error("expected server to be called at least once")
+		if calls < 2 {
+			t.Error("expected server to be called at least twice")
 		}
 	})
 

--- a/src/pkg/auth/auth_test.go
+++ b/src/pkg/auth/auth_test.go
@@ -79,7 +79,7 @@ func TestPoll(t *testing.T) {
 		calls := 0
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			calls++
-			http.Error(w, "timeout", http.StatusRequestTimeout)
+			http.Error(w, "internal error", http.StatusInternalServerError)
 		}))
 		t.Cleanup(server.Close)
 
@@ -87,7 +87,7 @@ func TestPoll(t *testing.T) {
 		OpenAuthClient = NewClient("test", server.URL)
 		t.Cleanup(func() { OpenAuthClient = orig })
 
-		ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second) // Retry client retires per second
 		defer cancel()
 
 		_, err := Poll(ctx, "state")

--- a/src/pkg/auth/client.go
+++ b/src/pkg/auth/client.go
@@ -166,46 +166,27 @@ func (c client) GetPollRedirectURI() string {
 	return c.issuer + "/clients/auth"
 }
 
-func (c client) Poll(ctx context.Context, state string) (string, error) {
-	// Poll the server for the auth result
+func (c client) Poll(ctx context.Context, state string) ([]byte, error) {
 	pollUrl := fmt.Sprintf("%s/clients/auth/poll?state=%s", c.issuer, state)
 
 	resp, err := defangHttp.PostFormWithContext(ctx, pollUrl, nil)
 	if err != nil {
-		return "", fmt.Errorf("poll request failed: %w", err)
+		return nil, fmt.Errorf("poll request failed: %w", err)
 	}
-
 	defer resp.Body.Close()
 
 	if resp.StatusCode == http.StatusRequestTimeout {
-		return "", ErrPollTimeout
+		return nil, ErrPollTimeout
 	}
-
 	if resp.StatusCode != http.StatusOK {
-		return "", ErrUnexpectedStatus{StatusCode: resp.StatusCode, Status: resp.Status}
+		return nil, ErrUnexpectedStatus{StatusCode: resp.StatusCode, Status: resp.Status}
 	}
 
-	// Parse the response body as form-urlencoded
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return "", fmt.Errorf("failed to read response: %w", err)
+		return nil, fmt.Errorf("failed to read response: %w", err)
 	}
-
-	query, err := url.ParseQuery(string(body))
-	if err != nil {
-		return "", fmt.Errorf("failed to parse response: %w", err)
-	}
-
-	if errorMsg := query.Get("error"); errorMsg != "" {
-		return "", fmt.Errorf("authentication failed: %s", query.Get("error_description"))
-	}
-
-	code := query.Get("code")
-	if code == "" {
-		return "", errors.New("no code received from auth server")
-	}
-
-	return code, nil
+	return body, nil
 }
 
 func generateState() (string, error) {

--- a/src/pkg/clouds/aws/login.go
+++ b/src/pkg/clouds/aws/login.go
@@ -1,7 +1,6 @@
 package aws
 
 import (
-	"bufio"
 	"context"
 	"crypto/ecdsa"
 	"crypto/elliptic"
@@ -31,7 +30,6 @@ import (
 	awssts "github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/google/uuid"
-	"golang.org/x/oauth2"
 )
 
 const (
@@ -142,6 +140,7 @@ func (a *Aws) Authenticate(ctx context.Context, interactive bool) error {
 		}
 		if creds != nil {
 			a.Credentials = awssdk.NewCredentialsCache(creds)
+			return nil
 		}
 	}
 
@@ -160,15 +159,8 @@ func (a *Aws) Authenticate(ctx context.Context, interactive bool) error {
 
 func (a *Aws) tryInteractiveLogin(ctx context.Context, n int) (awssdk.CredentialsProvider, error) {
 	for range n {
-		var cached *awsTokenCache
-		var err error
-		// VS Code dev containers sets REMOTE_CONTAINERS=true, so we use that as a heuristic to determine when to use the cross-device flow which doesn't rely on opening a browser on the same machine.
-		if os.Getenv("REMOTE_CONTAINERS") == "true" {
-			term.Debug("detected REMOTE_CONTAINERS environment variable, using cross-device login flow")
-			cached, err = a.CrossDeviceLogin(ctx)
-		} else {
-			cached, err = a.InteractiveLogin(ctx)
-		}
+		// Defaults to cross-device flow which works in more environments (e.g. SSH, Dev Containers)
+		cached, err := a.CrossDeviceLogin(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("interactive login failed: %w", err)
 		}
@@ -326,7 +318,6 @@ func (a *Aws) InteractiveLogin(ctx context.Context) (*awsTokenCache, error) {
 	if err != nil {
 		return nil, fmt.Errorf("generating PKCE parameters: %w", err)
 	}
-	tokenURL := baseEndpoint + "/v1/token"
 
 	code, redirectURI, err := auth.WaitForOAuthCode(ctx, auth.WaitForOAuthCodeInput{
 		CallbackPath:   "/oauth/callback",
@@ -334,24 +325,23 @@ func (a *Aws) InteractiveLogin(ctx context.Context) (*awsTokenCache, error) {
 		Title:          "Logged in to AWS",
 		SuccessMessage: "You have successfully logged in to AWS.",
 		BuildAuthURL: func(redirectURL, state string) string {
-			cfg := &oauth2.Config{
-				ClientID: clientIDSameDevice,
-				Endpoint: oauth2.Endpoint{
-					AuthURL: baseEndpoint + "/v1/sessions",
-				},
-				RedirectURL: redirectURL,
-				Scopes:      []string{"openid"},
+			// Extract the port from the redirect URL to construct the shortened auth URL with the correct callback port
+			// Since the callback url is required to be http://127.0.0.1:{port}/oauth/callback, it is coded in the auth shortener.
+			port := "8080" // default port if parsing fails
+			parsed, err := url.Parse(redirectURL)
+			if err != nil {
+				term.Warnf("failed to parse redirect URL %q, assume port 8080: %v", redirectURL, err)
+			} else {
+				port = parsed.Port()
 			}
-			return cfg.AuthCodeURL(state,
-				oauth2.SetAuthURLParam("code_challenge_method", "SHA-256"), // AWS requires "SHA-256" literally, not "S256"
-				oauth2.SetAuthURLParam("code_challenge", pkce.Challenge),
-			)
+			return auth.GetAuthorizeUrl("aws", "same", string(a.Region), state, pkce.Challenge, port)
 		},
 	})
 	if err != nil {
 		return nil, err
 	}
 
+	tokenURL := baseEndpoint + "/v1/token"
 	return RetrieveToken(ctx, tokenURL, clientIDSameDevice, code, pkce.Verifier, redirectURI)
 }
 
@@ -360,38 +350,26 @@ func (a *Aws) InteractiveLogin(ctx context.Context) (*awsTokenCache, error) {
 // to paste the base64-encoded verification code displayed in their browser.
 // TODO: Support cross device login workflow with a flag
 func (a *Aws) CrossDeviceLogin(ctx context.Context) (*awsTokenCache, error) {
-	baseEndpoint := fmt.Sprintf("https://%s.signin.aws.amazon.com", a.Region)
-	redirectURI := baseEndpoint + "/v1/sessions/confirmation"
 	pkce, err := auth.GeneratePKCE(64, auth.S256Method)
 	if err != nil {
 		return nil, fmt.Errorf("generating PKCE parameters: %w", err)
 	}
 	state := rand.Text()[:16] // random state for CSRF protection
-	tokenURL := baseEndpoint + "/v1/token"
+	authURL := auth.GetAuthorizeUrl("aws", "cross", string(a.Region), state, pkce.Challenge)
 
-	config := &oauth2.Config{
-		ClientID: clientIDCrossDevice,
-		Endpoint: oauth2.Endpoint{
-			AuthURL: baseEndpoint + "/v1/authorize",
-		},
-		RedirectURL: redirectURI,
-		Scopes:      []string{"openid"},
-	}
-
-	authURL := config.AuthCodeURL(state,
-		oauth2.SetAuthURLParam("code_challenge_method", "SHA-256"), // AWS require this to be "SHA-256" literally, not "S256"
-		oauth2.SetAuthURLParam("code_challenge", pkce.Challenge),
-	)
-
-	term.Printf("Browser will not be automatically opened. Please visit the following URL:\n\n  %s\n\n", authURL)
+	term.Println("Please visit the following URL to log in to AWS: (Right click the URL or press ENTER to open browser)")
+	term.Printf("  %s\n", authURL)
 	term.Print("Enter the authorization code displayed in your browser: ")
+	ctx, inputCh, done := term.OpenBrowserWithInputOnEnter(ctx, authURL)
+	defer done()
 
-	reader := bufio.NewReader(os.Stdin)
-	input, err := reader.ReadString('\n')
-	if err != nil {
-		return nil, fmt.Errorf("reading verification code: %w", err)
+	var input string
+	select {
+	case input = <-inputCh:
+		input = strings.TrimSpace(input)
+	case <-ctx.Done():
+		return nil, ctx.Err()
 	}
-	input = strings.TrimSpace(input)
 
 	authCode, gotState, err := parseVerificationCode(input)
 	if err != nil {
@@ -401,6 +379,9 @@ func (a *Aws) CrossDeviceLogin(ctx context.Context) (*awsTokenCache, error) {
 		return nil, fmt.Errorf("state mismatch: got %q, want %q", gotState, state)
 	}
 
+	baseEndpoint := fmt.Sprintf("https://%s.signin.aws.amazon.com", a.Region)
+	tokenURL := baseEndpoint + "/v1/token"
+	redirectURI := baseEndpoint + "/v1/sessions/confirmation"
 	return RetrieveToken(ctx, tokenURL, clientIDCrossDevice, authCode, pkce.Verifier, redirectURI)
 }
 

--- a/src/pkg/clouds/aws/login_test.go
+++ b/src/pkg/clouds/aws/login_test.go
@@ -1,6 +1,7 @@
 package aws
 
 import (
+	"context"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
@@ -15,6 +16,7 @@ import (
 
 	"github.com/DefangLabs/defang/src/pkg/tokenstore"
 	awssdk "github.com/aws/aws-sdk-go-v2/aws"
+	awssts "github.com/aws/aws-sdk-go-v2/service/sts"
 )
 
 // makeTestJWT creates a minimal unsigned JWT with the given claims for testing ParseUnverified.
@@ -534,6 +536,59 @@ func TestFindStoredCredentials(t *testing.T) {
 		_, err := a.findStoredCredentials(t.Context())
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}
+
+// failStsAPI is an STS mock that always returns an error.
+type failStsAPI struct{}
+
+func (failStsAPI) GetCallerIdentity(ctx context.Context, params *awssts.GetCallerIdentityInput, optFns ...func(*awssts.Options)) (*awssts.GetCallerIdentityOutput, error) {
+	return nil, errors.New("no credentials available")
+}
+
+func (failStsAPI) AssumeRole(ctx context.Context, params *awssts.AssumeRoleInput, optFns ...func(*awssts.Options)) (*awssts.AssumeRoleOutput, error) {
+	return nil, errors.New("no credentials available")
+}
+
+func TestAuthenticate_AWS(t *testing.T) {
+	const region = "us-east-1"
+
+	t.Run("stored credentials are used when default credentials fail", func(t *testing.T) {
+		// First call: no default credentials. Subsequent calls: stored token validates OK.
+		calls := 0
+		origSts := NewStsFromConfig
+		NewStsFromConfig = func(cfg awssdk.Config) StsClientAPI {
+			calls++
+			if calls == 1 {
+				return failStsAPI{}
+			}
+			return MockStsClientAPI{}
+		}
+		t.Cleanup(func() { NewStsFromConfig = origSts })
+
+		store := tokenstore.NewMemTokenStore()
+		store.Save(tokenStoreKeyPrefix+"valid", validAwsToken(t, "https://us-east-1.signin.aws.amazon.com/v1/token")) //nolint:errcheck
+
+		a := &Aws{Region: region, TokenStore: store}
+		err := a.Authenticate(t.Context(), false)
+		if err != nil {
+			t.Fatalf("Authenticate() error = %v", err)
+		}
+		if a.Credentials == nil {
+			t.Error("expected Credentials to be set after finding stored token")
+		}
+	})
+
+	t.Run("non-interactive with no credentials returns error", func(t *testing.T) {
+		origSts := NewStsFromConfig
+		NewStsFromConfig = func(cfg awssdk.Config) StsClientAPI { return failStsAPI{} }
+		t.Cleanup(func() { NewStsFromConfig = origSts })
+
+		a := &Aws{Region: region, TokenStore: tokenstore.NewMemTokenStore()}
+		err := a.Authenticate(t.Context(), false)
+		if err == nil {
+			t.Fatal("expected error when no credentials available")
 		}
 	})
 }

--- a/src/pkg/clouds/gcp/login.go
+++ b/src/pkg/clouds/gcp/login.go
@@ -2,6 +2,8 @@ package gcp
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -16,6 +18,7 @@ import (
 	"github.com/DefangLabs/defang/src/pkg/github"
 	"github.com/DefangLabs/defang/src/pkg/term"
 	gax "github.com/googleapis/gax-go/v2"
+	"golang.org/x/crypto/nacl/box"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
 	"golang.org/x/oauth2/google/externalaccount"
@@ -296,9 +299,38 @@ func audienceToPrincipalSet(audience string) (string, error) {
 }
 
 func (gcp *Gcp) InteractiveLogin(ctx context.Context) (oauth2.TokenSource, error) {
-	pkce, err := auth.GeneratePKCE(64, auth.S256Method)
+	pubKey, privKey, err := box.GenerateKey(rand.Reader)
 	if err != nil {
-		return nil, fmt.Errorf("failed to generate PKCE: %w", err)
+		return nil, fmt.Errorf("failed to generate keypair: %w", err)
+	}
+
+	publicKeyBase64 := base64.URLEncoding.EncodeToString(pubKey[:])
+	authorizeURL := auth.GetAuthorizeUrl("gcp", publicKeyBase64)
+
+	term.Println("Please visit the following URL to log in to Google Cloud Platform: (Right click the URL or press ENTER to open browser)")
+	term.Printf("  %s\n", authorizeURL)
+
+	ctx, done := term.OpenBrowserOnEnter(ctx, authorizeURL)
+	defer done()
+
+	encryptedToken, err := auth.Poll(ctx, publicKeyBase64)
+	if err != nil {
+		return nil, fmt.Errorf("failed to poll for token: %w", err)
+	}
+
+	ciphertext, err := base64.StdEncoding.DecodeString(strings.TrimSpace(string(encryptedToken)))
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode encrypted token: %w", err)
+	}
+
+	tokenJSON, ok := box.OpenAnonymous(nil, ciphertext, pubKey, privKey)
+	if !ok {
+		return nil, errors.New("failed to decrypt token")
+	}
+
+	var token oauth2.Token
+	if err := json.Unmarshal(tokenJSON, &token); err != nil {
+		return nil, fmt.Errorf("failed to parse token: %w", err)
 	}
 
 	cfg := &oauth2.Config{
@@ -307,31 +339,7 @@ func (gcp *Gcp) InteractiveLogin(ctx context.Context) (oauth2.TokenSource, error
 		Scopes:       scopes,
 		Endpoint:     google.Endpoint,
 	}
-
-	code, _, err := auth.WaitForOAuthCode(ctx, auth.WaitForOAuthCodeInput{
-		CallbackPath:   "/",
-		Prompt:         "Please visit the following URL to log in to Google Cloud Platform: (Right click the URL or press ENTER to open browser)",
-		Title:          "Logged in to Google Cloud Platform",
-		SuccessMessage: "You have successfully logged in to Google Cloud Platform.",
-		BuildAuthURL: func(redirectURL, state string) string {
-			cfg.RedirectURL = redirectURL
-			return cfg.AuthCodeURL(state,
-				oauth2.AccessTypeOffline,
-				oauth2.SetAuthURLParam("code_challenge", pkce.Challenge),
-				oauth2.SetAuthURLParam("code_challenge_method", "S256"),
-			)
-		},
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	token, err := cfg.Exchange(ctx, code, oauth2.SetAuthURLParam("code_verifier", pkce.Verifier))
-	if err != nil {
-		return nil, fmt.Errorf("failed to exchange code for token: %w", err)
-	}
-
-	return cfg.TokenSource(ctx, token), nil
+	return cfg.TokenSource(ctx, &token), nil
 }
 
 type ErrorMissingPermissions []string

--- a/src/pkg/clouds/gcp/login_test.go
+++ b/src/pkg/clouds/gcp/login_test.go
@@ -333,6 +333,10 @@ func pollServerForGCP(t *testing.T, payload []byte) *httptest.Server {
 			return
 		}
 		var pubKey [32]byte
+		if len(pubKeyBytes) != len(pubKey) {
+			http.Error(w, "bad state length", http.StatusBadRequest)
+			return
+		}
 		copy(pubKey[:], pubKeyBytes)
 
 		ciphertext, err := box.SealAnonymous(nil, payload, &pubKey, cryptorand.Reader)

--- a/src/pkg/clouds/gcp/login_test.go
+++ b/src/pkg/clouds/gcp/login_test.go
@@ -2,14 +2,21 @@ package gcp
 
 import (
 	"context"
+	cryptorand "crypto/rand"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
 	"cloud.google.com/go/iam/apiv1/iampb"
+	"github.com/DefangLabs/defang/src/pkg/auth"
 	"github.com/DefangLabs/defang/src/pkg/tokenstore"
 	gax "github.com/googleapis/gax-go/v2"
+	"golang.org/x/crypto/nacl/box"
 	"golang.org/x/oauth2"
 	"google.golang.org/api/option"
 )
@@ -310,4 +317,127 @@ func TestParseWIFProvider(t *testing.T) {
 			}
 		})
 	}
+}
+
+// pollServerForGCP starts an httptest server that simulates the auth portal's
+// poll endpoint for GCP interactive login. The handler extracts the public key
+// from the state query parameter, encrypts payload with it using box.SealAnonymous,
+// and returns base64-encoded ciphertext.
+func pollServerForGCP(t *testing.T, payload []byte) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		pubKeyB64 := r.URL.Query().Get("state")
+		pubKeyBytes, err := base64.URLEncoding.DecodeString(pubKeyB64)
+		if err != nil {
+			http.Error(w, "bad state: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+		var pubKey [32]byte
+		copy(pubKey[:], pubKeyBytes)
+
+		ciphertext, err := box.SealAnonymous(nil, payload, &pubKey, cryptorand.Reader)
+		if err != nil {
+			http.Error(w, "encryption failed", http.StatusInternalServerError)
+			return
+		}
+		w.Write([]byte(base64.StdEncoding.EncodeToString(ciphertext))) //nolint:errcheck
+	}))
+}
+
+func TestInteractiveLogin_GCP(t *testing.T) {
+	t.Run("invalid base64 response returns error", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte("!!!not valid base64!!!")) //nolint:errcheck
+		}))
+		t.Cleanup(srv.Close)
+
+		orig := auth.OpenAuthClient
+		auth.OpenAuthClient = auth.NewClient("test", srv.URL)
+		t.Cleanup(func() { auth.OpenAuthClient = orig })
+
+		gcp := &Gcp{}
+		_, err := gcp.InteractiveLogin(t.Context())
+		if err == nil {
+			t.Fatal("expected error for invalid base64")
+		}
+		if !strings.Contains(err.Error(), "failed to decode encrypted token") {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("decryption with wrong key returns error", func(t *testing.T) {
+		// Encrypt with a different key than what InteractiveLogin will generate
+		wrongPub, _, err := box.GenerateKey(cryptorand.Reader)
+		if err != nil {
+			t.Fatalf("generating wrong key: %v", err)
+		}
+		ciphertext, err := box.SealAnonymous(nil, []byte("secret"), wrongPub, cryptorand.Reader)
+		if err != nil {
+			t.Fatalf("encrypting: %v", err)
+		}
+
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte(base64.StdEncoding.EncodeToString(ciphertext))) //nolint:errcheck
+		}))
+		t.Cleanup(srv.Close)
+
+		orig := auth.OpenAuthClient
+		auth.OpenAuthClient = auth.NewClient("test", srv.URL)
+		t.Cleanup(func() { auth.OpenAuthClient = orig })
+
+		gcp := &Gcp{}
+		_, err = gcp.InteractiveLogin(t.Context())
+		if err == nil {
+			t.Fatal("expected decryption failure")
+		}
+		if !strings.Contains(err.Error(), "failed to decrypt token") {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("invalid JSON after decryption returns error", func(t *testing.T) {
+		srv := pollServerForGCP(t, []byte("not-valid-json"))
+		t.Cleanup(srv.Close)
+
+		orig := auth.OpenAuthClient
+		auth.OpenAuthClient = auth.NewClient("test", srv.URL)
+		t.Cleanup(func() { auth.OpenAuthClient = orig })
+
+		gcp := &Gcp{}
+		_, err := gcp.InteractiveLogin(t.Context())
+		if err == nil {
+			t.Fatal("expected error for invalid JSON")
+		}
+		if !strings.Contains(err.Error(), "failed to parse token") {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("success returns token source", func(t *testing.T) {
+		wantToken := oauth2.Token{
+			AccessToken:  "gcp-access-token",
+			RefreshToken: "gcp-refresh-token",
+			Expiry:       time.Now().Add(time.Hour),
+		}
+		tokenJSON, err := json.Marshal(wantToken)
+		if err != nil {
+			t.Fatalf("marshaling token: %v", err)
+		}
+
+		srv := pollServerForGCP(t, tokenJSON)
+		t.Cleanup(srv.Close)
+
+		orig := auth.OpenAuthClient
+		auth.OpenAuthClient = auth.NewClient("test", srv.URL)
+		t.Cleanup(func() { auth.OpenAuthClient = orig })
+
+		gcp := &Gcp{}
+		ts, err := gcp.InteractiveLogin(t.Context())
+		if err != nil {
+			t.Fatalf("InteractiveLogin() error = %v", err)
+		}
+		if ts == nil {
+			t.Error("expected non-nil token source")
+		}
+	})
 }

--- a/src/pkg/term/browser.go
+++ b/src/pkg/term/browser.go
@@ -1,14 +1,30 @@
 package term
 
 import (
+	"bytes"
 	"context"
+	"io"
 
 	"github.com/pkg/browser"
 )
 
+func init() {
+	// Suppress browser package output
+	browser.Stdout = io.Discard
+	browser.Stderr = io.Discard
+}
+
 func OpenBrowserOnEnter(ctx context.Context, url string) (context.Context, func()) {
 	ctx, cancel := context.WithCancel(ctx)
 	input := NewNonBlockingStdin()
+
+	// Handles context cancellation to ensure input is closed and goroutine exits when context is cancelled.
+	// In linux Ctrl-C is handled by the signal handler, and input will not get a byte
+	go func() {
+		<-ctx.Done()
+		input.Close()
+	}()
+
 	go func() {
 		var b [1]byte
 		for {
@@ -29,6 +45,55 @@ func OpenBrowserOnEnter(ctx context.Context, url string) (context.Context, func(
 		}
 	}()
 	return ctx, func() {
+		input.Close()
+		cancel()
+	}
+}
+
+func OpenBrowserWithInputOnEnter(ctx context.Context, url string) (context.Context, <-chan string, func()) {
+	ctx, cancel := context.WithCancel(ctx)
+	input := NewNonBlockingStdin()
+	inputChan := make(chan string, 1) // Buffered channel to avoid blocking goroutine
+
+	// Handles context cancellation to ensure input is closed and goroutine exits when context is cancelled.
+	// In linux Ctrl-C is handled by the signal handler, and input will not get a byte
+	go func() {
+		<-ctx.Done()
+		input.Close()
+	}()
+
+	go func() {
+		var b [1]byte
+		var buf bytes.Buffer
+	inputloop:
+		for {
+			if _, err := input.Read(b[:]); err != nil {
+				break
+			}
+			switch b[0] {
+			case 3: // Ctrl-C
+				cancel()
+				break inputloop
+			case 10, 13: // Enter or Return
+				// If the user has already entered some input, we assume browser is already opened
+				// and we don't want to open the browser again.
+				if buf.Len() > 0 {
+					break inputloop
+				}
+				err := browser.OpenURL(url)
+				if err != nil {
+					Errorf("failed to open browser: %v", err)
+				}
+			default:
+				buf.WriteByte(b[0]) //nolint:gosec // G602 false positive: b is [1]byte, index 0 is always valid
+			}
+		}
+		if buf.Len() > 0 {
+			inputChan <- buf.String()
+		}
+		close(inputChan)
+	}()
+	return ctx, inputChan, func() {
 		input.Close()
 		cancel()
 	}

--- a/src/pkg/term/browser.go
+++ b/src/pkg/term/browser.go
@@ -44,10 +44,7 @@ func OpenBrowserOnEnter(ctx context.Context, url string) (context.Context, func(
 			}
 		}
 	}()
-	return ctx, func() {
-		input.Close()
-		cancel()
-	}
+	return ctx, cancel
 }
 
 func OpenBrowserWithInputOnEnter(ctx context.Context, url string) (context.Context, <-chan string, func()) {
@@ -93,8 +90,5 @@ func OpenBrowserWithInputOnEnter(ctx context.Context, url string) (context.Conte
 		}
 		close(inputChan)
 	}()
-	return ctx, inputChan, func() {
-		input.Close()
-		cancel()
-	}
+	return ctx, inputChan, cancel
 }


### PR DESCRIPTION
## Description
Make use auth portal for better oauth UX:
1. GCP: use server side oauth to allow poll model so running defang with oauth workflow in a container would still work
2. AWS uses auth server as oauth url shortener

## Linked Issues
#1991 

## Checklist

- [X] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved interactive login flows for AWS and GCP, including a keypair-based GCP flow and streamlined cross-device AWS login
  * Browser prompt now accepts typed input before opening and better handles cancellation

* **Refactor**
  * Centralized authorization URL construction and simplified polling for authentication responses

* **Tests**
  * Added comprehensive tests covering auth URL construction, polling/retry behavior, and cloud login scenarios

* **Chores**
  * Updated build/dependency pins and module dependency declarations
<!-- end of auto-generated comment: release notes by coderabbit.ai -->