### PR TITLE
Add login annotation to stack commands

### DIFF
--- a/src/cmd/cli/command/cd.go
+++ b/src/cmd/cli/command/cd.go
@@ -23,9 +23,7 @@ func cdCommand(cmd *cobra.Command, command client.CdCommand, args []string, fabr
 	ctx := cmd.Context()
 	allowUpgrade, _ := cmd.Flags().GetBool("allow-upgrade")
 
-	session, err := newCommandSessionWithOpts(cmd, commandSessionOpts{
-		CheckAccountInfo: true,
-	})
+	session, err := newCommandSession(cmd)
 	if err != nil {
 		return err
 	}
@@ -102,9 +100,7 @@ var cdTearDownCmd = &cobra.Command{
 		ctx := cmd.Context()
 		force, _ := cmd.Flags().GetBool("force")
 
-		session, err := newCommandSessionWithOpts(cmd, commandSessionOpts{
-			CheckAccountInfo: true,
-		})
+		session, err := newCommandSession(cmd)
 		if err != nil {
 			return err
 		}
@@ -123,12 +119,11 @@ var cdListCmd = &cobra.Command{
 	Aliases: []string{"list"},
 	Short:   "List all the projects and stacks in the CD cluster",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx := cmd.Context()
 		remote, _ := cmd.Flags().GetBool("remote")
 		all, _ := cmd.Flags().GetBool("all")
 
-		session, err := newCommandSessionWithOpts(cmd, commandSessionOpts{
-			CheckAccountInfo: true,
-		})
+		session, err := newCommandSession(cmd)
 		if err != nil {
 			return err
 		}
@@ -138,15 +133,15 @@ var cdListCmd = &cobra.Command{
 				return errors.New("--all cannot be used with --remote")
 			}
 
-			err = canIUseProvider(cmd.Context(), session.Provider, "", 0, true) // safe to use latest CD image
+			err = canIUseProvider(ctx, session.Provider, "", 0, true) // safe to use latest CD image
 			if err != nil {
 				return err
 			}
 
 			// FIXME: this needs auth because it spawns the CD task
-			return cli.CdCommandAndTail(cmd.Context(), session.Provider, "", global.Verbose, client.CdCommandList, global.Client)
+			return cli.CdCommandAndTail(ctx, session.Provider, "", global.Verbose, client.CdCommandList, global.Client)
 		} else {
-			return cli.CdListFromStorage(cmd.Context(), session.Provider, all || global.Verbose)
+			return cli.CdListFromStorage(ctx, session.Provider, all || global.Verbose)
 		}
 	},
 }
