### PR TITLE
fix(aws): use survey for AWS login code input

### DIFF
--- a/src/pkg/clouds/aws/login.go
+++ b/src/pkg/clouds/aws/login.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/AlecAivazis/survey/v2"
 	"github.com/DefangLabs/defang/src/pkg/auth"
 	"github.com/DefangLabs/defang/src/pkg/term"
 	"github.com/DefangLabs/defang/src/pkg/tokenstore"
@@ -30,6 +31,7 @@ import (
 	awssts "github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/google/uuid"
+	"github.com/pkg/browser"
 )
 
 const (
@@ -368,18 +370,32 @@ func (a *Aws) CrossDeviceLogin(ctx context.Context) (*awsTokenCache, error) {
 	term.Println("Please visit the following URL to log in to AWS: (Right click the URL or press ENTER to open browser)")
 	term.Printf("  %s\n", authURL)
 	term.Print("Enter the authorization code displayed in your browser: ")
-	ctx, inputCh, done := term.OpenBrowserWithInputOnEnter(ctx, authURL)
-	defer done()
+	browserOpened := false
+	var code string
+	for code == "" {
+		err = survey.AskOne(
+			&survey.Input{
+				Message: "Code",
+			},
+			&code,
+			survey.WithStdio(term.DefaultTerm.Stdio()),
+		)
+		if err != nil {
+			return nil, fmt.Errorf("reading authorization code: %w", err)
+		}
 
-	var input string
-	select {
-	case input = <-inputCh:
-		input = strings.TrimSpace(input)
-	case <-ctx.Done():
-		return nil, ctx.Err()
+		code = strings.TrimSpace(code)
+
+		if code == "" && !browserOpened {
+			err := browser.OpenURL(authURL)
+			if err != nil {
+				term.Warn("failed to open browser automatically, please open the URL above manually")
+			}
+			browserOpened = true
+		}
 	}
 
-	authCode, gotState, err := parseVerificationCode(input)
+	authCode, gotState, err := parseVerificationCode(code)
 	if err != nil {
 		return nil, err
 	}

--- a/src/pkg/clouds/aws/login.go
+++ b/src/pkg/clouds/aws/login.go
@@ -355,6 +355,29 @@ func (a *Aws) InteractiveLogin(ctx context.Context) (*awsTokenCache, error) {
 	return RetrieveToken(ctx, tokenURL, clientIDSameDevice, code, pkce.Verifier, redirectURI)
 }
 
+// collectAuthCode prompts the user for an authorization code, opening the browser
+// on the first empty submission. askFn is called repeatedly until a non-empty
+// trimmed value is returned; openBrowser is called at most once.
+func collectAuthCode(askFn func() (string, error), openBrowser func(string) error, authURL string) (string, error) {
+	browserOpened := false
+	for {
+		raw, err := askFn()
+		if err != nil {
+			return "", fmt.Errorf("reading authorization code: %w", err)
+		}
+		code := strings.TrimSpace(raw)
+		if code != "" {
+			return code, nil
+		}
+		if !browserOpened {
+			if err := openBrowser(authURL); err != nil {
+				term.Warn("failed to open browser automatically, please open the URL above manually")
+			}
+			browserOpened = true
+		}
+	}
+}
+
 // CrossDeviceLogin runs the cross-device flow for remote/SSH sessions where the
 // browser runs on a different machine. It prints the auth URL and prompts the user
 // to paste the base64-encoded verification code displayed in their browser.
@@ -370,29 +393,18 @@ func (a *Aws) CrossDeviceLogin(ctx context.Context) (*awsTokenCache, error) {
 	term.Println("Please visit the following URL to log in to AWS: (Right click the URL or press ENTER to open browser)")
 	term.Printf("  %s\n", authURL)
 	term.Print("Enter the authorization code displayed in your browser: ")
-	browserOpened := false
-	var code string
-	for code == "" {
-		err = survey.AskOne(
-			&survey.Input{
-				Message: "Code",
-			},
+	askFn := func() (string, error) {
+		var code string
+		err := survey.AskOne(
+			&survey.Input{Message: "Code"},
 			&code,
 			survey.WithStdio(term.DefaultTerm.Stdio()),
 		)
-		if err != nil {
-			return nil, fmt.Errorf("reading authorization code: %w", err)
-		}
-
-		code = strings.TrimSpace(code)
-
-		if code == "" && !browserOpened {
-			err := browser.OpenURL(authURL)
-			if err != nil {
-				term.Warn("failed to open browser automatically, please open the URL above manually")
-			}
-			browserOpened = true
-		}
+		return code, err
+	}
+	code, err := collectAuthCode(askFn, browser.OpenURL, authURL)
+	if err != nil {
+		return nil, err
 	}
 
 	authCode, gotState, err := parseVerificationCode(code)

--- a/src/pkg/clouds/aws/login_test.go
+++ b/src/pkg/clouds/aws/login_test.go
@@ -432,6 +432,7 @@ func TestCollectAuthCode(t *testing.T) {
 
 	t.Run("browser open error does not abort the loop", func(t *testing.T) {
 		calls := 0
+		browserCalls := 0
 		code, err := collectAuthCode(
 			func() (string, error) {
 				calls++
@@ -440,7 +441,10 @@ func TestCollectAuthCode(t *testing.T) {
 				}
 				return "code", nil
 			},
-			func(string) error { return errors.New("no browser") },
+			func(string) error {
+				browserCalls++
+				return errors.New("no browser")
+			},
 			"https://example.com",
 		)
 		if err != nil {
@@ -448,6 +452,9 @@ func TestCollectAuthCode(t *testing.T) {
 		}
 		if code != "code" {
 			t.Errorf("code = %q, want %q", code, "code")
+		}
+		if browserCalls != 1 {
+			t.Errorf("browser opened %d times, want 1", browserCalls)
 		}
 	})
 

--- a/src/pkg/clouds/aws/login_test.go
+++ b/src/pkg/clouds/aws/login_test.go
@@ -366,6 +366,106 @@ func TestRefreshTokenSuccess(t *testing.T) {
 	}
 }
 
+func TestCollectAuthCode(t *testing.T) {
+	noopBrowser := func(string) error { return nil }
+
+	t.Run("non-empty first response returns immediately without opening browser", func(t *testing.T) {
+		browserOpened := false
+		code, err := collectAuthCode(
+			func() (string, error) { return "mycode", nil },
+			func(string) error { browserOpened = true; return nil },
+			"https://example.com",
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if code != "mycode" {
+			t.Errorf("code = %q, want %q", code, "mycode")
+		}
+		if browserOpened {
+			t.Error("browser should not have been opened")
+		}
+	})
+
+	t.Run("whitespace-only response is treated as empty", func(t *testing.T) {
+		calls := 0
+		code, err := collectAuthCode(
+			func() (string, error) {
+				calls++
+				if calls == 1 {
+					return "   ", nil
+				}
+				return "realcode", nil
+			},
+			noopBrowser,
+			"https://example.com",
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if code != "realcode" {
+			t.Errorf("code = %q, want %q", code, "realcode")
+		}
+	})
+
+	t.Run("empty response opens browser once then retries", func(t *testing.T) {
+		browserCalls := 0
+		calls := 0
+		_, err := collectAuthCode(
+			func() (string, error) {
+				calls++
+				if calls < 3 {
+					return "", nil
+				}
+				return "code", nil
+			},
+			func(string) error { browserCalls++; return nil },
+			"https://example.com",
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if browserCalls != 1 {
+			t.Errorf("browser opened %d times, want 1", browserCalls)
+		}
+	})
+
+	t.Run("browser open error does not abort the loop", func(t *testing.T) {
+		calls := 0
+		code, err := collectAuthCode(
+			func() (string, error) {
+				calls++
+				if calls == 1 {
+					return "", nil
+				}
+				return "code", nil
+			},
+			func(string) error { return errors.New("no browser") },
+			"https://example.com",
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if code != "code" {
+			t.Errorf("code = %q, want %q", code, "code")
+		}
+	})
+
+	t.Run("askFn error is returned", func(t *testing.T) {
+		_, err := collectAuthCode(
+			func() (string, error) { return "", errors.New("interrupted") },
+			noopBrowser,
+			"https://example.com",
+		)
+		if err == nil {
+			t.Fatal("expected error from askFn")
+		}
+		if !strings.Contains(err.Error(), "interrupted") {
+			t.Errorf("error = %q, want it to contain %q", err.Error(), "interrupted")
+		}
+	})
+}
+
 func TestSameRole(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/src/pkg/term/browser.go
+++ b/src/pkg/term/browser.go
@@ -1,7 +1,6 @@
 package term
 
 import (
-	"bytes"
 	"context"
 	"io"
 
@@ -45,50 +44,4 @@ func OpenBrowserOnEnter(ctx context.Context, url string) (context.Context, func(
 		}
 	}()
 	return ctx, cancel
-}
-
-func OpenBrowserWithInputOnEnter(ctx context.Context, url string) (context.Context, <-chan string, func()) {
-	ctx, cancel := context.WithCancel(ctx)
-	input := NewNonBlockingStdin()
-	inputChan := make(chan string, 1) // Buffered channel to avoid blocking goroutine
-
-	// Handles context cancellation to ensure input is closed and goroutine exits when context is cancelled.
-	// In linux Ctrl-C is handled by the signal handler, and input will not get a byte
-	go func() {
-		<-ctx.Done()
-		input.Close()
-	}()
-
-	go func() {
-		var b [1]byte
-		var buf bytes.Buffer
-	inputloop:
-		for {
-			if _, err := input.Read(b[:]); err != nil {
-				break
-			}
-			switch b[0] {
-			case 3: // Ctrl-C
-				cancel()
-				break inputloop
-			case 10, 13: // Enter or Return
-				// If the user has already entered some input, we assume browser is already opened
-				// and we don't want to open the browser again.
-				if buf.Len() > 0 {
-					break inputloop
-				}
-				err := browser.OpenURL(url)
-				if err != nil {
-					Errorf("failed to open browser: %v", err)
-				}
-			default:
-				buf.WriteByte(b[0]) //nolint:gosec // G602 false positive: b is [1]byte, index 0 is always valid
-			}
-		}
-		if buf.Len() > 0 {
-			inputChan <- buf.String()
-		}
-		close(inputChan)
-	}()
-	return ctx, inputChan, cancel
 }


### PR DESCRIPTION
## Summary

- Replaces the custom `OpenBrowserWithInputOnEnter` approach with `survey.AskOne` for the AWS cross-device login authorization code prompt
- Opens the browser automatically when the user submits an empty response (press Enter), matching the previous UX of pressing Enter to open browser
- Uses `github.com/pkg/browser` directly for browser opening instead of the previous combined input+browser helper

Fixes https://github.com/DefangLabs/defang/issues/2068

## Test plan

- [ ] Run `defang login --provider aws` and verify the authorization code prompt appears correctly
- [ ] Press Enter on empty input to confirm browser opens automatically
- [ ] Paste authorization code and confirm login completes successfully
- [ ] Verify non-interactive mode behavior is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved AWS cross-device authentication prompt: repeatedly asks for a non-empty, trimmed authorization code, attempts to open the browser once after the first empty submission, and logs browser-open failures without blocking further retries.
* **Tests**
  * Added tests covering retry behavior, single browser-open attempt, handling of whitespace-only input, propagation of prompt errors, and resilience to browser-open failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->