### PR TITLE
Fix aws OIDC github login

### DIFF
--- a/src/pkg/clouds/aws/login.go
+++ b/src/pkg/clouds/aws/login.go
@@ -127,7 +127,9 @@ func (a *Aws) Authenticate(ctx context.Context, interactive bool) error {
 
 	// 1. Try default AWS credentials
 	term.Debugf("checking default AWS credentials for region %s...", a.Region)
-	if _, err := a.testCredentials(ctx, nil); err == nil {
+	if _, err := a.testCredentials(ctx, nil); err != nil {
+		term.Debugf("default AWS credentials invalid: %v", err)
+	} else {
 		term.Debug("found valid default AWS credentials")
 		return nil
 	}

--- a/src/pkg/login/login.go
+++ b/src/pkg/login/login.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"connectrpc.com/connect"
 	"github.com/DefangLabs/defang/src/pkg/auth"
@@ -92,10 +93,9 @@ func NonInteractiveGitHubLogin(ctx context.Context, fabric client.FabricClient, 
 		return err
 	}
 
-	// If AWS_ROLE_ARN is set, we're doing "Assume Role with Web Identity"
-	if os.Getenv("AWS_ROLE_ARN") != "" && os.Getenv("AWS_WEB_IDENTITY_TOKEN_FILE") == "" {
-		// AWS_ROLE_ARN is set, but AWS_WEB_IDENTITY_TOKEN_FILE is empty: write the token to a new file
-		jwtPath, err := writeWebIdentityToken(fabricAddr, resp.AccessToken)
+	// write the IDToken to a new file, if AWS_WEB_IDENTITY_TOKEN_FILE is empty
+	if os.Getenv("AWS_WEB_IDENTITY_TOKEN_FILE") == "" {
+		jwtPath, err := writeWebIdentityToken(fabricAddr, idToken)
 		if err != nil {
 			return err
 		}
@@ -112,6 +112,10 @@ func NonInteractiveGitHubLogin(ctx context.Context, fabric client.FabricClient, 
 func writeWebIdentityToken(fabricAddr, token string) (string, error) {
 	jwtPath, _ := client.GetWebIdentityTokenFile(fabricAddr)
 	term.Debugf("writing web identity token to %s", jwtPath)
+	dir, _ := filepath.Split(jwtPath)
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return "", fmt.Errorf("failed to create web identity token directory: %w", err)
+	}
 	if err := os.WriteFile(jwtPath, []byte(token), 0600); err != nil {
 		return "", fmt.Errorf("failed to save web identity token: %w", err)
 	}

--- a/src/pkg/login/login_test.go
+++ b/src/pkg/login/login_test.go
@@ -115,10 +115,11 @@ func TestNonInteractiveLogin(t *testing.T) {
 		}
 
 		// use a prevStateDir dir for the token file
+		tempDir := t.TempDir()
 		prevStateDir := client.StateDir
-		client.StateDir = filepath.Join(t.TempDir(), "defang")
+		client.StateDir = filepath.Join(tempDir, "defang")
 		originalTokenStore := client.TokenStore
-		client.TokenStore = &tokenstore.LocalDirTokenStore{Dir: t.TempDir()}
+		client.TokenStore = &tokenstore.LocalDirTokenStore{Dir: client.StateDir}
 
 		t.Cleanup(func() {
 			client.StateDir = prevStateDir
@@ -130,7 +131,7 @@ func TestNonInteractiveLogin(t *testing.T) {
 			t.Fatalf("expected no error, got %v", err)
 		}
 
-		savedToken, err := client.TokenStore.Load(client.TokenStorageName(fabric))
+		savedToken, err := client.TokenStore.Load(client.TokenStorageName(fabric) + ".jwt")
 		if err != nil {
 			t.Fatalf("expected no error, got %v", err)
 		}


### PR DESCRIPTION
## Description
Write AWS_WEB_IDENTITY_TOKEN_FILE with github idtoken irrespective of if AWS_ROLE_ARN is present.

## Linked Issues
fixes: #2831

## Checklist

- [X] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Default credential checks now detect and log invalid default credentials instead of silently ignoring them.
  * Web identity token handling improved: parent directories are created for token files and the GitHub-issued identity token is used when writing the token.

* **Tests**
  * Tests updated to use a single temporary directory and to adjust token persistence validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->