### PR TITLE
record deployment even if putStack fails

### DIFF
--- a/src/pkg/cli/common.go
+++ b/src/pkg/cli/common.go
@@ -67,8 +67,7 @@ func putDeploymentAndStack(ctx context.Context, provider client.Provider, fabric
 			return err
 		}
 
-		// TODO: should we always update the stack and upload the stack file?
-		if err := fabric.PutStack(ctx, &defangv1.PutStackRequest{
+		err = fabric.PutStack(ctx, &defangv1.PutStackRequest{
 			Stack: &defangv1.Stack{
 				Name:              provider.GetStackName(),
 				Project:           req.ProjectName,
@@ -79,8 +78,9 @@ func putDeploymentAndStack(ctx context.Context, provider client.Provider, fabric
 				LastDeployedAt:    now,
 				StackFile:         []byte(stackFile),
 			},
-		}); err != nil {
-			return err
+		})
+		if err != nil {
+			term.Debugf("Failed to put stack for deployment: %v", err)
 		}
 	}
 

--- a/src/pkg/cli/common.go
+++ b/src/pkg/cli/common.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"os"
 
+	"connectrpc.com/connect"
 	"github.com/DefangLabs/defang/src/pkg/cli/client"
 	"github.com/DefangLabs/defang/src/pkg/stacks"
 	"github.com/DefangLabs/defang/src/pkg/term"
@@ -80,7 +81,11 @@ func putDeploymentAndStack(ctx context.Context, provider client.Provider, fabric
 			},
 		})
 		if err != nil {
-			term.Debugf("Failed to put stack for deployment: %v", err)
+			if connect.CodeOf(err) == connect.CodeAlreadyExists {
+				term.Debugf("Stack %q already exists; proceeding to track deployment: %v", provider.GetStackName(), err)
+			} else {
+				return err
+			}
 		}
 	}
 

--- a/src/pkg/cli/common_test.go
+++ b/src/pkg/cli/common_test.go
@@ -1,0 +1,61 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/DefangLabs/defang/src/pkg/cli/client"
+	defangv1 "github.com/DefangLabs/defang/src/protos/io/defang/v1"
+)
+
+type mockFabricForCommon struct {
+	client.MockFabricClient
+	putStackErr         error
+	putDeploymentCalled bool
+}
+
+func (m *mockFabricForCommon) PutStack(_ context.Context, _ *defangv1.PutStackRequest) error {
+	return m.putStackErr
+}
+
+func (m *mockFabricForCommon) PutDeployment(_ context.Context, _ *defangv1.PutDeploymentRequest) error {
+	m.putDeploymentCalled = true
+	return nil
+}
+
+func TestPutDeploymentAndStack_ContinuesOnPutStackError(t *testing.T) {
+	fabric := &mockFabricForCommon{
+		putStackErr: errors.New("PutStack failed"),
+	}
+	provider := client.MockProvider{}
+
+	err := putDeploymentAndStack(context.Background(), provider, fabric, nil, putDeploymentParams{
+		Action:      defangv1.DeploymentAction_DEPLOYMENT_ACTION_UP,
+		ProjectName: "test-project",
+	})
+
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if !fabric.putDeploymentCalled {
+		t.Error("PutDeployment should be called even when PutStack fails")
+	}
+}
+
+func TestPutDeploymentAndStack_CallsDeploymentOnSuccess(t *testing.T) {
+	fabric := &mockFabricForCommon{}
+	provider := client.MockProvider{}
+
+	err := putDeploymentAndStack(context.Background(), provider, fabric, nil, putDeploymentParams{
+		Action:      defangv1.DeploymentAction_DEPLOYMENT_ACTION_UP,
+		ProjectName: "test-project",
+	})
+
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if !fabric.putDeploymentCalled {
+		t.Error("PutDeployment should be called when PutStack succeeds")
+	}
+}

