### PR TITLE
feat: press D to toggle debug mode

### DIFF
--- a/src/pkg/cli/tail.go
+++ b/src/pkg/cli/tail.go
@@ -275,9 +275,18 @@ func streamLogs(ctx context.Context, provider client.Provider, projectName strin
 							cancel() // cancel the tail context
 						case 10, 13: // Enter or Return
 							term.Println(" ") // empty line, but overwrite the spinner
+						case 'd', 'D':
+							debug := !term.DoDebug()
+							term.SetDebug(debug)
+							debugStr := "OFF"
+							if debug {
+								debugStr = "ON"
+							}
+							term.Info("Debug mode", debugStr)
+							track.Evt("Debug Toggled", P("debug", debug))
 						case 'v', 'V':
 							verbose := !options.Verbose
-							options.Verbose = verbose
+							options.Verbose = verbose // FIXME: race
 							modeStr := "OFF"
 							if verbose {
 								modeStr = "ON"

--- a/src/pkg/term/colorizer.go
+++ b/src/pkg/term/colorizer.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 	"slices"
 	"strings"
+	"sync/atomic"
 
 	"github.com/muesli/termenv"
 	"golang.org/x/term"
@@ -16,7 +17,7 @@ type Term struct {
 	stdin          FileReader
 	stdout, stderr io.Writer
 	out, err       *termenv.Output
-	debug          bool
+	debug          atomic.Bool
 	json           bool
 
 	isTerminal bool
@@ -82,7 +83,7 @@ func (t *Term) ForceColor(color bool) {
 }
 
 func (t *Term) SetDebug(debug bool) {
-	t.debug = debug
+	t.debug.Store(debug)
 }
 
 func (t *Term) SetJSON(json bool) {
@@ -93,7 +94,7 @@ func (t *Term) SetJSON(json bool) {
 }
 
 func (t *Term) DoDebug() bool {
-	return t.debug
+	return t.debug.Load()
 }
 
 func (t *Term) HasDarkBackground() bool {
@@ -211,14 +212,14 @@ func (t *Term) Printf(format string, v ...any) (int, error) {
 }
 
 func (t *Term) Debug(v ...any) (int, error) {
-	if !t.debug {
+	if !t.DoDebug() {
 		return 0, nil
 	}
 	return output(t.err, DebugColor, ensurePrefix(debugPrefix, fmt.Sprintln(v...)))
 }
 
 func (t *Term) Debugf(format string, v ...any) (int, error) {
-	if !t.debug {
+	if !t.DoDebug() {
 		return 0, nil
 	}
 	return output(t.err, DebugColor, ensureNewline(ensurePrefix(debugPrefix, fmt.Sprintf(format, v...))))

--- a/src/pkg/term/colorizer.go
+++ b/src/pkg/term/colorizer.go
@@ -68,7 +68,7 @@ func NewTerm(stdin FileReader, stdout, stderr io.Writer) *Term {
 	return t
 }
 
-func (t Term) Stdio() (FileReader, termenv.File, io.Writer) {
+func (t *Term) Stdio() (FileReader, termenv.File, io.Writer) {
 	return t.stdin, t.out.TTY(), t.err
 }
 


### PR DESCRIPTION
## Description

For debugging, during tail, accept `d` or `D` key press to toggle debug logs. 

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added keyboard shortcut (d/D) to toggle terminal debug mode in interactive tail; displays “Debug mode ON/OFF” confirmation.
* **Improvements**
  * Made debug state handling safer for concurrent use and unified debug-output gating.
* **Telemetry**
  * Emits an event when debug is toggled for usage tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->