@@ -158,6 +153,7 @@ var cdPreviewCmd = &cobra.Command{
 	Short:       "Preview the changes that will be made by the CD task",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := cmd.Context()
+
 		session, err := newCommandSession(cmd)
 		if err != nil {
 			return err
@@ -190,6 +186,7 @@ var cdInstallCmd = &cobra.Command{
 	Hidden:      true, // users shouldn't have to run this manually, because it's done on deploy
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := cmd.Context()
+
 		session, err := newCommandSession(cmd)
 		if err != nil {
 			return err

--- a/src/cmd/cli/command/commands.go
+++ b/src/cmd/cli/command/commands.go
@@ -25,7 +25,6 @@ import (
 	"github.com/DefangLabs/defang/src/pkg/migrate"
 	"github.com/DefangLabs/defang/src/pkg/modes"
 	"github.com/DefangLabs/defang/src/pkg/scope"
-	"github.com/DefangLabs/defang/src/pkg/session"
 	"github.com/DefangLabs/defang/src/pkg/stacks"
 	"github.com/DefangLabs/defang/src/pkg/term"
 	"github.com/DefangLabs/defang/src/pkg/track"
@@ -462,13 +461,9 @@ var RootCmd = &cobra.Command{
 	},
 }
 
-func configureLoaderForCommand(cmd *cobra.Command) *compose.Loader {
-	loaderFlags := newSessionLoaderOptionsForCommand(cmd)
-	return configureLoader(loaderFlags.LoaderOptions)
-}
-
-func configureLoader(loaderOptions session.LoaderOptions) *compose.Loader {
-	return compose.NewLoader(compose.WithProjectName(loaderOptions.ProjectName), compose.WithPath(loaderOptions.ComposeFilePaths...))
+func newLoaderForCommand(cmd *cobra.Command) *compose.Loader {
+	loaderOptions := loaderOptionsForCommand(cmd)
+	return compose.NewLoaderFromOptions(loaderOptions)
 }
 
 func isCompletionCommand(cmd *cobra.Command) bool {

--- a/src/cmd/cli/command/compose.go
+++ b/src/cmd/cli/command/compose.go
@@ -522,7 +522,7 @@ func makeComposeConfigCmd() *cobra.Command {
 			if err != nil {
 				term.Warn("unable to load stack:", err, "- some information may not be up-to-date")
 				sessionx = &session.Session{
-					Loader:   configureLoaderForCommand(cmd),
+					Loader:   newLoaderForCommand(cmd),
 					Provider: client.NewPlaygroundProvider(global.Client, stacks.DefaultBeta),
 					Stack:    &stacks.Parameters{Name: stacks.DefaultBeta, Provider: client.ProviderDefang},
 				}

--- a/src/cmd/cli/command/deployments.go
+++ b/src/cmd/cli/command/deployments.go
@@ -25,7 +25,7 @@ func makeDeploymentsCmd(use string) *cobra.Command {
 				listType = defangv1.DeploymentType_DEPLOYMENT_TYPE_ACTIVE
 			}
 
-			loader := configureLoaderForCommand(cmd)
+			loader := newLoaderForCommand(cmd)
 			projectName, _, err := loader.LoadProjectName(cmd.Context())
 			if err != nil {
 				if listType == defangv1.DeploymentType_DEPLOYMENT_TYPE_HISTORY {

--- a/src/cmd/cli/command/estimate.go
+++ b/src/cmd/cli/command/estimate.go
@@ -23,7 +23,7 @@ func makeEstimateCmd() *cobra.Command {
 			ctx := cmd.Context()
 			region, _ := cmd.Flags().GetString("region")
 
-			loader := configureLoaderForCommand(cmd)
+			loader := newLoaderForCommand(cmd)
 			project, err := loader.LoadProject(ctx)
 			if err != nil {
 				return err

--- a/src/cmd/cli/command/session.go
+++ b/src/cmd/cli/command/session.go
@@ -34,9 +34,17 @@ func newCommandSession(cmd *cobra.Command) (*session.Session, error) {
 func newCommandSessionWithOpts(cmd *cobra.Command, opts commandSessionOpts) (*session.Session, error) {
 	ctx := cmd.Context()
 
-	options := newSessionLoaderOptionsForCommand(cmd)
-	options.AllowStackCreation = opts.AllowStackCreation
-	sm, err := newStackManagerForLoader(ctx, configureLoader(options.LoaderOptions))
+	options := session.SessionLoaderOptions{
+		LoaderOptions: loaderOptionsForCommand(cmd),
+		GetStackOpts: stacks.GetStackOpts{
+			Interactive: !global.NonInteractive,
+			Default:     global.Stack,
+			SelectStackOptions: stacks.SelectStackOptions{
+				AllowStackCreation: opts.AllowStackCreation,
+			},
+		},
+	}
+	sm, err := newStackManagerForLoader(ctx, compose.NewLoaderFromOptions(options.LoaderOptions))
 	if err != nil {
 		if !errors.Is(err, types.ErrComposeFileNotFound) {
 			return nil, err
@@ -60,7 +68,7 @@ func newCommandSessionWithOpts(cmd *cobra.Command, opts commandSessionOpts) (*se
 	return session, nil
 }
 
-func newSessionLoaderOptionsForCommand(cmd *cobra.Command) session.SessionLoaderOptions {
+func loaderOptionsForCommand(cmd *cobra.Command) compose.LoaderOptions {
 	configPaths, _ := cmd.Flags().GetStringArray("file")
 	projectName, _ := cmd.Flags().GetString("project-name")
 
@@ -81,15 +89,9 @@ func newSessionLoaderOptionsForCommand(cmd *cobra.Command) session.SessionLoader
 			doubleCheckProjectName(projectName)
 		}
 	}
-	return session.SessionLoaderOptions{
-		LoaderOptions: session.LoaderOptions{
-			ComposeFilePaths: configPaths,
-			ProjectName:      projectName,
-		},
-		GetStackOpts: stacks.GetStackOpts{
-			Interactive: !global.NonInteractive,
-			Default:     global.Stack,
-		},
+	return compose.LoaderOptions{
+		ConfigPaths: configPaths,
+		ProjectName: projectName,
 	}
 }
 

--- a/src/cmd/cli/command/stack.go
+++ b/src/cmd/cli/command/stack.go
@@ -32,10 +32,11 @@ func makeStackCmd() *cobra.Command {
 
 func makeStackNewCmd() *cobra.Command {
 	var stackNewCmd = &cobra.Command{
-		Use:     "new [STACK_NAME]",
-		Aliases: []string{"init", "create"},
-		Args:    cobra.MaximumNArgs(1),
-		Short:   "Create a new Defang deployment stack",
+		Use:         "new [STACK_NAME]",
+		Aliases:     []string{"init", "create"},
+		Annotations: authNeededAlways, // stack tracked remotely
+		Args:        cobra.MaximumNArgs(1),
+		Short:       "Create a new Defang deployment stack",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 
@@ -111,10 +112,11 @@ func makeStackNewCmd() *cobra.Command {
 
 func makeStackListCmd() *cobra.Command {
 	stackListCmd := &cobra.Command{
-		Use:     "list",
-		Aliases: []string{"ls"},
-		Args:    cobra.NoArgs,
-		Short:   "List existing Defang deployment stacks",
+		Use:         "list",
+		Aliases:     []string{"ls"},
+		Annotations: authNeededAlways, // stack tracked remotely
+		Args:        cobra.NoArgs,
+		Short:       "List existing Defang deployment stacks",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			loader := configureLoaderForCommand(cmd)
@@ -149,10 +151,11 @@ func makeStackListCmd() *cobra.Command {
 
 func makeStackDefaultCmd() *cobra.Command {
 	var stackDefaultCmd = &cobra.Command{
-		Use:     "default STACK_NAME",
-		Aliases: []string{"set-default", "select", "use"},
-		Args:    cobra.ExactArgs(1),
-		Short:   "Set the default Defang deployment stack for the current directory",
+		Use:         "default STACK_NAME",
+		Aliases:     []string{"set-default", "select", "use"},
+		Annotations: authNeededAlways, // default stack tracked remotely
+		Args:        cobra.ExactArgs(1),
+		Short:       "Set the default Defang deployment stack for the current directory",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			name := args[0]
@@ -183,10 +186,11 @@ func makeStackDefaultCmd() *cobra.Command {
 func makeStackRemoveCmd() *cobra.Command {
 	var force bool
 	var stackRemoveCmd = &cobra.Command{
-		Use:     "remove STACK_NAME",
-		Aliases: []string{"rm"},
-		Args:    cobra.ExactArgs(1),
-		Short:   "Remove an existing Defang deployment stack",
+		Use:         "remove STACK_NAME",
+		Aliases:     []string{"rm"},
+		Annotations: authNeededAlways, // stack tracked remotely
+		Args:        cobra.ExactArgs(1),
+		Short:       "Remove an existing Defang deployment stack",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			name := args[0]

--- a/src/cmd/cli/command/stack.go
+++ b/src/cmd/cli/command/stack.go
@@ -48,7 +48,7 @@ func makeStackNewCmd() *cobra.Command {
 				}
 			}
 
-			loader := configureLoaderForCommand(cmd)
+			loader := newLoaderForCommand(cmd)
 			projectName, _, err := loader.LoadProjectName(ctx)
 			if err != nil {
 				return err
@@ -119,7 +119,7 @@ func makeStackListCmd() *cobra.Command {
 		Short:       "List existing Defang deployment stacks",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
-			loader := configureLoaderForCommand(cmd)
+			loader := newLoaderForCommand(cmd)
 			projectName, _, err := loader.LoadProjectName(ctx)
 			if err != nil {
 				return err
@@ -159,7 +159,7 @@ func makeStackDefaultCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			name := args[0]
-			loader := configureLoaderForCommand(cmd)
+			loader := newLoaderForCommand(cmd)
 			projectName, _, err := loader.LoadProjectName(ctx)
 			if err != nil {
 				return err
@@ -194,7 +194,7 @@ func makeStackRemoveCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			name := args[0]
-			loader := configureLoaderForCommand(cmd)
+			loader := newLoaderForCommand(cmd)
 			sm, err := newStackManagerForLoader(ctx, loader)
 			if err != nil {
 				return err

--- a/src/pkg/cli/compose/loader.go
+++ b/src/pkg/cli/compose/loader.go
@@ -68,6 +68,10 @@ func NewLoader(opts ...LoaderOption) *Loader {
 		}
 	}
 
+	return NewLoaderFromOptions(options)
+}
+
+func NewLoaderFromOptions(options LoaderOptions) *Loader {
 	return &Loader{options: options}
 }
 

--- a/src/pkg/cli/compose/loader.go
+++ b/src/pkg/cli/compose/loader.go
@@ -59,8 +59,11 @@ func NewLoader(opts ...LoaderOption) *Loader {
 	for _, o := range opts {
 		o(&options)
 	}
+	return NewLoaderFromOptions(options)
+}
 
-	// if no --project-name is provided, try to get it from the environment
+func NewLoaderFromOptions(options LoaderOptions) *Loader {
+	// If no --project-name is provided, try to get it from the environment
 	// https://docs.docker.com/compose/project-name/#set-a-project-name
 	if options.ProjectName == "" {
 		if envProjName, ok := os.LookupEnv("COMPOSE_PROJECT_NAME"); ok {
@@ -68,10 +71,6 @@ func NewLoader(opts ...LoaderOption) *Loader {
 		}
 	}
 
-	return NewLoaderFromOptions(options)
-}
-
-func NewLoaderFromOptions(options LoaderOptions) *Loader {
 	return &Loader{options: options}
 }
 

--- a/src/pkg/session/session.go
+++ b/src/pkg/session/session.go
@@ -26,13 +26,8 @@ type Session struct {
 	Provider client.Provider
 }
 
-type LoaderOptions struct {
-	ProjectName      string
-	ComposeFilePaths []string
-}
-
 type SessionLoaderOptions struct {
-	LoaderOptions
+	compose.LoaderOptions
 	stacks.GetStackOpts
 }
 
@@ -59,7 +54,7 @@ func (sl *SessionLoader) LoadSession(ctx context.Context) (*Session, error) {
 	provider := cli.NewProvider(ctx, stack.Provider, sl.client, stack.Name)
 	session := &Session{
 		Stack:    stack,
-		Loader:   sl.newLoader(),
+		Loader:   compose.NewLoaderFromOptions(sl.opts.LoaderOptions),
 		Provider: provider,
 	}
 
@@ -92,13 +87,6 @@ func (sl *SessionLoader) loadStack(ctx context.Context) (*stacks.Parameters, str
 		return nil, whence, fmt.Errorf("failed to load stack env: %w", err)
 	}
 	return stack, whence, nil
-}
-
-func (sl *SessionLoader) newLoader() client.Loader {
-	return compose.NewLoader(
-		compose.WithProjectName(sl.opts.ProjectName),
-		compose.WithPath(sl.opts.ComposeFilePaths...),
-	)
 }
 
 func printProviderMismatchWarnings(ctx context.Context, provider client.ProviderID) {


### PR DESCRIPTION
## Description

Before this PR, stack commands will fail with `Error: missing bearer token`. This PR ensures the user is logged in (to Fabric). Second commit is to dedupe some helpers. 

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved loader initialization across CLI commands for more consistent project-context loading.
  * Streamlined session handling for CD-related commands to reduce redundant context usage and simplify command flow.
* **Behavior**
  * Stack commands now always require authentication to enable remote stack tracking and management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->