### PR TITLE
Retry when creating service account in case IAM is being enabled

### DIFF
--- a/src/pkg/cli/client/byoc/gcp/byoc.go
+++ b/src/pkg/cli/client/byoc/gcp/byoc.go
@@ -848,7 +848,11 @@ func (b *ByocGcp) GetProjectUpdate(ctx context.Context, projectName string) (*de
 		term.Debugf("Failed to get project bucket object from bucket %q at path %q with service account %q: %v", bucketName, path, uploadSA, err)
 		// Handle the case where the object does not exist, or where we do not have permission to view the object, ie.
 		// "Permission 'iam.serviceAccounts.getAccessToken' denied on resource (or it may not exist)."  #2051
-		if errors.Is(err, gcp.ErrObjectNotExist) || strings.Contains(err.Error(), "(or it may not exist)") {
+		// Also handle the case where the upload service account itself does not exist yet (first deployment
+		// before SetUpCD has run), which surfaces as an impersonate 404 "Gaia id not found for email ...".
+		if errors.Is(err, gcp.ErrObjectNotExist) ||
+			strings.Contains(err.Error(), "(or it may not exist)") ||
+			strings.Contains(err.Error(), "Gaia id not found for email") {
 			return nil, client.ErrNotExist // first deployment, no services yet
 		}
 		return nil, annotateGcpError(err)

--- a/src/pkg/cli/client/byoc/gcp/byoc_test.go
+++ b/src/pkg/cli/client/byoc/gcp/byoc_test.go
@@ -384,4 +384,22 @@ func TestGetServices(t *testing.T) {
 		require.NoError(t, err)
 		assert.Empty(t, res.Services)
 	})
+
+	t.Run("upload service account not yet created = no services", func(t *testing.T) {
+		b.driver = &mockGcpDriver{
+			bucketName: "bucket-a",
+			getBucketObjectWithServiceAccountError: errors.New(`failed to get bucket object ("projects/project1/stack1/project.pb") reader: Get "https://storage.googleapis.com/defang-cd-xyz/projects%2Fproject1%2Fstack1%2Fproject.pb": impersonate: status code 404: {
+  "error": {
+    "code": 404,
+    "message": "Not found; Gaia id not found for email defang-upload@example.iam.gserviceaccount.com",
+    "status": "NOT_FOUND"
+  }
+}`),
+		}
+		res, err := b.GetServices(t.Context(), &defangv1.GetServicesRequest{
+			Project: "project1",
+		})
+		require.NoError(t, err)
+		assert.Empty(t, res.Services)
+	})
 }

--- a/src/pkg/clouds/gcp/iam.go
+++ b/src/pkg/clouds/gcp/iam.go
@@ -108,7 +108,7 @@ func (gcp Gcp) EnsureServiceAccountExists(ctx context.Context, serviceAccountId,
 		if i < maxAttempts-1 {
 			term.Debugf("IAM API not yet usable, will retry in %v: %v\n", retryInterval, err)
 			if err := pkg.SleepWithContext(ctx, retryInterval); err != nil {
-				return "", err
+				return "", fmt.Errorf("waiting for IAM API propagation before checking service account %q: %w", serviceAccountId, err)
 			}
 		}
 	}

--- a/src/pkg/clouds/gcp/iam.go
+++ b/src/pkg/clouds/gcp/iam.go
@@ -98,7 +98,20 @@ func (gcp Gcp) EnsureServiceAccountExists(ctx context.Context, serviceAccountId,
 	// Check if the service account already exists, if so, update it if necessary
 	serviceAccountEmail := gcp.GetServiceAccountEmail(serviceAccountId)
 	serviceAccountPath := fmt.Sprintf("projects/%s/serviceAccounts/%s", gcp.ProjectId, serviceAccountEmail)
-	account, err := client.GetServiceAccount(ctx, &iamadmpb.GetServiceAccountRequest{Name: serviceAccountPath})
+	// The IAM API may have only just been enabled; retry while the enable is still propagating.
+	var account *iamadmpb.ServiceAccount
+	for i := range maxAttempts {
+		account, err = client.GetServiceAccount(ctx, &iamadmpb.GetServiceAccountRequest{Name: serviceAccountPath})
+		if err == nil || !IsAccessNotEnabled(err) {
+			break
+		}
+		if i < maxAttempts-1 {
+			term.Debugf("IAM API not yet usable, will retry in %v: %v\n", retryInterval, err)
+			if err := pkg.SleepWithContext(ctx, retryInterval); err != nil {
+				return "", err
+			}
+		}
+	}
 	if err == nil {
 		if account.GetDisplayName() == displayName &&
 			account.GetDescription() == description {


### PR DESCRIPTION
## Description
Also consider missing service account for accessing project update object the same as object missing

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [X] I have performed a self-review of my code
- [X] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Treats certain 404 impersonation errors as "no services yet" during initial GCP deployments.
  * Adds retry/wait logic for IAM propagation when checking service accounts to reduce transient failures.

* **Tests**
  * New tests covering impersonation-404 and service-account initialization scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->