### PR TITLE
Add Codex plugin with deploy skill and MCP server

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,22 @@
+{
+  "name": "defang-skills",
+  "owner": {
+    "name": "DefangLabs",
+    "email": "support@defang.io"
+  },
+  "plugins": [
+    {
+      "name": "defang",
+      "source": {
+        "source": "local",
+        "path": "./codex-plugin"
+      },
+      "description": "Deploy Docker Compose apps to your own cloud account using Defang. Includes a /defang:deploy skill and Defang MCP server integration.",
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Infrastructure"
+    }
+  ]
+}

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -20,7 +20,15 @@
       "repository": "https://github.com/DefangLabs/defang",
       "license": "Apache-2.0",
       "category": "infrastructure",
-      "keywords": ["deploy", "cloud", "aws", "gcp", "digitalocean", "docker", "compose"]
+      "keywords": [
+        "deploy",
+        "cloud",
+        "aws",
+        "gcp",
+        "digitalocean",
+        "docker",
+        "compose"
+      ]
     }
   ]
 }

--- a/claude-plugin/skills/deploy/SKILL.md
+++ b/claude-plugin/skills/deploy/SKILL.md
@@ -42,7 +42,8 @@ defang stack new
 ```
 
 Required parameters:
-- **Name**: alphanumeric, cannot start with a number (e.g., `my-app-prod`)
+
+- **Name**: alphanumeric, cannot start with a number (e.g., `production`)
 - **Provider**: `aws`, `gcp`, or `digitalocean`
 - **Region**: e.g., `us-east-1` (AWS), `us-central1` (GCP)
 - **Deployment Mode**: controls cost and resiliency
@@ -87,6 +88,7 @@ defang compose up
 ```
 
 Useful flags:
+
 - `-d` / `--detach`: return immediately without streaming logs
 - `--force`: force a fresh image build even if nothing changed
 - `--mode affordable|balanced|high_availability`: override the stack's deployment mode

--- a/codex-plugin/.codex-plugin/plugin.json
+++ b/codex-plugin/.codex-plugin/plugin.json
@@ -1,0 +1,20 @@
+{
+  "name": "defang",
+  "version": "1.0.0",
+  "description": "Deploy Docker Compose apps to your own cloud account using Defang. Includes a /defang:deploy skill and Defang MCP server integration.",
+  "author": {
+    "name": "DefangLabs",
+    "email": "support@defang.io"
+  },
+  "homepage": "https://defang.io",
+  "repository": "https://github.com/DefangLabs/defang",
+  "license": "Apache-2.0",
+  "keywords": ["deploy", "cloud", "aws", "gcp", "digitalocean", "docker", "compose"],
+  "skills": "./skills/",
+  "mcpServers": "./.mcp.json",
+  "interface": {
+    "displayName": "Defang",
+    "shortDescription": "Deploy Docker Compose apps to AWS, GCP, or DigitalOcean.",
+    "category": "Infrastructure"
+  }
+}

--- a/codex-plugin/.mcp.json
+++ b/codex-plugin/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "defang": {
+      "command": "defang",
+      "args": ["mcp", "serve"]
+    }
+  }
+}

--- a/codex-plugin/skills/deploy/SKILL.md
+++ b/codex-plugin/skills/deploy/SKILL.md
@@ -41,7 +41,8 @@ defang stack new
 ```
 
 Required parameters:
-- **Name**: alphanumeric, cannot start with a number (e.g., `my-app-prod`)
+
+- **Name**: alphanumeric, cannot start with a number (e.g., `production`)
 - **Provider**: `aws`, `gcp`, or `digitalocean`
 - **Region**: e.g., `us-east-1` (AWS), `us-central1` (GCP)
 - **Deployment Mode**: controls cost and resiliency
@@ -86,6 +87,7 @@ defang compose up
 ```
 
 Useful flags:
+
 - `-d` / `--detach`: return immediately without streaming logs
 - `--force`: force a fresh image build even if nothing changed
 - `--mode affordable|balanced|high_availability`: override the stack's deployment mode

