### PR TITLE
feat(stack): add Account column to stack ls table

### DIFF
--- a/src/cmd/cli/command/stack.go
+++ b/src/cmd/cli/command/stack.go
@@ -137,7 +137,7 @@ func makeStackListCmd() *cobra.Command {
 				return err
 			}
 
-			columns := []string{"Name", "Default", "Provider", "Region", "Mode", "DeployedAt"}
+			columns := []string{"Name", "Default", "Provider", "Region", "Account", "Mode", "DeployedAt"}
 			return term.Table(stacks, columns...)
 		},
 	}

--- a/src/cmd/cli/command/stack_test.go
+++ b/src/cmd/cli/command/stack_test.go
@@ -111,9 +111,9 @@ func TestStackListCmd(t *testing.T) {
 					Mode:     modes.ModeBalanced,
 				},
 			},
-			expectOutput: "NAME        DEFAULT  PROVIDER  REGION       MODE        DEPLOYEDAT\n" +
-				"teststack1           aws       us-test-2    AFFORDABLE    \n" +
-				"teststack2           gcp       us-central1  BALANCED      \n",
+			expectOutput: "NAME        DEFAULT  PROVIDER  REGION       ACCOUNT  MODE        DEPLOYEDAT\n" +
+				"teststack1           aws       us-test-2             AFFORDABLE    \n" +
+				"teststack2           gcp       us-central1           BALANCED      \n",
 		},
 	}
 	for _, tt := range tests {

--- a/src/pkg/stacks/manager.go
+++ b/src/pkg/stacks/manager.go
@@ -123,6 +123,7 @@ func (sm *manager) ListRemote(ctx context.Context) ([]ListItem, error) {
 		}
 		stackParams = append(stackParams, ListItem{
 			Parameters: *params,
+			Account:    params.Account(),
 			DeployedAt: timeutils.AsTime(stack.GetLastDeployedAt(), time.Time{}).Local(),
 			Default:    stack.GetIsDefault(),
 		})

--- a/src/pkg/stacks/stacks.go
+++ b/src/pkg/stacks/stacks.go
@@ -142,9 +142,21 @@ func CreateInDirectory(workingDirectory string, params Parameters) (string, erro
 	return filename, nil
 }
 
+func (p *Parameters) Account() string {
+	switch p.Provider {
+	case client.ProviderAWS:
+		return p.Variables["AWS_PROFILE"]
+	case client.ProviderGCP:
+		return p.Variables["GCP_PROJECT_ID"]
+	default:
+		return ""
+	}
+}
+
 // for shell printing for converting to string format of StackParameters
 type ListItem struct {
 	Parameters
+	Account    string
 	Default    bool
 	DeployedAt time.Time
 }
@@ -179,6 +191,7 @@ func ListInDirectory(workingDirectory string) ([]ListItem, error) {
 		}
 		stacks = append(stacks, ListItem{
 			Parameters: *params,
+			Account:    params.Account(),
 		})
 	}
 


### PR DESCRIPTION
## Summary

- Adds an `Account` column to the `defang stack ls` table output
- Shows `AWS_PROFILE` for AWS stacks and `GCP_PROJECT_ID` for GCP stacks
- Makes it easier to distinguish between multiple stacks deployed to the same provider

## Test plan

- [ ] Run `defang stack ls` and confirm the `ACCOUNT` column appears between `REGION` and `MODE`
- [ ] Verify AWS stacks show the correct `AWS_PROFILE` value
- [ ] Verify GCP stacks show the correct `GCP_PROJECT_ID` value
- [ ] Verify non-AWS/GCP stacks (e.g. defang provider) show an empty account column
- [ ] Existing unit tests updated and passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `stack list` command now displays an "Account" column showing the associated AWS profile or GCP project identifier for each stack.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->