--- a/src/pkg/cli/common_test.go
+++ b/src/pkg/cli/common_test.go
@@ -5,12 +5,13 @@ import (
 	"errors"
 	"testing"
 
+	"connectrpc.com/connect"
 	"github.com/DefangLabs/defang/src/pkg/cli/client"
 	defangv1 "github.com/DefangLabs/defang/src/protos/io/defang/v1"
 )
 
 type mockFabricForCommon struct {
-	client.MockFabricClient
+	client.FabricClient
 	putStackErr         error
 	putDeploymentCalled bool
 }
@@ -24,38 +25,57 @@ func (m *mockFabricForCommon) PutDeployment(_ context.Context, _ *defangv1.PutDe
 	return nil
 }
 
-func TestPutDeploymentAndStack_ContinuesOnPutStackError(t *testing.T) {
-	fabric := &mockFabricForCommon{
-		putStackErr: errors.New("PutStack failed"),
+func TestPutDeploymentAndStack(t *testing.T) {
+	tests := []struct {
+		name              string
+		putStackErr       error
+		wantErr           bool
+		wantPutDeployment bool
+	}{
+		{
+			name:              "PutStack AlreadyExists, but PutDeployment is still called",
+			putStackErr:       connect.NewError(connect.CodeAlreadyExists, errors.New("stack already exists")),
+			wantErr:           false,
+			wantPutDeployment: true,
+		},
+		{
+			name:              "PutStack failed, PutDeployment errors",
+			putStackErr:       errors.New("PutStack failed"),
+			wantErr:           true,
+			wantPutDeployment: false,
+		},
+		{
+			name:              "PutStack succeeds, and PutDeployment is called",
+			putStackErr:       nil,
+			wantErr:           false,
+			wantPutDeployment: true,
+		},
 	}
-	provider := client.MockProvider{}
 
-	err := putDeploymentAndStack(context.Background(), provider, fabric, nil, putDeploymentParams{
-		Action:      defangv1.DeploymentAction_DEPLOYMENT_ACTION_UP,
-		ProjectName: "test-project",
-	})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fabric := &mockFabricForCommon{
+				putStackErr: tt.putStackErr,
+			}
+			provider := client.MockProvider{}
 
-	if err != nil {
-		t.Fatalf("expected no error, got: %v", err)
-	}
-	if !fabric.putDeploymentCalled {
-		t.Error("PutDeployment should be called even when PutStack fails")
-	}
-}
+			err := putDeploymentAndStack(context.Background(), provider, fabric, nil, putDeploymentParams{
+				Action:      defangv1.DeploymentAction_DEPLOYMENT_ACTION_UP,
+				ProjectName: "test-project",
+			})
 
-func TestPutDeploymentAndStack_CallsDeploymentOnSuccess(t *testing.T) {
-	fabric := &mockFabricForCommon{}
-	provider := client.MockProvider{}
-
-	err := putDeploymentAndStack(context.Background(), provider, fabric, nil, putDeploymentParams{
-		Action:      defangv1.DeploymentAction_DEPLOYMENT_ACTION_UP,
-		ProjectName: "test-project",
-	})
-
-	if err != nil {
-		t.Fatalf("expected no error, got: %v", err)
-	}
-	if !fabric.putDeploymentCalled {
-		t.Error("PutDeployment should be called when PutStack succeeds")
+			if err != nil {
+				if !tt.wantErr {
+					t.Fatalf("expected no error, got: %v", err)
+				}
+			} else {
+				if tt.wantErr {
+					t.Fatalf("expected error, got nil")
+				}
+			}
+			if fabric.putDeploymentCalled != tt.wantPutDeployment {
+				t.Errorf("expected PutDeploymentCalled to be %v, got %v", tt.wantPutDeployment, fabric.putDeploymentCalled)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Description

<!-- Concise description of what this PR is tackling. -->

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [ ] I have performed a self-review of my code
- [x] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Deployment now continues when a stack creation/update yields a "already exists" error; a diagnostic message is logged and subsequent deployment steps still run.
* **Tests**
  * Added unit tests to verify deployment proceeds when stack updates report existing stacks, and to ensure failures block deployment when appropriate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->