### PR TITLE
chore: rename Region in 'cd ls' to CdRegion

### DIFF
--- a/src/pkg/cli/cd.go
+++ b/src/pkg/cli/cd.go
@@ -12,7 +12,6 @@ import (
 	"connectrpc.com/connect"
 	"github.com/DefangLabs/defang/src/pkg"
 	"github.com/DefangLabs/defang/src/pkg/cli/client"
-	"github.com/DefangLabs/defang/src/pkg/cli/client/byoc/state"
 	"github.com/DefangLabs/defang/src/pkg/dryrun"
 	"github.com/DefangLabs/defang/src/pkg/logs"
 	"github.com/DefangLabs/defang/src/pkg/term"
@@ -145,13 +144,7 @@ func CdListFromStorage(ctx context.Context, provider client.Provider, allRegions
 		return err
 	}
 
-	stacks := slices.Collect(func(yield func(state.Info) bool) {
-		for stackInfo := range stacksIter {
-			if !yield(stackInfo) {
-				return
-			}
-		}
-	})
+	stacks := slices.Collect(stacksIter)
 
 	if len(stacks) == 0 {
 		accountInfo, err := provider.AccountInfo(ctx)
@@ -164,7 +157,7 @@ func CdListFromStorage(ctx context.Context, provider client.Provider, allRegions
 		term.Printf("No projects found in %v\n", accountInfo)
 	}
 
-	return term.Table(stacks, "Project", "Stack", "Workspace", "Region")
+	return term.Table(stacks, "Project", "Stack", "Workspace", "CdRegion")
 }
 
 func GetStatesAndEventsUploadUrls(ctx context.Context, projectName string, provider client.Provider, fabric client.FabricClient) (statesUrl string, eventsUrl string, err error) {

--- a/src/pkg/cli/client/byoc/aws/list.go
+++ b/src/pkg/cli/client/byoc/aws/list.go
@@ -33,7 +33,7 @@ func (b *ByocAws) listPulumiStacksInBucket(ctx context.Context, region aws.Regio
 				Project:   st.Project,
 				Stack:     st.Name,
 				Workspace: string(st.Workspace),
-				Region:    string(region),
+				CdRegion:  string(region),
 			}
 			if !yield(info) {
 				break

--- a/src/pkg/cli/client/byoc/do/byoc.go
+++ b/src/pkg/cli/client/byoc/do/byoc.go
@@ -277,7 +277,7 @@ func (b *ByocDo) CdList(ctx context.Context, _allRegions bool) (iter.Seq[state.I
 				Project:   st.Project,
 				Stack:     st.Name,
 				Workspace: string(st.Workspace),
-				Region:    string(b.driver.Region),
+				CdRegion:  string(b.driver.Region),
 			}
 			if !yield(info) {
 				break

--- a/src/pkg/cli/client/byoc/gcp/byoc.go
+++ b/src/pkg/cli/client/byoc/gcp/byoc.go
@@ -334,7 +334,7 @@ func (b *ByocGcp) CdList(ctx context.Context, _allRegions bool) (iter.Seq[state.
 				Stack:     st.Name,
 				Project:   st.Project,
 				Workspace: string(st.Workspace),
-				Region:    b.driver.GetRegion(),
+				CdRegion:  b.driver.GetRegion(),
 			}
 			if !yield(stack) {
 				break

--- a/src/pkg/cli/client/byoc/state/state.go
+++ b/src/pkg/cli/client/byoc/state/state.go
@@ -4,5 +4,5 @@ type Info struct {
 	Project   string
 	Stack     string
 	Workspace string
-	Region    string
+	CdRegion  string // not necessarily the stack region
 }


### PR DESCRIPTION
## Description

…because might not be the same as stack region, especially after #1916   


## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated column label in CD list from "Region" to "CdRegion" for improved semantic accuracy.
  * Simplified internal stack collection logic for better code efficiency across cloud providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->