### PR TITLE
fix(aws): use mutex for deployment-etag cache

### DIFF
--- a/src/cmd/cli/command/session.go
+++ b/src/cmd/cli/command/session.go
@@ -105,6 +105,7 @@ func doubleCheckProjectName(projectName string) {
 func newStackManagerForLoader(ctx context.Context, loader *compose.Loader) (session.StacksManager, error) {
 	targetDirectory, err := loader.ProjectWorkingDir(ctx)
 	if err != nil {
+		term.Debugf("Could not determine project working directory: %v", err)
 		// No project directory; look for .defang directory in current or parent directories
 		targetDirectory, _ = findTargetDirectory(".")
 	} else {

--- a/src/pkg/clouds/aws/codebuild/event.go
+++ b/src/pkg/clouds/aws/codebuild/event.go
@@ -4,12 +4,13 @@ import (
 	"strings"
 	"time"
 
+	"github.com/DefangLabs/defang/src/pkg/types"
 	defangv1 "github.com/DefangLabs/defang/src/protos/io/defang/v1"
 )
 
 type Event interface {
 	Service() string
-	Etag() string
+	Etag() types.ETag
 	Host() string
 	Status() string
 	State() defangv1.ServiceState
@@ -56,7 +57,7 @@ func (e *CodebuildEvent) Service() string {
 	return e.service
 }
 
-func (e *CodebuildEvent) Etag() string {
+func (e *CodebuildEvent) Etag() types.ETag {
 	return e.etag
 }
 

--- a/src/pkg/clouds/aws/ecs/event.go
+++ b/src/pkg/clouds/aws/ecs/event.go
@@ -5,28 +5,39 @@ import (
 	"fmt"
 	"path"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/DefangLabs/defang/src/pkg/clouds/aws/ecs/ecsserviceaction"
 	"github.com/DefangLabs/defang/src/pkg/clouds/aws/ecs/ecstaskstatechange"
+	"github.com/DefangLabs/defang/src/pkg/types"
 	defangv1 "github.com/DefangLabs/defang/src/protos/io/defang/v1"
 )
 
 type Cache interface {
-	Get(string) string
-	Set(string, string)
+	Get(string) types.ETag
+	Set(string, types.ETag)
 }
 
-type LocalCache map[string]string
-
-var DeploymentEtags Cache = make(LocalCache)
-
-func (c LocalCache) Get(k string) string {
-	return c[k]
+type LocalCache struct {
+	data  map[string]string
+	mutex sync.RWMutex
 }
 
-func (c LocalCache) Set(k, v string) {
-	c[k] = v
+func (c *LocalCache) Get(k string) types.ETag {
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
+	return c.data[k]
+}
+
+func (c *LocalCache) Set(k string, v types.ETag) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	c.data[k] = v
+}
+
+var DeploymentEtags Cache = &LocalCache{
+	data: make(map[string]types.ETag),
 }
 
 type ECSServiceAction = ecsserviceaction.ECSServiceAction
@@ -40,7 +51,7 @@ type ECSDeploymentStateChange struct {
 
 type Event interface {
 	Service() string
-	Etag() string
+	Etag() types.ETag
 	Host() string
 	Status() string
 	State() defangv1.ServiceState
@@ -136,7 +147,7 @@ func (e *TaskStateChangeEvent) Service() string {
 	}
 	return service
 }
-func (e *TaskStateChangeEvent) Etag() string {
+func (e *TaskStateChangeEvent) Etag() types.ETag {
 	var etag string
 	override := e.Detail.Overrides.ContainerOverrides[0]
 	i := strings.LastIndex(override.Name, "_")
@@ -209,7 +220,7 @@ func (e *KanikoTaskStateChangeEvent) Service() string {
 	return service
 }
 
-func (e *KanikoTaskStateChangeEvent) Etag() string {
+func (e *KanikoTaskStateChangeEvent) Etag() types.ETag {
 	override := e.getKanikoOverride()
 	if override == nil {
 		return ""
@@ -283,7 +294,7 @@ func (e *KanikoTaskStateChangeEvent) getKanikoOverride() *ecstaskstatechange.Ove
 func (e *ServiceActionEvent) Service() string {
 	return serviceNameFromResources(e.Resources)
 }
-func (e *ServiceActionEvent) Etag() string {
+func (e *ServiceActionEvent) Etag() types.ETag {
 	return ""
 }
 func (e *ServiceActionEvent) Host() string {
@@ -299,7 +310,7 @@ func (e *ServiceActionEvent) State() defangv1.ServiceState {
 func (e *DeploymentStateChangeEvent) Service() string {
 	return serviceNameFromResources(e.Resources)
 }
-func (e *DeploymentStateChangeEvent) Etag() string {
+func (e *DeploymentStateChangeEvent) Etag() types.ETag {
 	return DeploymentEtags.Get(e.Detail.DeploymentId)
 }
 func (e *DeploymentStateChangeEvent) Host() string {


### PR DESCRIPTION
## Description

Fix panic when receiving ECS events from different go routines.
[Untitled.txt](https://github.com/user-attachments/files/26124458/Untitled.txt)

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated internal event handling interfaces for improved type consistency and safety across cloud infrastructure modules.
  * Refactored cache implementation to support concurrent access with thread-safe operations.

* **Chores**
  * Enhanced debug logging for error diagnostics in session management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->