### PR TITLE
Handle 403 during first GCP up

### DIFF
--- a/src/bin/install
+++ b/src/bin/install
@@ -286,9 +286,11 @@ _install_completion_script() {
     esac
 }
 
-_install_completion_script "$SHELL" || true
-CURRENT_SHELL=${0#-}
-[ "$CURRENT_SHELL" != "$SHELL" ] && _install_completion_script "$CURRENT_SHELL" || true
+if [ "$CI" != "1" ]; then
+    _install_completion_script "$SHELL" || true
+    CURRENT_SHELL=${0#-}
+    [ "$CURRENT_SHELL" != "$SHELL" ] && _install_completion_script "$CURRENT_SHELL" || true
+fi
 
 # Cleanup: Remove the temporary directory
 echo "Cleaning up..."

--- a/src/pkg/cli/client/byoc/aws/byoc_test.go
+++ b/src/pkg/cli/client/byoc/aws/byoc_test.go
@@ -94,18 +94,6 @@ func TestDomainMultipleProjectSupport(t *testing.T) {
 	}
 }
 
-type FakeLoader struct {
-	ProjectName string
-}
-
-func (f FakeLoader) LoadProject(ctx context.Context) (*composeTypes.Project, error) {
-	return &composeTypes.Project{Name: f.ProjectName}, nil
-}
-
-func (f FakeLoader) LoadProjectName(ctx context.Context) (string, bool, error) {
-	return f.ProjectName, false, nil
-}
-
 //go:embed testdata/*.json
 var testDir embed.FS
 

--- a/src/pkg/cli/client/byoc/gcp/byoc.go
+++ b/src/pkg/cli/client/byoc/gcp/byoc.go
@@ -282,7 +282,6 @@ func (b *ByocGcp) SetUpCD(ctx context.Context, force bool) error {
 		}
 	}
 
-	// 5. Setup Cloud Run Job
 	term.Debugf("Using CD image: %q", b.CDImage)
 
 	b.SetupDone = true
@@ -847,10 +846,12 @@ func (b *ByocGcp) GetProjectUpdate(ctx context.Context, projectName string) (*de
 	pbBytes, err := b.driver.GetBucketObjectWithServiceAccount(ctx, bucketName, path, uploadSA)
 	if err != nil {
 		term.Debugf("Failed to get project bucket object from bucket %q at path %q with service account %q: %v", bucketName, path, uploadSA, err)
-		if errors.Is(err, gcp.ErrObjectNotExist) {
-			return nil, client.ErrNotExist // no services yet
+		// Handle the case where the object does not exist, or where we do not have permission to view the object, ie.
+		// "Permission 'iam.serviceAccounts.getAccessToken' denied on resource (or it may not exist)."  #2051
+		if errors.Is(err, gcp.ErrObjectNotExist) || strings.Contains(err.Error(), "(or it may not exist)") {
+			return nil, client.ErrNotExist // first deployment, no services yet
 		}
-		return nil, err
+		return nil, annotateGcpError(err)
 	}
 
 	var projUpdate defangv1.ProjectUpdate

--- a/src/pkg/cli/client/byoc/gcp/byoc_test.go
+++ b/src/pkg/cli/client/byoc/gcp/byoc_test.go
@@ -17,6 +17,7 @@ import (
 	defangv1 "github.com/DefangLabs/defang/src/protos/io/defang/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/api/googleapi"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -364,6 +365,21 @@ func TestGetServices(t *testing.T) {
 		}
 		res, err := b.GetServices(t.Context(), &defangv1.GetServicesRequest{
 			Project: "project2",
+		})
+		require.NoError(t, err)
+		assert.Empty(t, res.Services)
+	})
+
+	t.Run("first deployment 403 = no services", func(t *testing.T) {
+		b.driver = &mockGcpDriver{
+			bucketName: "bucket-a",
+			getBucketObjectWithServiceAccountError: &googleapi.Error{
+				Code:    403,
+				Message: "Permission 'iam.serviceAccounts.getAccessToken' denied on resource (or it may not exist).",
+			},
+		}
+		res, err := b.GetServices(t.Context(), &defangv1.GetServicesRequest{
+			Project: "project1",
 		})
 		require.NoError(t, err)
 		assert.Empty(t, res.Services)

--- a/src/pkg/cli/client/byoc/gcp/errors.go
+++ b/src/pkg/cli/client/byoc/gcp/errors.go
@@ -3,7 +3,6 @@ package gcp
 import (
 	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/DefangLabs/defang/src/pkg/http"
 	"google.golang.org/api/googleapi"
@@ -40,21 +39,4 @@ func annotateGcpError(err error) error {
 		return briefErr
 	}
 	return err
-}
-
-// Used to get nested values from the detail of a googleapi.Error
-func GetGoogleAPIErrorDetail(detail any, path string) string {
-	if path == "" {
-		value, ok := detail.(string)
-		if ok {
-			return value
-		}
-		return ""
-	}
-	dm, ok := detail.(map[string]any)
-	if !ok {
-		return ""
-	}
-	key, rest, _ := strings.Cut(path, ".")
-	return GetGoogleAPIErrorDetail(dm[key], rest)
 }

--- a/src/pkg/cli/client/byoc/gcp/errors_test.go
+++ b/src/pkg/cli/client/byoc/gcp/errors_test.go
@@ -65,7 +65,7 @@ func Test_BadGCPprojectnameErrorWrap(t *testing.T) {
 	wrappedErr := annotateGcpError(gcpErr)
 	assert.Equal(t, `double check the GCP project ID and make sure your Application Default Credentials have permission to access the project: `+gcpErr.Message, wrappedErr.Error())
 
-	// Test the error is wrapper correctly
+	// Test the error is wrapped correctly
 	var unwrappedErr *googleapi.Error
 	assert.True(t, errors.As(wrappedErr, &unwrappedErr))
 	assert.Equal(t, gcpErr, unwrappedErr)


### PR DESCRIPTION
## Description

Handle permission error that happens when we try to load the ProjectUpdate bucket object the first time we do "up". This happens before the `SetupCD` is run, so before bootstrapping.

## Linked Issues

Fixes #2051 
 

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error handling for Google Cloud Storage bucket operations to correctly identify missing objects during access-denied scenarios
  * Updated install script to skip shell completion setup in continuous integration environments

* **Tests**
  * Added test coverage for HTTP 403 error scenarios in GCP service deployment
  * Removed unused test helper utilities

* **Chores**
  * Removed unused helper function
  * Fixed typo in test documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->