--- a/codex-plugin/skills/deploy/SKILL.md
+++ b/codex-plugin/skills/deploy/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: deploy
+description: Deploy the current project to the cloud using Defang. Guides through CLI setup, authentication, compose file creation, stack selection, config management, and deployment.
+---
+
+Deploy the current project using the Defang CLI by following these steps:
+
+## Step 1: Validate the CLI
+
+Run `defang --version` to confirm the CLI is installed. If it is not found, install it:
+
+- npm: `npm install -g @defang-io/defang`
+- Homebrew: `brew install DefangLabs/defang/defang`
+- curl: `eval "$(curl -fsSL s.defang.io/install)"`
+
+## Step 2: Authenticate
+
+Run `defang whoami` to check if the user is already logged in. If not, run `defang login` and wait for authentication to complete.
+
+## Step 3: Find or Create a compose.yaml file
+
+Look for any compose.yaml files in the current directory or parent directories. If multiple are found, ask the user to select one. If none are found, ask the user if they want to create a new one. If yes, ask them about the services they want to deploy and generate a compose.yaml based on their answers. You will need to know which command each service should run, any environment variables they require, whether or not they should listen on a port, and if so, which one, and so on.
+
+## Step 4: Select or create a stack
+
+A stack is a single deployed instance of the project in a specific cloud account and region, for example: `production` is deployed to `aws` in `us-east-1`. Additional configuration associated with a stack can be specified in the stack file (e.g., `.defang/production`). Note that stack variables are read at deployment time, and are not available at runtime in your application services.
+
+List existing stacks:
+
+```bash
+defang stack list
+```
+
+- If one or more stacks exist, ask the user whether to use an existing one or create a new one.
+- If no stacks exist, create a new one.
+
+To create a stack interactively:
+
+```bash
+defang stack new
+```
+
+Required parameters:
+- **Name**: alphanumeric, cannot start with a number (e.g., `my-app-prod`)
+- **Provider**: `aws`, `gcp`, or `digitalocean`
+- **Region**: e.g., `us-east-1` (AWS), `us-central1` (GCP)
+- **Deployment Mode**: controls cost and resiliency
+  - `affordable` — lowest cost, for dev/test (default)
+  - `balanced` — general production workloads
+  - `high_availability` — critical services
+  - See https://docs.defang.io/docs/concepts/deployment-modes
+
+After creating a stack, set it as the default:
+
+```bash
+defang stack default STACK_NAME
+```
+
+## Step 5: Set required configs
+
+Check the `compose.yaml` for environment variables listed without a value — these must be set as configs before deployment.
+
+List configs already set:
+
+```bash
+defang config ls
+```
+
+For each unset config, ask the user whether to provide a specific value or generate a random one. Do not assume a default. Then set it:
+
+```bash
+# specific value
+defang config set KEY=value
+
+# random value
+defang config set --random KEY
+
+# prompted securely (interactive)
+defang config set KEY
+```
+
+## Step 6: Deploy
+
+```bash
+defang compose up
+```
+
+Useful flags:
+- `-d` / `--detach`: return immediately without streaming logs
+- `--force`: force a fresh image build even if nothing changed
+- `--mode affordable|balanced|high_availability`: override the stack's deployment mode
+
+The CLI will stream logs automatically. If the deployment fails, Defang may offer an AI-assisted debug prompt — allow it to run before investigating manually.
+
+## Step 7: Verify
+
+Once deployment completes, check service status and endpoints:
+
+```bash
+defang compose ps
+```
+
+To tail logs after the fact:
+
+```bash
+defang logs --follow
+defang logs SERVICE_NAME --follow   # filter to one service
+```

--- a/skills/deploy.md
+++ b/skills/deploy.md
@@ -36,7 +36,8 @@ defang stack new
 ```
 
 Required parameters:
-- **Name**: alphanumeric, cannot start with a number (e.g., `my-app-prod`)
+
+- **Name**: alphanumeric, cannot start with a number (e.g., `production`)
 - **Provider**: `aws`, `gcp`, or `digitalocean`
 - **Region**: e.g., `us-east-1` (AWS), `us-central1` (GCP)
 - **Deployment Mode**: controls cost and resiliency
@@ -81,6 +82,7 @@ defang compose up
 ```
 
 Useful flags:
+
 - `-d` / `--detach`: return immediately without streaming logs
 - `--force`: force a fresh image build even if nothing changed
 - `--mode affordable|balanced|high_availability`: override the stack's deployment mode


### PR DESCRIPTION
## Summary

- Adds a Codex plugin parallel to the existing Claude Code plugin, so OpenAI Codex users can install the same Defang deploy skill and MCP server integration
- Follows the Codex plugin spec: `.codex-plugin/plugin.json` manifest, `skills/<name>/SKILL.md` structure, and `.agents/plugins/marketplace.json` marketplace catalog

## Plugin structure

```
.agents/
  plugins/
    marketplace.json              # Codex marketplace catalog (name: defang-skills)
codex-plugin/
  .codex-plugin/
    plugin.json                   # Plugin manifest (name: defang)
  skills/
    deploy/
      SKILL.md                    # /defang:deploy skill
  .mcp.json                       # Registers `defang mcp serve`
```

## Differences from the Claude Code plugin

| | Claude Code | Codex |
|---|---|---|
| Manifest dir | `.claude-plugin/` | `.codex-plugin/` |
| Marketplace | `.claude-plugin/marketplace.json` | `.agents/plugins/marketplace.json` |
| Plugin dir | `claude-plugin/` | `codex-plugin/` |
| SKILL.md frontmatter | `description` only | `name` + `description` |

The skill content is identical. The Claude Code-specific `/reload-plugins` hint is omitted from the Codex version.

## Caveat

Codex's public plugin registry is not yet available ("coming soon" per their docs), so installation is currently local/personal marketplace only — there is no equivalent of `/plugin marketplace add` from a GitHub URL yet.

## Test plan

- [ ] Verify `codex-plugin/` loads correctly with `--plugin-dir ./codex-plugin` (or Codex equivalent)
- [ ] Verify `/defang:deploy` appears in skill list
- [ ] Verify MCP tools appear once Defang CLI is installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the Defang plugin to marketplace listings — includes a deploy skill for Docker Compose applications, MCP server integration, and marketplace installation/auth policies.
* **Documentation**
  * Added a comprehensive deploy guide covering CLI validation, authentication, compose discovery, stack/config management, deployment flags, and verification.
  * Minor doc updates to examples and formatting for stack creation and compose flags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->