### PR TITLE
fix(aws): add CodeBuild log to subscribe events

### DIFF
--- a/src/pkg/clouds/aws/codebuild/event.go
+++ b/src/pkg/clouds/aws/codebuild/event.go
@@ -66,7 +66,7 @@ func (e *CodebuildEvent) Host() string {
 }
 
 func (e *CodebuildEvent) Status() string {
-	return ""
+	return e.message
 }
 
 func parseCodebuildMessage(message string) defangv1.ServiceState {


### PR DESCRIPTION
## Description

CI occasionally fails with:
```
Error: deployment failed for service "website": 
 ! deployment failed for service "website": 
Error: Process completed with exit code 2.
```

The reason is that CodeBuild log has this line:
```
2026-04-06T19:06:04.957Z website-image 7278f071-bfd4-4deb-ab0f-7c5d6904c070 [Container] 2026/04/06 19:06:04.685784 Phase complete: PRE_BUILD State: FAILED
```

which resulted in a failed build for the "website" service. This PR doesn't fix the failure (related to `/tmp/nginx.conf` being a folder), but at least adds the actual CodeBuild log line as the event status.

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * CodeBuild event status now correctly displays message content instead of appearing blank.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->