### PR TITLE
Add Claude Code plugin (deploy skill + MCP server)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,26 @@
+{
+  "name": "defang-labs",
+  "owner": {
+    "name": "DefangLabs",
+    "email": "support@defang.io"
+  },
+  "metadata": {
+    "description": "Official Defang plugin for Claude Code — deploy Docker Compose apps to AWS, GCP, or DigitalOcean."
+  },
+  "plugins": [
+    {
+      "name": "defang",
+      "source": "./claude-plugin",
+      "description": "Deploy Docker Compose apps to your own cloud account using Defang. Includes a /defang:deploy skill and Defang MCP server integration.",
+      "version": "1.0.0",
+      "author": {
+        "name": "DefangLabs"
+      },
+      "homepage": "https://defang.io",
+      "repository": "https://github.com/DefangLabs/defang",
+      "license": "Apache-2.0",
+      "category": "infrastructure",
+      "keywords": ["deploy", "cloud", "aws", "gcp", "digitalocean", "docker", "compose"]
+    }
+  ]
+}

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,5 +1,5 @@
 {
-  "name": "defang-labs",
+  "name": "defang-skills",
   "owner": {
     "name": "DefangLabs",
     "email": "support@defang.io"

--- a/README.md
+++ b/README.md
@@ -76,6 +76,17 @@ $ defang up --stack=awsuswest2
 
 The Defang Model Context Protocol [(MCP)](https://docs.defang.io/docs/concepts/mcp) Server is tailored for developers who work primarily within integrated development environments (IDEs). It enables seamless cloud deployment from supported editors such as Cursor, Windsurf, VS Code, VS Code Insiders and Claude delivering a fully integrated experience without leaving your development environment.
 
+## Claude Code Plugin
+
+Install the Defang plugin for [Claude Code](https://claude.ai/code) to deploy directly from any Claude Code session — no CLI required upfront:
+
+```shell
+/plugin marketplace add DefangLabs/defang
+/plugin install defang@defang-skills
+```
+
+After installing, use `/defang:deploy` to guide you through deploying your project. The Defang MCP server activates automatically once the Defang CLI is installed.
+
 ## This repo includes:
 
 - Public releases of the Defang CLI; [click here](https://github.com/DefangLabs/defang/releases/latest/) for the latest version

--- a/claude-plugin/.claude-plugin/plugin.json
+++ b/claude-plugin/.claude-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "defang",
+  "description": "Deploy Docker Compose apps to your own cloud account using Defang. Includes a /defang:deploy skill and Defang MCP server integration.",
+  "version": "1.0.0",
+  "author": {
+    "name": "DefangLabs",
+    "email": "support@defang.io"
+  },
+  "homepage": "https://defang.io",
+  "repository": "https://github.com/DefangLabs/defang",
+  "license": "Apache-2.0",
+  "keywords": ["deploy", "cloud", "aws", "gcp", "digitalocean", "docker", "compose"]
+}

--- a/claude-plugin/.mcp.json
+++ b/claude-plugin/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "defang": {
+      "command": "defang",
+      "args": ["mcp", "serve"]
+    }
+  }
+}

--- a/claude-plugin/skills/deploy/SKILL.md
+++ b/claude-plugin/skills/deploy/SKILL.md
@@ -1,0 +1,109 @@
+---
+description: Deploy the current project to the cloud using Defang. Guides through CLI setup, authentication, compose file creation, stack selection, config management, and deployment.
+---
+
+Deploy the current project using the Defang CLI by following these steps:
+
+## Step 1: Validate the CLI
+
+Run `defang --version` to confirm the CLI is installed. If it is not found, install it:
+
+- npm: `npm install -g @defang-io/defang`
+- Homebrew: `brew install DefangLabs/defang/defang`
+- curl: `eval "$(curl -fsSL s.defang.io/install)"`
+
+If you installed defang for the first time, run `/reload-plugins` to activate the Defang MCP server.
+
+## Step 2: Authenticate
+
+Run `defang whoami` to check if the user is already logged in. If not, run `defang login` and wait for authentication to complete.
+
+## Step 3: Find or Create a compose.yaml file
+
+Look for any compose.yaml files in the current directory or parent directories. If multiple are found, ask the user to select one. If none are found, ask the user if they want to create a new one. If yes, ask them about the services they want to deploy and generate a compose.yaml based on their answers. You will need to know which command each service should run, any environment variables they require, whether or not they should listen on a port, and if so, which one, and so on.
+
+## Step 4: Select or create a stack
+
+A stack is a single deployed instance of the project in a specific cloud account and region, for example: `production` is deployed to `aws` in `us-east-1`. Additional configuration associated with a stack can be specified in the stack file (e.g., `.defang/production`). Note that stack variables are read at deployment time, and are not available at runtime in your application services.
+
+List existing stacks:
+
+```bash
+defang stack list
+```
+
+- If one or more stacks exist, ask the user whether to use an existing one or create a new one.
+- If no stacks exist, create a new one.
+
+To create a stack interactively:
+
+```bash
+defang stack new
+```
+
+Required parameters:
+- **Name**: alphanumeric, cannot start with a number (e.g., `my-app-prod`)
+- **Provider**: `aws`, `gcp`, or `digitalocean`
+- **Region**: e.g., `us-east-1` (AWS), `us-central1` (GCP)
+- **Deployment Mode**: controls cost and resiliency
+  - `affordable` — lowest cost, for dev/test (default)
+  - `balanced` — general production workloads
+  - `high_availability` — critical services
+  - See https://docs.defang.io/docs/concepts/deployment-modes
+
+After creating a stack, set it as the default:
+
+```bash
+defang stack default STACK_NAME
+```
+
+## Step 5: Set required configs
+
+Check the `compose.yaml` for environment variables listed without a value — these must be set as configs before deployment.
+
+List configs already set:
+
+```bash
+defang config ls
+```
+
+For each unset config, ask the user whether to provide a specific value or generate a random one. Do not assume a default. Then set it:
+
+```bash
+# specific value
+defang config set KEY=value
+
+# random value
+defang config set --random KEY
+
+# prompted securely (interactive)
+defang config set KEY
+```
+
+## Step 6: Deploy
+
+```bash
+defang compose up
+```
+
+Useful flags:
+- `-d` / `--detach`: return immediately without streaming logs
+- `--force`: force a fresh image build even if nothing changed
+- `--mode affordable|balanced|high_availability`: override the stack's deployment mode
+
+The CLI will stream logs automatically. If the deployment fails, Defang may offer an AI-assisted debug prompt — allow it to run before investigating manually.
+
+## Step 7: Verify
+
+Once deployment completes, check service status and endpoints:
+
+```bash
+defang compose ps
+```
+
+To tail logs after the fact:
+
+```bash
+defang logs --follow
+defang logs SERVICE_NAME --follow   # filter to one service
+```

--- a/skills/deploy.md
+++ b/skills/deploy.md
@@ -1,0 +1,103 @@
+Deploy the current project using the Defang CLI by following these steps:
+
+## Step 1: Validate the CLI
+
+Run `defang --version` to confirm the CLI is installed. If it is not found, install it:
+
+- npm: `npm install -g @defang-io/defang`
+- Homebrew: `brew install DefangLabs/defang/defang`
+- curl: `eval "$(curl -fsSL s.defang.io/install)"`
+
+## Step 2: Authenticate
+
+Run `defang whoami` to check if the user is already logged in. If not, run `defang login` and wait for authentication to complete.
+
+## Step 3: Find or Create a compose.yaml file
+
+Look for any compose.yaml files in the current directory or parent directories. If multiple are found, ask the user to select one. If none are found, ask the user if they want to create a new one. If yes, ask them about the services they want to deploy and generate a compose.yaml based on their answers. You will need to know which command each service should run, any environment variables they require, whether or not they should listen on a port, and if so, which one, and so on.
+
+## Step 4: Select or create a stack
+
+A stack is a single deployed instance of the project in a specific cloud account and region, for example: `production` is deployed to `aws` in `us-east-1`. Additional configuration associated with a stack can be specified in the stack file (e.g., `.defang/production`). Note that stack variables are read at deployment time, and are not available at runtime in your application services.
+
+List existing stacks:
+
+```bash
+defang stack list
+```
+
+- If one or more stacks exist, ask the user whether to use an existing one or create a new one.
+- If no stacks exist, create a new one.
+
+To create a stack interactively:
+
+```bash
+defang stack new
+```
+
+Required parameters:
+- **Name**: alphanumeric, cannot start with a number (e.g., `my-app-prod`)
+- **Provider**: `aws`, `gcp`, or `digitalocean`
+- **Region**: e.g., `us-east-1` (AWS), `us-central1` (GCP)
+- **Deployment Mode**: controls cost and resiliency
+  - `affordable` — lowest cost, for dev/test (default)
+  - `balanced` — general production workloads
+  - `high_availability` — critical services
+  - See https://docs.defang.io/docs/concepts/deployment-modes
+
+After creating a stack, set it as the default:
+
+```bash
+defang stack default STACK_NAME
+```
+
+## Step 5: Set required configs
+
+Check the `compose.yaml` for environment variables listed without a value — these must be set as configs before deployment.
+
+List configs already set:
+
+```bash
+defang config ls
+```
+
+For each unset config, ask the user whether to provide a specific value or generate a random one. Do not assume a default. Then set it:
+
+```bash
+# specific value
+defang config set KEY=value
+
+# random value
+defang config set --random KEY
+
+# prompted securely (interactive)
+defang config set KEY
+```
+
+## Step 6: Deploy
+
+```bash
+defang compose up
+```
+
+Useful flags:
+- `-d` / `--detach`: return immediately without streaming logs
+- `--force`: force a fresh image build even if nothing changed
+- `--mode affordable|balanced|high_availability`: override the stack's deployment mode
+
+The CLI will stream logs automatically. If the deployment fails, Defang may offer an AI-assisted debug prompt — allow it to run before investigating manually.
+
+## Step 7: Verify
+
+Once deployment completes, check service status and endpoints:
+
+```bash
+defang compose ps
+```
+
+To tail logs after the fact:
+
+```bash
+defang logs --follow
+defang logs SERVICE_NAME --follow   # filter to one service
+```


### PR DESCRIPTION
## Summary

- Adds a distributable Claude Code plugin so any Claude Code user can install Defang tooling into their sessions — not just contributors to this repo
- The plugin bundles the `/defang:deploy` skill and the Defang MCP server, structured as a proper Claude Code marketplace plugin

## Install flow

Two commands, and the Defang CLI does **not** need to be installed first:

```shell
/plugin marketplace add DefangLabs/defang
/plugin install defang@defang-skills
```

After that, `/defang:deploy` is available in any Claude Code session. The Defang MCP tools activate automatically once the Defang CLI is installed.

## Plugin structure

```
.claude-plugin/
  marketplace.json              # Marketplace catalog (name: defang-skills)
claude-plugin/
  .claude-plugin/
    plugin.json                 # Plugin manifest (name: defang)
  skills/
    deploy/
      SKILL.md                  # /defang:deploy skill
  .mcp.json                     # Registers `defang mcp serve`
```

### `.claude-plugin/marketplace.json`
Allows `/plugin marketplace add DefangLabs/defang` to work. Points to `./claude-plugin` as the plugin source using a relative path (works because users add the marketplace via Git).

### `claude-plugin/.claude-plugin/plugin.json`
Declares plugin name (`defang`), version, author, license, etc.

### `claude-plugin/skills/deploy/SKILL.md`
The `/defang:deploy` skill, migrated from `skills/deploy.md` with proper SKILL.md frontmatter added. Content is identical except:
- Added frontmatter with description
- Added a note in Step 1 to run `/reload-plugins` after installing defang for the first time (activates the MCP server without needing a full restart)

### `claude-plugin/.mcp.json`
Registers `defang mcp serve` as an MCP server. If defang isn't installed yet, this silently fails with a note in the `/plugin Errors` tab — the skill still works normally and guides through installation.

## What's preserved

`skills/deploy.md` is unchanged. It serves a different purpose: a project-local skill (no namespace prefix) for contributors working in this repo. The plugin version (`/defang:deploy`) is for users deploying their own projects with Defang.

## Next step

Once this ships, we can submit to the Anthropic official marketplace (`claude-plugins-official`) for single-command install: `/plugin install defang@claude-plugins-official`.

## Test plan

- [ ] Run `/plugin marketplace add DefangLabs/defang` in Claude Code
- [ ] Run `/plugin install defang@defang-skills`
- [ ] Run `/reload-plugins`
- [ ] Verify `/defang:deploy` appears in skill list
- [ ] Verify MCP tools appear in tool list (requires Defang CLI installed)
- [ ] Verify `/defang:deploy` guides through defang installation if CLI is missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Claude plugin for Defang enabling deployment of Docker Compose apps to AWS, GCP, and DigitalOcean; includes marketplace listing and automatic background service activation for the plugin.

* **Documentation**
  * Added step‑by‑step deployment guides covering CLI validation, authentication, stack creation/selection, environment configuration, deployment commands, and verification with log monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->