### PR TITLE
Add estimate and debug skills

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -11,7 +11,7 @@
         "source": "local",
         "path": "./codex-plugin"
       },
-      "description": "Deploy Docker Compose apps to your own cloud account using Defang. Includes /defang:deploy and /defang:estimate skills and Defang MCP server integration.",
+      "description": "Deploy Docker Compose apps to your own cloud account using Defang. Includes /defang:deploy, /defang:estimate, and /defang:debug skills and Defang MCP server integration.",
       "policy": {
         "installation": "AVAILABLE",
         "authentication": "ON_INSTALL"

--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -11,7 +11,7 @@
         "source": "local",
         "path": "./codex-plugin"
       },
-      "description": "Deploy Docker Compose apps to your own cloud account using Defang. Includes a /defang:deploy skill and Defang MCP server integration.",
+      "description": "Deploy Docker Compose apps to your own cloud account using Defang. Includes /defang:deploy and /defang:estimate skills and Defang MCP server integration.",
       "policy": {
         "installation": "AVAILABLE",
         "authentication": "ON_INSTALL"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "defang",
       "source": "./claude-plugin",
-      "description": "Deploy Docker Compose apps to your own cloud account using Defang. Includes a /defang:deploy skill and Defang MCP server integration.",
+      "description": "Deploy Docker Compose apps to your own cloud account using Defang. Includes /defang:deploy and /defang:estimate skills and Defang MCP server integration.",
       "version": "1.0.0",
       "author": {
         "name": "DefangLabs"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "defang",
       "source": "./claude-plugin",
-      "description": "Deploy Docker Compose apps to your own cloud account using Defang. Includes /defang:deploy and /defang:estimate skills and Defang MCP server integration.",
+      "description": "Deploy Docker Compose apps to your own cloud account using Defang. Includes /defang:deploy, /defang:estimate, and /defang:debug skills and Defang MCP server integration.",
       "version": "1.0.0",
       "author": {
         "name": "DefangLabs"

--- a/skills/debug.md
+++ b/skills/debug.md
@@ -1,0 +1,75 @@
+Debug the current Defang project by inspecting deployment status and logs for errors.
+
+## Step 1: Validate the CLI
+
+Run `defang --version` to confirm the CLI is installed. If it is not found, install it:
+
+- npm: `npm install -g @defang-io/defang`
+- Homebrew: `brew install DefangLabs/defang/defang`
+- curl: `eval "$(curl -fsSL s.defang.io/install)"`
+
+## Step 2: Authenticate
+
+Run `defang whoami` to check if the user is already logged in. If not, run `defang login` and wait for authentication to complete.
+
+## Step 3: Find the compose.yaml file
+
+Look for any compose.yaml files in the current directory or parent directories. If multiple are found, ask the user to select one. Note the services defined — their names will be used to correlate status and log output.
+
+## Step 4: Check the current stack
+
+```bash
+defang stack ls
+```
+
+Note the active stack (provider, region, deployment mode). If no stack is selected, ask the user to select one or run `defang stack default STACK_NAME`.
+
+## Step 5: Check deployment status
+
+```bash
+defang compose ps
+```
+
+For each service, note:
+- Whether it is running, stopped, or in an error state
+- The number of healthy vs. unhealthy replicas
+- Any listed endpoints
+
+Flag any service that is not in a healthy running state for closer investigation.
+
+## Step 6: Fetch recent logs and look for errors
+
+Fetch the last few minutes of logs across all services:
+
+```bash
+defang logs --since 15m
+```
+
+To narrow down to a specific service showing problems:
+
+```bash
+defang logs SERVICE_NAME --since 15m
+```
+
+Scan the output for:
+- Stack traces or panics
+- HTTP 5xx responses
+- `error`, `fatal`, `exception`, `crash`, or `OOM` keywords
+- Repeated restart or exit messages
+- Connection failures (database, external APIs, etc.)
+
+If the initial window misses relevant context, expand it:
+
+```bash
+defang logs SERVICE_NAME --since 1h
+```
+
+## Step 7: Summarize and recommend
+
+After gathering the above information, provide a concise diagnosis:
+
+1. **Status summary** — which services are healthy, degraded, or down
+2. **Root cause** — the most likely error based on log evidence, with the relevant log lines quoted
+3. **Next steps** — specific, actionable recommendations (e.g., fix a misconfigured env var, increase memory, redeploy after a code fix)
+
+If the issue is unclear, suggest running `defang compose up` with logs streaming to observe the next deployment in real time.

--- a/skills/debug.md
+++ b/skills/debug.md
@@ -22,7 +22,14 @@ Look for any compose.yaml files in the current directory or parent directories. 
 defang stack ls
 ```
 
-Note the active stack (provider, region, deployment mode). If no stack is selected, ask the user to select one or run `defang stack default STACK_NAME`.
+Interpret the output as follows:
+
+- **No stacks listed** — No deployment has been made yet. Stop here and inform the user: "No deployment found yet." Ask them to either run the project's deploy command (e.g., `/defang:deploy`) to create one, or verify they are in the correct project directory before continuing.
+- **Stacks listed but none marked as default** — A deployment exists but no stack is active. Ask the user which stack to debug, then set it as the default:
+  ```bash
+  defang stack default STACK_NAME
+  ```
+- **A stack is already active** — Note its provider, region, and deployment mode and continue to the next step.
 
 ## Step 5: Check deployment status
 

--- a/skills/estimate.md
+++ b/skills/estimate.md
@@ -1,0 +1,53 @@
+Estimate the monthly cloud cost for the current project using the Defang CLI by following these steps:
+
+## Step 1: Validate the CLI
+
+Run `defang --version` to confirm the CLI is installed. If it is not found, install it:
+
+- npm: `npm install -g @defang-io/defang`
+- Homebrew: `brew install DefangLabs/defang/defang`
+- curl: `eval "$(curl -fsSL s.defang.io/install)"`
+
+## Step 2: Authenticate
+
+Run `defang whoami` to check if the user is already logged in. If not, run `defang login` and wait for authentication to complete.
+
+## Step 3: Find or Create a compose.yaml file
+
+Look for any compose.yaml files in the current directory or parent directories. If multiple are found, ask the user to select one. If none are found, ask the user if they want to create a new one. If yes, ask them about the services they want to deploy and generate a compose.yaml based on their answers.
+
+## Step 4: Determine target stack
+
+A stack specifies the cloud provider, region, and deployment mode used for the estimate.
+
+List existing stacks:
+
+```bash
+defang stack list
+```
+
+- If one or more stacks exist, ask the user which one to base the estimate on.
+- If no stacks exist, ask the user for:
+  - **Provider**: `aws` or `gcp`
+  - **Region**: e.g., `us-east-1` (AWS), `us-central1` (GCP)
+  - **Deployment Mode**: controls cost and resiliency
+    - `affordable` — lowest cost, for dev/test (default)
+    - `balanced` — general production workloads
+    - `high_availability` — critical services
+    - See https://docs.defang.io/docs/concepts/deployment-modes
+
+## Step 5: Run the estimate
+
+```bash
+defang compose estimate
+```
+
+Useful flags:
+
+- `--provider aws|gcp`: override the provider
+- `--region REGION`: override the region
+- `--mode affordable|balanced|high_availability`: override the deployment mode
+
+## Step 6: Explain the results
+
+After the estimate completes, summarize the breakdown for the user — call out the most significant cost drivers (e.g., compute, storage, data transfer) and suggest lower-cost alternatives if the estimate seems high (e.g., switching to `affordable` mode or reducing replica counts).


### PR DESCRIPTION
## Summary

- Adds `/defang:estimate` skill — guides through finding a compose.yaml, selecting a stack (or prompting for provider/region/mode), running `defang compose estimate`, and explaining the cost breakdown
- Adds `/defang:debug` skill — checks deployment status via `defang compose ps`, fetches recent logs, scans for common error patterns, and produces a structured diagnosis with next steps
- Updates plugin descriptions in both `.agents/plugins/marketplace.json` and `.claude-plugin/marketplace.json` to reference all three skills

## Test plan

- [ ] Invoke `/defang:estimate` on a project with an existing stack and verify it runs `defang compose estimate` and explains results
- [ ] Invoke `/defang:estimate` on a project with no stacks and verify it prompts for provider/region/mode
- [ ] Invoke `/defang:debug` on a healthy deployment and verify status + log summary
- [ ] Invoke `/defang:debug` on a deployment with errors and verify it surfaces the root cause and recommends next steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Debugging skill to troubleshoot and resolve Defang project deployment issues
  * Cost estimation skill to evaluate and plan monthly cloud expenses

* **Documentation**
  * Comprehensive debugging guide with step-by-step troubleshooting workflow and log analysis
  * Cost estimation guide for evaluating cloud infrastructure expenses using the CLI

* **Chores**
  * Marketplace listings updated to advertise the new /defang:estimate and /defang:debug skills
<!-- end of auto-generated comment: release notes by coderabbit.ai -->