### PR TITLE
fix: only check for existing stack when interactive

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,9 +1,13 @@
 {
   "permissions": {
     "allow": [
+      "Bash(docker pull:*)",
       "Bash(git ls-remote:*)",
+      "Bash(go vet:*)",
+      "Bash(head:*)",
       "Bash(sort:*)",
-      "Bash(docker pull:*)"
+      "Bash(tail:*)",
+      "Bash(xxd:*)"
     ]
   }
 }

--- a/src/cmd/cli/command/stack.go
+++ b/src/cmd/cli/command/stack.go
@@ -53,13 +53,15 @@ func makeStackNewCmd() *cobra.Command {
 				return err
 			}
 
-			if stackName != "" {
+			if stackName != "" && global.Interactive() {
+				// Avoid prompting for stack parameters (interactive mode), if the stack name is provided, but the
+				// given stack name already exists in the project. The PutStack gRPC call would fail.
 				exists, err := stackExists(ctx, projectName, stackName)
 				if err != nil {
 					return err
 				}
 				if exists {
-					return fmt.Errorf("stack with name %q already exists in project %q", stackName, projectName)
+					return fmt.Errorf("a stack with name %q already exists in project %q", stackName, projectName)
 				}
 			}
 

--- a/src/cmd/cli/command/stack_test.go
+++ b/src/cmd/cli/command/stack_test.go
@@ -144,20 +144,20 @@ func TestStackListCmd(t *testing.T) {
 	}
 }
 
-func TestNonInteractiveStackNewCmd(t *testing.T) {
+func TestStackNewCmd(t *testing.T) {
 	origClient := global.Client
 	origNI := global.NonInteractive
-	global.NonInteractive = true
 	t.Cleanup(func() {
 		global.Client = origClient
 		global.NonInteractive = origNI
 	})
 
 	tests := []struct {
+		interactive    bool
 		name           string
 		parameters     stacks.Parameters
 		existingStacks []*defangv1.Stack
-		expectErr      bool
+		expectErr      string
 	}{
 		{
 			name: "valid parameters",
@@ -168,7 +168,6 @@ func TestNonInteractiveStackNewCmd(t *testing.T) {
 				Mode:     modes.ModeAffordable,
 			},
 			existingStacks: []*defangv1.Stack{},
-			expectErr:      false,
 		},
 		{
 			name: "missing stack name",
@@ -179,7 +178,7 @@ func TestNonInteractiveStackNewCmd(t *testing.T) {
 				Mode:     modes.ModeAffordable,
 			},
 			existingStacks: []*defangv1.Stack{},
-			expectErr:      true,
+			expectErr:      "invalid stack name",
 		},
 		{
 			name: "stack already exists",
@@ -190,12 +189,24 @@ func TestNonInteractiveStackNewCmd(t *testing.T) {
 				Mode:     modes.ModeAffordable,
 			},
 			existingStacks: []*defangv1.Stack{{Name: "existingstack", Project: ""}},
-			expectErr:      true,
+		},
+		{
+			name:        "stack already exists; interactive mode should error",
+			interactive: true,
+			parameters: stacks.Parameters{
+				Name:     "existingstack",
+				Provider: client.ProviderAWS,
+				Region:   "us-test-2",
+				Mode:     modes.ModeAffordable,
+			},
+			existingStacks: []*defangv1.Stack{{Name: "existingstack", Project: ""}},
+			expectErr:      "already exists",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			global.NonInteractive = !tt.interactive
 			t.Chdir(t.TempDir())
 			os.WriteFile("compose.yaml", []byte(testComposeYaml), 0644)
 
@@ -207,8 +218,10 @@ func TestNonInteractiveStackNewCmd(t *testing.T) {
 			stackCreateCmd.Flags().Set("region", tt.parameters.Region)
 
 			err := stackCreateCmd.RunE(stackCreateCmd, []string{tt.parameters.Name})
-			if (err != nil) != tt.expectErr {
-				t.Errorf("RunE() error = %v, expectErr %v", err, tt.expectErr)
+			if tt.expectErr == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.ErrorContains(t, err, tt.expectErr)
 			}
 		})
 	}


### PR DESCRIPTION
## Description

CLI Smoketests were failing because they do `defang stack create` with a stack that already exists. The `PutStack` gRPC call is idempotent and would succeed (iff the stack file is identical), but since #1964 we proactively check for the existence of a stack, to avoid users entering a bunch of stack info (provider, account) and then getting an error. 

This check is not done for interactive use only.

## Linked Issues

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
- Enhanced the stack creation process with improved validation timing and clearer error messaging: the command now checks whether a stack with the provided name already exists in the project before prompting for configuration parameters, ensuring users receive more informative feedback when attempting to create duplicate stacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->