### PR TITLE
refactor(dns): dependency-inject fabric resolver; fix lookup regressions

### DIFF
--- a/src/cmd/cli/command/cd.go
+++ b/src/cmd/cli/command/cd.go
@@ -211,7 +211,7 @@ var cdCloudformationCmd = &cobra.Command{
 	Args:        cobra.NoArgs,
 	Hidden:      true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		provider := aws.NewByocProvider(cmd.Context(), global.Client.GetTenantName(), global.Stack.Name)
+		provider := aws.NewByocProvider(cmd.Context(), global.Client.GetTenantName(), global.Stack.Name, global.Client)
 
 		if err := canIUseProvider(cmd.Context(), provider, "", 0, false); err != nil {
 			return err

--- a/src/pkg/cert/check.go
+++ b/src/pkg/cert/check.go
@@ -9,8 +9,7 @@ import (
 	"github.com/DefangLabs/defang/src/pkg/dns"
 )
 
-func CheckTLSCert(ctx context.Context, domain string) error {
-	resolver := dns.RootResolver{}
+func CheckTLSCert(ctx context.Context, domain string, resolver dns.Resolver) error {
 	ips, err := resolver.LookupIPAddr(ctx, domain)
 	if err != nil {
 		return err

--- a/src/pkg/cli/cert.go
+++ b/src/pkg/cli/cert.go
@@ -32,10 +32,14 @@ type DNSResult struct {
 }
 
 var (
-	resolver         dns.Resolver = dns.RootResolver{}
-	dnsCache                      = make(map[string]DNSResult)
-	dnsCacheDuration              = 1 * time.Minute
-	httpClient       HTTPClient   = &http.Client{
+	dnsCache         = make(map[string]DNSResult)
+	dnsCacheDuration = 1 * time.Minute
+
+	httpRetryDelayBase = 5 * time.Second
+)
+
+func newCertHTTPClient(r dns.Resolver) HTTPClient {
+	return &http.Client{
 		// Based on the default transport: https://pkg.go.dev/net/http#RoundTripper
 		Transport: &http.Transport{
 			Proxy: http.ProxyFromEnvironment,
@@ -49,7 +53,7 @@ var (
 				if ok && cached.Expiry.After(time.Now()) {
 					ips = cached.IPs
 				} else {
-					ips, err = resolver.LookupIPAddr(ctx, host)
+					ips, err = r.LookupIPAddr(ctx, host)
 					if err != nil {
 						return nil, err
 					}
@@ -73,8 +77,7 @@ var (
 			return nil
 		},
 	}
-	httpRetryDelayBase = 5 * time.Second
-)
+}
 
 func GenerateLetsEncryptCert(ctx context.Context, project *compose.Project, client client.FabricClient, provider client.Provider) error {
 	term.Debugf("Generating TLS cert for project %q", project.Name)
@@ -105,7 +108,7 @@ func GenerateLetsEncryptCert(ctx context.Context, project *compose.Project, clie
 			}
 			term.Debugf("Found service %v with domains %v and targets %v", service.Name, domains, targets)
 			for _, domain := range domains {
-				generateCert(ctx, domain, targets, client)
+				generateCert(ctx, domain, targets, client, dns.FabricResolver{Client: client})
 			}
 		}
 	}
@@ -131,7 +134,7 @@ func getDomainTargets(serviceInfo *defangv1.ServiceInfo, service compose.Service
 	}
 }
 
-func generateCert(ctx context.Context, domain string, targets []string, client client.FabricClient) {
+func generateCert(ctx context.Context, domain string, targets []string, client client.FabricClient, r dns.Resolver) {
 	term.Infof("Checking DNS setup for %v", domain)
 	if err := waitForCNAME(ctx, domain, targets, client); err != nil {
 		term.Errorf("Error waiting for CNAME: %v", err)
@@ -139,7 +142,7 @@ func generateCert(ctx context.Context, domain string, targets []string, client c
 	}
 
 	term.Infof("%v DNS is properly configured!", domain)
-	if err := cert.CheckTLSCert(ctx, domain); err == nil {
+	if err := cert.CheckTLSCert(ctx, domain, r); err == nil {
 		term.Infof("TLS cert for %v is already ready", domain)
 		return
 	}
@@ -148,13 +151,13 @@ func generateCert(ctx context.Context, domain string, targets []string, client c
 		return
 	}
 	term.Infof("Triggering cert generation for %v", domain)
-	if err := triggerCertGeneration(ctx, domain); err != nil {
+	if err := triggerCertGeneration(ctx, domain, r); err != nil {
 		term.Errorf("Error triggering cert generation, please try again")
 		return
 	}
 
 	term.Infof("Waiting for TLS cert to be online for %v, this could take a few minutes", domain)
-	if err := waitForTLS(ctx, domain); err != nil {
+	if err := waitForTLS(ctx, domain, r); err != nil {
 		term.Errorf("Error waiting for TLS to be online: %v", err)
 		// FIXME: Add more info on how to debug, possibly provided by the server side to avoid client type detection here
 		return
@@ -163,7 +166,7 @@ func generateCert(ctx context.Context, domain string, targets []string, client c
 	term.Infof("TLS cert for %v is ready\n", domain)
 }
 
-func triggerCertGeneration(ctx context.Context, domain string) error {
+func triggerCertGeneration(ctx context.Context, domain string, r dns.Resolver) error {
 	doSpinner := term.StdoutCanColor() && term.IsTerminal()
 	if doSpinner {
 		term.HideCursor()
@@ -174,7 +177,7 @@ func triggerCertGeneration(ctx context.Context, domain string) error {
 		defer cancelSpinner()
 	}
 	// Our own retry logic uses the root resolver to prevent cached DNS and retry on all non-200 errors
-	if err := getWithRetries(ctx, fmt.Sprintf("http://%v", domain), 5); err != nil { // Retry incase of DNS error
+	if err := getWithRetries(ctx, fmt.Sprintf("http://%v", domain), 5, newCertHTTPClient(r)); err != nil { // Retry incase of DNS error
 		// Ignore possible tls error as cert attachment may take time
 		term.Debugf("Error triggering cert generation: %v", err)
 		return err
@@ -182,7 +185,7 @@ func triggerCertGeneration(ctx context.Context, domain string) error {
 	return nil
 }
 
-func waitForTLS(ctx context.Context, domain string) error {
+func waitForTLS(ctx context.Context, domain string, r dns.Resolver) error {
 	ticker := time.NewTicker(3 * time.Second)
 	defer ticker.Stop()
 	timeout, cancel := context.WithTimeout(ctx, 10*time.Minute)
@@ -202,7 +205,7 @@ func waitForTLS(ctx context.Context, domain string) error {
 		case <-timeout.Done():
 			return timeout.Err()
 		case <-ticker.C:
-			if err := cert.CheckTLSCert(timeout, domain); err == nil {
+			if err := cert.CheckTLSCert(timeout, domain, r); err == nil {
 				return nil
 			} else {
 				term.Debugf("Error checking TLS cert for %v: %v", domain, err)
@@ -283,14 +286,14 @@ func waitForCNAME(ctx context.Context, domain string, targets []string, client c
 	}
 }
 
-func getWithRetries(ctx context.Context, url string, tries int) error {
+func getWithRetries(ctx context.Context, url string, tries int, c HTTPClient) error {
 	var errs []error
 	for i := range make([]struct{}, tries) {
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 		if err != nil {
 			return err // No point retrying if we can't even create the request
 		}
-		resp, err := httpClient.Do(req)
+		resp, err := c.Do(req)
 		if err == nil {
 			defer resp.Body.Close()
 			_, err = io.ReadAll(resp.Body) // Read the body to ensure the request is not swallowed by alb

--- a/src/pkg/cli/cert.go
+++ b/src/pkg/cli/cert.go
@@ -249,7 +249,10 @@ func waitForCNAME(ctx context.Context, domain string, targets []string, client c
 			}
 		}
 		if serverSideVerified || serverVerifyRpcFailure >= 3 {
-			locallyVerified := dns.CheckDomainDNSReady(ctx, domain, targets)
+			fabricResolverAt := func(nsServer string) dns.Resolver {
+				return dns.FabricResolver{Client: client, NSServer: nsServer}
+			}
+			locallyVerified := dns.CheckDomainDNSReady(ctx, domain, targets, fabricResolverAt)
 			if serverSideVerified && !locallyVerified {
 				term.Warnf("DNS settings for %v are verified, but changes may take a few minutes to propagate due to caching.", domain)
 				return nil

--- a/src/pkg/cli/cert_test.go
+++ b/src/pkg/cli/cert_test.go
@@ -59,10 +59,7 @@ func TestGetWithRetries(t *testing.T) {
 		tc := &testClient{tries: []tryResult{
 			{result: &http.Response{StatusCode: 200, Body: mockBody("")}, err: nil},
 		}}
-		originalClient := httpClient
-		t.Cleanup(func() { httpClient = originalClient })
-		httpClient = tc
-		err := getWithRetries(t.Context(), "http://example.com", 3)
+		err := getWithRetries(t.Context(), "http://example.com", 3, tc)
 		if err != nil {
 			t.Errorf("Expected no error, got %v", err)
 		}
@@ -76,10 +73,7 @@ func TestGetWithRetries(t *testing.T) {
 			{result: nil, err: errors.New("error")},
 			{result: &http.Response{StatusCode: 200, Body: mockBody("")}, err: nil},
 		}}
-		originalClient := httpClient
-		t.Cleanup(func() { httpClient = originalClient })
-		httpClient = tc
-		err := getWithRetries(t.Context(), "http://example.com", 3)
+		err := getWithRetries(t.Context(), "http://example.com", 3, tc)
 		if err != nil {
 			t.Errorf("Expected no error, got %v", err)
 		}
@@ -93,10 +87,7 @@ func TestGetWithRetries(t *testing.T) {
 			{result: &http.Response{StatusCode: 503, Body: mockBody("Random Error")}, err: nil},
 			{result: nil, err: errors.New("error")},
 		}}
-		originalClient := httpClient
-		t.Cleanup(func() { httpClient = originalClient })
-		httpClient = tc
-		err := getWithRetries(t.Context(), "http://example.com", 3)
+		err := getWithRetries(t.Context(), "http://example.com", 3, tc)
 		if err == nil {
 			t.Errorf("Expected error, got %v", err)
 		} else if !strings.Contains(err.Error(), "HTTP: 503") {
@@ -111,10 +102,7 @@ func TestGetWithRetries(t *testing.T) {
 		tc := &testClient{tries: []tryResult{
 			{result: &http.Response{StatusCode: 503, Request: &http.Request{URL: redirectURL}, Body: mockBody("Random Error")}, err: nil},
 		}}
-		originalClient := httpClient
-		t.Cleanup(func() { httpClient = originalClient })
-		httpClient = tc
-		err := getWithRetries(t.Context(), "http://example.com", 3)
+		err := getWithRetries(t.Context(), "http://example.com", 3, tc)
 		if err != nil {
 			t.Errorf("Expected no error, got %v", err)
 		}
@@ -126,10 +114,7 @@ func TestGetWithRetries(t *testing.T) {
 		tc := &testClient{tries: []tryResult{
 			{result: nil, err: &tls.CertificateVerificationError{Err: errors.New("error")}},
 		}}
-		originalClient := httpClient
-		t.Cleanup(func() { httpClient = originalClient })
-		httpClient = tc
-		err := getWithRetries(t.Context(), "http://example.com", 3)
+		err := getWithRetries(t.Context(), "http://example.com", 3, tc)
 		if err != nil {
 			t.Errorf("Expected no error, got %v", err)
 		}
@@ -143,10 +128,7 @@ func TestGetWithRetries(t *testing.T) {
 			{result: &http.Response{StatusCode: 502, Body: mockBody("Random Error")}, err: nil},
 			{result: &http.Response{StatusCode: 503, Body: mockBody("Random Error")}, err: nil},
 		}}
-		originalClient := httpClient
-		t.Cleanup(func() { httpClient = originalClient })
-		httpClient = tc
-		err := getWithRetries(t.Context(), "http://example.com", 3)
+		err := getWithRetries(t.Context(), "http://example.com", 3, tc)
 		if err == nil {
 			t.Errorf("Expected error, got %v", err)
 		} else if !strings.Contains(err.Error(), "HTTP: 404") || !strings.Contains(err.Error(), "HTTP: 502") || !strings.Contains(err.Error(), "HTTP: 503") {
@@ -162,10 +144,7 @@ func TestGetWithRetries(t *testing.T) {
 			{result: &http.Response{StatusCode: 502, Body: mockBody("Random Error")}, err: nil},
 			{result: &http.Response{StatusCode: 503, Body: mockBody("Random Error")}, err: nil},
 		}}
-		originalClient := httpClient
-		t.Cleanup(func() { httpClient = originalClient })
-		httpClient = tc
-		err := getWithRetries(t.Context(), "http://example.com", 1)
+		err := getWithRetries(t.Context(), "http://example.com", 1, tc)
 		if err == nil {
 			t.Errorf("Expected error, got %v", err)
 		}
@@ -198,8 +177,9 @@ func TestHttpClient(t *testing.T) {
 	}))
 	defer ts.Close()
 	var mr MockResolver
-	resolver = &mr
 	dnsCacheDuration = 50 * time.Millisecond
+
+	tc := newCertHTTPClient(&mr)
 
 	tsu, err := url.Parse(ts.URL)
 	if err != nil {
@@ -214,7 +194,7 @@ func TestHttpClient(t *testing.T) {
 		t.Fatalf("failed to create request: %v", err)
 	}
 
-	resp, err := httpClient.Do(req)
+	resp, err := tc.Do(req)
 	if err != nil {
 		t.Fatalf("failed to make http call: %v", err)
 	}
@@ -224,7 +204,7 @@ func TestHttpClient(t *testing.T) {
 		t.Fatalf("expected 1 dns lookup, but got %v", mr.calls)
 	}
 
-	resp, err = httpClient.Do(req)
+	resp, err = tc.Do(req)
 	if err != nil {
 		t.Fatalf("failed to make http call: %v", err)
 	}
@@ -234,7 +214,7 @@ func TestHttpClient(t *testing.T) {
 	}
 
 	time.Sleep(80 * time.Millisecond)
-	resp, err = httpClient.Do(req)
+	resp, err = tc.Do(req)
 	if err != nil {
 		t.Fatalf("failed to make http call: %v", err)
 	}

--- a/src/pkg/cli/client/byoc/aws/byoc.go
+++ b/src/pkg/cli/client/byoc/aws/byoc.go
@@ -52,7 +52,8 @@ type Config = awssdk.Config
 type ByocAws struct {
 	*byoc.ByocBaseClient
 
-	driver *cfn.AwsCfn // TODO: ecs is stateful, contains the output of the cd cfn stack after SetUpCD
+	driver       *cfn.AwsCfn // TODO: ecs is stateful, contains the output of the cd cfn stack after SetUpCD
+	fabricClient dns.FabricResolverClient
 
 	cdEtag    types.ETag
 	cdStart   time.Time
@@ -114,7 +115,7 @@ func AnnotateAwsError(err error) error {
 	return err
 }
 
-func NewByocProvider(ctx context.Context, tenantName types.TenantLabel, stack string) *ByocAws {
+func NewByocProvider(ctx context.Context, tenantName types.TenantLabel, stack string, fabricClient dns.FabricResolverClient) *ByocAws {
 	if awsProfileName := os.Getenv("AWS_PROFILE"); awsProfileName != "" {
 		AWSAccessKeyID := os.Getenv("AWS_ACCESS_KEY_ID")
 		AWSSecretAccessKey := os.Getenv("AWS_SECRET_ACCESS_KEY")
@@ -129,7 +130,8 @@ func NewByocProvider(ctx context.Context, tenantName types.TenantLabel, stack st
 	}
 
 	b := &ByocAws{
-		driver: cfn.New(byoc.CdTaskPrefix, aws.Region("")), // default region
+		driver:       cfn.New(byoc.CdTaskPrefix, aws.Region("")), // default region
+		fabricClient: fabricClient,
 	}
 	b.ByocBaseClient = byoc.NewByocBaseClient(tenantName, b, stack)
 
@@ -425,7 +427,10 @@ func (b *ByocAws) PrepareDomainDelegation(ctx context.Context, req client.Prepar
 	r53Client := route53.NewFromConfig(cfg)
 
 	projectDomain := req.DelegateDomain
-	nsServers, delegationSetId, err := prepareDomainDelegation(ctx, projectDomain, req.Project, b.PulumiStack, r53Client, dns.ResolverAt)
+	resolverAt := func(nsServer string) dns.Resolver {
+		return dns.FabricResolver{Client: b.fabricClient, NSServer: nsServer}
+	}
+	nsServers, delegationSetId, err := prepareDomainDelegation(ctx, projectDomain, req.Project, b.PulumiStack, r53Client, resolverAt)
 	if err != nil {
 		return nil, AnnotateAwsError(err)
 	}

--- a/src/pkg/cli/client/byoc/aws/byoc_test.go
+++ b/src/pkg/cli/client/byoc/aws/byoc_test.go
@@ -379,7 +379,7 @@ aws_secret_access_key = wJalrXUtnFEMI/KDEFANG/bPxRfiCYEXAMPLEKEY
 			ctx := t.Context()
 
 			// Create ByocAws instance - warning is printed here in NewByocProvider
-			b := NewByocProvider(ctx, "tenant1", "exampleStack")
+			b := NewByocProvider(ctx, "tenant1", "exampleStack", nil)
 			_, err := b.AccountInfo(ctx)
 
 			if tt.expectedError {

--- a/src/pkg/cli/client/mock.go
+++ b/src/pkg/cli/client/mock.go
@@ -272,6 +272,18 @@ func (m MockFabricClient) GetDefaultStack(context.Context, *defangv1.GetDefaultS
 	}, nil
 }
 
+func (m MockFabricClient) ResolveIPAddr(_ context.Context, _ *defangv1.ResolveIPAddrRequest) (*defangv1.ResolveIPAddrResponse, error) {
+	return &defangv1.ResolveIPAddrResponse{}, nil
+}
+
+func (m MockFabricClient) ResolveCNAME(_ context.Context, _ *defangv1.ResolveCNAMERequest) (*defangv1.ResolveCNAMEResponse, error) {
+	return &defangv1.ResolveCNAMEResponse{}, nil
+}
+
+func (m MockFabricClient) ResolveNS(_ context.Context, _ *defangv1.ResolveNSRequest) (*defangv1.ResolveNSResponse, error) {
+	return &defangv1.ResolveNSResponse{}, nil
+}
+
 type MockLoader struct {
 	Project composeTypes.Project
 	Error   error

--- a/src/pkg/cli/connect.go
+++ b/src/pkg/cli/connect.go
@@ -7,7 +7,6 @@ import (
 	"github.com/DefangLabs/defang/src/pkg/cli/client/byoc/aws"
 	"github.com/DefangLabs/defang/src/pkg/cli/client/byoc/do"
 	"github.com/DefangLabs/defang/src/pkg/cli/client/byoc/gcp"
-	"github.com/DefangLabs/defang/src/pkg/dns"
 	"github.com/DefangLabs/defang/src/pkg/term"
 	"github.com/DefangLabs/defang/src/pkg/types"
 )
@@ -18,9 +17,7 @@ func Connect(fabricAddr string, requestedTenant types.TenantNameOrID) *client.Gr
 	term.Debugf("Using tenant %q for cluster %q", requestedTenant, host)
 
 	accessToken := client.GetExistingToken(host)
-	grpcClient := client.NewGrpcClient(host, accessToken, requestedTenant)
-	dns.UseFabricResolver(grpcClient)
-	return grpcClient
+	return client.NewGrpcClient(host, accessToken, requestedTenant)
 }
 
 func ConnectWithTenant(ctx context.Context, fabricAddr string, requestedTenant types.TenantNameOrID) (*client.GrpcClient, error) {

--- a/src/pkg/cli/connect.go
+++ b/src/pkg/cli/connect.go
@@ -41,7 +41,7 @@ func NewProvider(ctx context.Context, providerID client.ProviderID, fabricClient
 	term.Debugf("Creating %s provider", providerID)
 	switch providerID {
 	case client.ProviderAWS:
-		provider = aws.NewByocProvider(ctx, fabricClient.GetTenantName(), stack)
+		provider = aws.NewByocProvider(ctx, fabricClient.GetTenantName(), stack, fabricClient)
 	case client.ProviderDO:
 		provider = do.NewByocProvider(ctx, fabricClient.GetTenantName(), stack)
 	case client.ProviderGCP:

--- a/src/pkg/dns/check.go
+++ b/src/pkg/dns/check.go
@@ -25,11 +25,11 @@ var (
 
 // The DNS is considered ready if the CNAME of the domain is pointing to the ALB domain and in sync
 // OR if the A record of the domain is pointing to the same IP addresses of the ALB domain and in sync
-func CheckDomainDNSReady(ctx context.Context, domain string, validCNAMEs []string) bool {
+func CheckDomainDNSReady(ctx context.Context, domain string, validCNAMEs []string, resolverAt func(string) Resolver) bool {
 	for i, validCNAME := range validCNAMEs {
 		validCNAMEs[i] = Normalize(validCNAME)
 	}
-	cname, err := getCNAMEInSync(ctx, domain)
+	cname, err := getCNAMEInSync(ctx, domain, resolverAt)
 	Logger.Debugf("CNAME for %v is: '%v', err: %v", domain, cname, err)
 	// Ignore other types of DNS errors
 	if err == errDNSNotInSync {
@@ -66,7 +66,7 @@ func CheckDomainDNSReady(ctx context.Context, domain string, validCNAMEs []strin
 	}
 
 	// Check if an valid A record has been set
-	ips, err := getIPInSync(ctx, domain)
+	ips, err := getIPInSync(ctx, domain, resolverAt)
 	if err != nil {
 		Logger.Debugf("IP for %v not in sync: %v", domain, err)
 		return false
@@ -78,8 +78,8 @@ func CheckDomainDNSReady(ctx context.Context, domain string, validCNAMEs []strin
 	return false
 }
 
-func getCNAMEInSync(ctx context.Context, domain string) (string, error) {
-	ns, err := FindNSServers(ctx, domain)
+func getCNAMEInSync(ctx context.Context, domain string, resolverAt func(string) Resolver) (string, error) {
+	ns, err := FindNSServers(ctx, domain, resolverAt)
 	if err != nil {
 		return "", err
 	}
@@ -88,7 +88,7 @@ func getCNAMEInSync(ctx context.Context, domain string) (string, error) {
 	var cname string
 	var lookupErr error
 	for _, n := range ns {
-		cname, err = ResolverAt(n.Host).LookupCNAME(ctx, domain)
+		cname, err = resolverAt(n.Host).LookupCNAME(ctx, domain)
 		if err != nil {
 			Logger.Debugf("Error looking up CNAME for %v at %v: %v", domain, n, err)
 			lookupErr = err
@@ -102,8 +102,8 @@ func getCNAMEInSync(ctx context.Context, domain string) (string, error) {
 	return cname, lookupErr
 }
 
-func getIPInSync(ctx context.Context, domain string) ([]net.IP, error) {
-	ns, err := FindNSServers(ctx, domain)
+func getIPInSync(ctx context.Context, domain string, resolverAt func(string) Resolver) ([]net.IP, error) {
+	ns, err := FindNSServers(ctx, domain, resolverAt)
 	if err != nil {
 		return nil, err
 	}
@@ -112,7 +112,7 @@ func getIPInSync(ctx context.Context, domain string) ([]net.IP, error) {
 	var lookupErr error
 	for i, n := range ns {
 		var ipAddrs []net.IPAddr
-		ipAddrs, err = ResolverAt(n.Host).LookupIPAddr(ctx, domain)
+		ipAddrs, err = resolverAt(n.Host).LookupIPAddr(ctx, domain)
 		if err != nil {
 			Logger.Debugf("Error looking up IP for %v at %v: %v", domain, n, err)
 			lookupErr = err

--- a/src/pkg/dns/check.go
+++ b/src/pkg/dns/check.go
@@ -17,8 +17,7 @@ type logger interface {
 }
 
 var (
-	Logger   logger   = term.DefaultTerm
-	resolver Resolver = RootResolver{}
+	Logger logger = term.DefaultTerm
 
 	errDNSNotInSync = errors.New("DNS not in sync")
 )
@@ -42,7 +41,7 @@ func CheckDomainDNSReady(ctx context.Context, domain string, validCNAMEs []strin
 		return true
 	}
 
-	albIPAddrs, err := resolver.LookupIPAddr(ctx, validCNAMEs[0])
+	albIPAddrs, err := resolverAt("").LookupIPAddr(ctx, validCNAMEs[0])
 	if err != nil {
 		Logger.Debugf("Could not resolve A/AAAA record for load balancer %v: %v", validCNAMEs[0], err)
 		return false
@@ -52,7 +51,7 @@ func CheckDomainDNSReady(ctx context.Context, domain string, validCNAMEs []strin
 	// In sync CNAME may be pointing to the same IP addresses of the load balancer, considered as valid
 	Logger.Debugf("Checking CNAME %v", cname)
 	if cname != "" {
-		cnameIPAddrs, err := resolver.LookupIPAddr(ctx, cname)
+		cnameIPAddrs, err := resolverAt("").LookupIPAddr(ctx, cname)
 		if err != nil {
 			Logger.Debugf("Could not resolve A/AAAA record for %v: %v", cname, err)
 		} else {

--- a/src/pkg/dns/check_test.go
+++ b/src/pkg/dns/check_test.go
@@ -12,10 +12,6 @@ import (
 var notFound = errors.New("not found")
 
 func TestGetCNAMEInSync(t *testing.T) {
-	t.Cleanup(func() {
-		resolverAt = DirectResolverAt
-	})
-
 	notFoundResolver := MockResolver{Records: map[DNSRequest]DNSResponse{
 		{Type: "NS", Domain: "web.test.com"}:    {Records: []string{"ns1.example.com", "ns2.example.com"}, Error: nil},
 		{Type: "CNAME", Domain: "web.test.com"}: {Records: nil, Error: notFound},
@@ -27,8 +23,7 @@ func TestGetCNAMEInSync(t *testing.T) {
 
 	// Test when the domain is not found
 	t.Run("domain not found", func(t *testing.T) {
-		resolverAt = func(_ string) Resolver { return notFoundResolver }
-		_, err := getCNAMEInSync(t.Context(), "web.test.com")
+		_, err := getCNAMEInSync(t.Context(), "web.test.com", func(_ string) Resolver { return notFoundResolver })
 		if err != notFound {
 			t.Errorf("Expected NotFound error, got %v", err)
 		}
@@ -36,14 +31,14 @@ func TestGetCNAMEInSync(t *testing.T) {
 
 	// Test when the domain is found but the DNS servers are not in sync
 	t.Run("DNS servers not in sync", func(t *testing.T) {
-		resolverAt = func(nsServer string) Resolver {
+		resolverAt := func(nsServer string) Resolver {
 			if nsServer == "ns1.example.com" {
 				return foundResolver
 			} else {
 				return notFoundResolver
 			}
 		}
-		_, err := getCNAMEInSync(t.Context(), "web.test.com")
+		_, err := getCNAMEInSync(t.Context(), "web.test.com", resolverAt)
 		if err != errDNSNotInSync {
 			t.Errorf("Expected NotInSync error, got %v", err)
 		}
@@ -51,8 +46,7 @@ func TestGetCNAMEInSync(t *testing.T) {
 
 	// Test when the domain is found and the DNS servers are in sync
 	t.Run("DNS servers in sync", func(t *testing.T) {
-		resolverAt = func(_ string) Resolver { return foundResolver }
-		cname, err := getCNAMEInSync(t.Context(), "web.test.com")
+		cname, err := getCNAMEInSync(t.Context(), "web.test.com", func(_ string) Resolver { return foundResolver })
 		if err != nil {
 			t.Errorf("Expected no error, got %v", err)
 		}
@@ -64,10 +58,6 @@ func TestGetCNAMEInSync(t *testing.T) {
 }
 
 func TestGetIPInSync(t *testing.T) {
-	t.Cleanup(func() {
-		resolverAt = DirectResolverAt
-	})
-
 	notFoundResolver := MockResolver{Records: map[DNSRequest]DNSResponse{
 		{Type: "NS", Domain: "test.com"}: {Records: []string{"ns1.example.com", "ns2.example.com"}, Error: nil},
 		{Type: "A", Domain: "test.com"}:  {Records: nil, Error: notFound},
@@ -83,8 +73,7 @@ func TestGetIPInSync(t *testing.T) {
 
 	// Test when the domain is not found
 	t.Run("domain not found", func(t *testing.T) {
-		resolverAt = func(_ string) Resolver { return notFoundResolver }
-		_, err := getIPInSync(t.Context(), "test.com")
+		_, err := getIPInSync(t.Context(), "test.com", func(_ string) Resolver { return notFoundResolver })
 		if err != notFound {
 			t.Errorf("Expected NotFound error, got %v", err)
 		}
@@ -92,14 +81,14 @@ func TestGetIPInSync(t *testing.T) {
 
 	// Test when the domain is found but the DNS servers are not in sync
 	t.Run("DNS servers not in sync", func(t *testing.T) {
-		resolverAt = func(nsServer string) Resolver {
+		resolverAt := func(nsServer string) Resolver {
 			if nsServer == "ns1.example.com" {
 				return foundResolver
 			} else {
 				return notFoundResolver
 			}
 		}
-		_, err := getIPInSync(t.Context(), "test.com")
+		_, err := getIPInSync(t.Context(), "test.com", resolverAt)
 		if err != errDNSNotInSync {
 			t.Errorf("Expected NotInSyncError error, got %v", err)
 		}
@@ -107,14 +96,14 @@ func TestGetIPInSync(t *testing.T) {
 
 	// 2nd not in sync scenario
 	t.Run("DNS servers not in sync with partial results", func(t *testing.T) {
-		resolverAt = func(nsServer string) Resolver {
+		resolverAt := func(nsServer string) Resolver {
 			if nsServer == "ns1.example.com" {
 				return partialFoundResolver
 			} else {
 				return foundResolver
 			}
 		}
-		_, err := getIPInSync(t.Context(), "test.com")
+		_, err := getIPInSync(t.Context(), "test.com", resolverAt)
 		if err != errDNSNotInSync {
 			t.Errorf("Expected NotInSyncError error, got %v", err)
 		}
@@ -122,8 +111,7 @@ func TestGetIPInSync(t *testing.T) {
 
 	// Test when the domain is found and the DNS servers are in sync
 	t.Run("DNS servers in sync", func(t *testing.T) {
-		resolverAt = func(_ string) Resolver { return foundResolver }
-		ips, err := getIPInSync(t.Context(), "test.com")
+		ips, err := getIPInSync(t.Context(), "test.com", func(_ string) Resolver { return foundResolver })
 		if err != nil {
 			t.Errorf("Expected no error, got %v", err)
 		}
@@ -153,43 +141,37 @@ func TestCheckDomainDNSReady(t *testing.T) {
 	}}
 	resolver = hasARecordResolver
 
-	oldResolver, oldDebug := resolverAt, term.DoDebug()
+	oldDebug := term.DoDebug()
 	t.Cleanup(func() {
-		resolverAt = oldResolver
 		term.SetDebug(oldDebug)
 	})
 	term.SetDebug(true)
 
 	t.Run("CNAME and A records not found", func(t *testing.T) {
-		resolverAt = func(_ string) Resolver { return emptyResolver }
-		if CheckDomainDNSReady(t.Context(), "api.test.com", []string{"some-alb.domain.com"}) != false {
+		if CheckDomainDNSReady(t.Context(), "api.test.com", []string{"some-alb.domain.com"}, func(_ string) Resolver { return emptyResolver }) != false {
 			t.Errorf("Expected false when both CNAME and A records are missing, got true")
 		}
 	})
 
 	t.Run("CNAME setup correctly", func(t *testing.T) {
-		resolverAt = func(_ string) Resolver { return hasCNAMEResolver }
-		if CheckDomainDNSReady(t.Context(), "api.test.com", []string{"some-alb.domain.com"}) != true {
+		if CheckDomainDNSReady(t.Context(), "api.test.com", []string{"some-alb.domain.com"}, func(_ string) Resolver { return hasCNAMEResolver }) != true {
 			t.Errorf("Expected true when CNAME is setup correctly, got false")
 		}
 	})
 
 	t.Run("CNAME setup incorrectly", func(t *testing.T) {
-		resolverAt = func(_ string) Resolver { return hasCNAMEResolver }
-		if CheckDomainDNSReady(t.Context(), "api.test.com", []string{"some-other-alb.domain.com"}) != false {
+		if CheckDomainDNSReady(t.Context(), "api.test.com", []string{"some-other-alb.domain.com"}, func(_ string) Resolver { return hasCNAMEResolver }) != false {
 			t.Errorf("Expected false when CNAME is setup incorrectly, got true")
 		}
 	})
 
 	t.Run("A record setup correctly", func(t *testing.T) {
-		resolverAt = func(_ string) Resolver { return hasARecordResolver }
-		if CheckDomainDNSReady(t.Context(), "api.test.com", []string{"some-alb.domain.com"}) != true {
+		if CheckDomainDNSReady(t.Context(), "api.test.com", []string{"some-alb.domain.com"}, func(_ string) Resolver { return hasARecordResolver }) != true {
 			t.Errorf("Expected true when A record is setup correctly, got false")
 		}
 	})
 	t.Run("A record setup incorrectly", func(t *testing.T) {
-		resolverAt = func(_ string) Resolver { return hasWrongARecordResolver }
-		if CheckDomainDNSReady(t.Context(), "api.test.com", []string{"some-alb.domain.com"}) != false {
+		if CheckDomainDNSReady(t.Context(), "api.test.com", []string{"some-alb.domain.com"}, func(_ string) Resolver { return hasWrongARecordResolver }) != false {
 			t.Errorf("Expected false when A record is setup incorrectly, got true")
 		}
 	})

--- a/src/pkg/dns/check_test.go
+++ b/src/pkg/dns/check_test.go
@@ -139,8 +139,6 @@ func TestCheckDomainDNSReady(t *testing.T) {
 		{Type: "A", Domain: "some-alb.domain.com"}: {Records: []string{"1.2.3.4", "5,6,7,8"}, Error: nil},
 		{Type: "CNAME", Domain: "api.test.com"}:    {Records: []string{"some-alb.domain.com"}, Error: nil},
 	}}
-	resolver = hasARecordResolver
-
 	oldDebug := term.DoDebug()
 	t.Cleanup(func() {
 		term.SetDebug(oldDebug)

--- a/src/pkg/dns/fabric_test.go
+++ b/src/pkg/dns/fabric_test.go
@@ -3,7 +3,6 @@ package dns
 import (
 	"context"
 	"errors"
-	"sync"
 	"testing"
 
 	defangv1 "github.com/DefangLabs/defang/src/protos/io/defang/v1"
@@ -105,64 +104,4 @@ func TestFabricResolverLookupNS(t *testing.T) {
 	if len(ns) != 2 || ns[0].Host != "ns1.example.com." {
 		t.Errorf("unexpected NS result: %+v", ns)
 	}
-}
-
-func TestUseFabricResolver(t *testing.T) {
-	t.Cleanup(func() {
-		fabricClient = nil
-		resolverAt = DirectResolverAt
-	})
-
-	m := &mockFabricClient{ipResp: &defangv1.ResolveIPAddrResponse{IpAddrs: []string{"9.9.9.9"}}}
-	UseFabricResolver(m)
-
-	// RootResolver should now delegate to FabricResolver.
-	ips, err := RootResolver{}.LookupIPAddr(t.Context(), "example.com")
-	if err != nil {
-		t.Fatalf("RootResolver.LookupIPAddr: %v", err)
-	}
-	if len(ips) != 1 || ips[0].IP.String() != "9.9.9.9" {
-		t.Errorf("unexpected IPs: %v", ips)
-	}
-
-	// ResolverAt should return a FabricResolver bound to the NS.
-	r := ResolverAt("ns1.example.com")
-	if fr, ok := r.(FabricResolver); !ok || fr.NSServer != "ns1.example.com" {
-		t.Errorf("ResolverAt did not return FabricResolver: %T %+v", r, r)
-	}
-}
-
-// TestResolverAtConcurrentWithUseFabricResolver exercises the synchronization
-// between UseFabricResolver (which swaps resolverAt) and ResolverAt callers.
-// Run with `go test -race` — prior to the mutex-guarded ResolverAt, concurrent
-// writes and reads on the package-level variable were a data race.
-func TestResolverAtConcurrentWithUseFabricResolver(t *testing.T) {
-	t.Cleanup(func() {
-		fabricClient = nil
-		resolverAt = DirectResolverAt
-	})
-
-	m := &mockFabricClient{nsResp: &defangv1.ResolveNSResponse{Hosts: []string{"ns1.example.com."}}}
-
-	var wg sync.WaitGroup
-	stop := make(chan struct{})
-	for range 4 {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			for {
-				select {
-				case <-stop:
-					return
-				default:
-					_ = ResolverAt("ns.example.com")
-				}
-			}
-		}()
-	}
-	for range 200 {
-		UseFabricResolver(m)
-	}
-	close(stop)
-	wg.Wait()
 }

--- a/src/pkg/dns/resolver.go
+++ b/src/pkg/dns/resolver.go
@@ -162,20 +162,20 @@ func (r RootResolver) LookupNS(ctx context.Context, domain string) ([]*net.NS, e
 }
 
 func (r RootResolver) getResolver(ctx context.Context, domain string) Resolver {
-	ns, err := FindNSServers(ctx, domain)
+	ns, err := FindNSServers(ctx, domain, ResolverAt)
 	if err != nil {
 		return DirectResolver{}
 	}
 	return DirectResolver{NSServer: ns[pkg.RandomIndex(len(ns))].Host}
 }
 
-func FindNSServers(ctx context.Context, domain string) ([]*net.NS, error) {
+func FindNSServers(ctx context.Context, domain string, resolverAt func(string) Resolver) ([]*net.NS, error) {
 	nsServers := rootServers
 	retries := 3
 	for {
 		index := pkg.RandomIndex(len(nsServers))
 		nsServer := nsServers[index].Host
-		ns, err := ResolverAt(nsServer).LookupNS(ctx, domain)
+		ns, err := resolverAt(nsServer).LookupNS(ctx, domain)
 		sort.Slice(ns, func(i, j int) bool { return ns[i].Host < ns[j].Host })
 		if err != nil {
 			if retries--; retries > 0 {

--- a/src/pkg/dns/resolver.go
+++ b/src/pkg/dns/resolver.go
@@ -7,7 +7,6 @@ import (
 	"net"
 	"slices"
 	"sort"
-	"sync"
 
 	"github.com/DefangLabs/defang/src/pkg"
 	defangv1 "github.com/DefangLabs/defang/src/protos/io/defang/v1"
@@ -26,31 +25,6 @@ type FabricResolverClient interface {
 	ResolveIPAddr(context.Context, *defangv1.ResolveIPAddrRequest) (*defangv1.ResolveIPAddrResponse, error)
 	ResolveCNAME(context.Context, *defangv1.ResolveCNAMERequest) (*defangv1.ResolveCNAMEResponse, error)
 	ResolveNS(context.Context, *defangv1.ResolveNSRequest) (*defangv1.ResolveNSResponse, error)
-}
-
-// fabricMu guards concurrent access to fabricClient and resolverAt.
-var fabricMu sync.RWMutex
-
-// fabricClient is set by UseFabricResolver. When non-nil, RootResolver and
-// ResolverAt route DNS lookups through the fabric gRPC API.
-var fabricClient FabricResolverClient
-
-// UseFabricResolver wires DNS lookups through the fabric gRPC API. After it is
-// called, RootResolver{} and ResolverAt(nsServer) both issue remote RPCs
-// instead of performing direct UDP DNS queries.
-func UseFabricResolver(c FabricResolverClient) {
-	fabricMu.Lock()
-	defer fabricMu.Unlock()
-	fabricClient = c
-	resolverAt = func(nsServer string) Resolver {
-		return FabricResolver{Client: c, NSServer: nsServer}
-	}
-}
-
-func getFabricClient() FabricResolverClient {
-	fabricMu.RLock()
-	defer fabricMu.RUnlock()
-	return fabricClient
 }
 
 // FabricResolver performs DNS lookups via the fabric gRPC API. An empty
@@ -109,7 +83,20 @@ func (r FabricResolver) LookupNS(ctx context.Context, domain string) ([]*net.NS,
 	return nss, nil
 }
 
-type RootResolver struct{}
+// RootResolver performs recursive DNS resolution starting from the root
+// nameservers. Set ResolverAt to override how individual nameservers are
+// queried (e.g. to route through the Fabric gRPC API). A nil ResolverAt
+// falls back to DirectResolverAt.
+type RootResolver struct {
+	ResolverAt func(string) Resolver
+}
+
+func (r RootResolver) resolverFn() func(string) Resolver {
+	if r.ResolverAt != nil {
+		return r.ResolverAt
+	}
+	return DirectResolverAt
+}
 
 // https://en.wikipedia.org/wiki/Root_name_server
 var rootServers = []*net.NS{
@@ -129,9 +116,6 @@ var rootServers = []*net.NS{
 }
 
 func (r RootResolver) LookupIPAddr(ctx context.Context, domain string) ([]net.IPAddr, error) {
-	if c := getFabricClient(); c != nil {
-		return FabricResolver{Client: c}.LookupIPAddr(ctx, domain)
-	}
 	for range 10 {
 		ips, err := r.getResolver(ctx, domain).LookupIPAddr(ctx, domain)
 		if err != nil {
@@ -148,21 +132,15 @@ func (r RootResolver) LookupIPAddr(ctx context.Context, domain string) ([]net.IP
 }
 
 func (r RootResolver) LookupCNAME(ctx context.Context, domain string) (string, error) {
-	if c := getFabricClient(); c != nil {
-		return FabricResolver{Client: c}.LookupCNAME(ctx, domain)
-	}
 	return r.getResolver(ctx, domain).LookupCNAME(ctx, domain)
 }
 
 func (r RootResolver) LookupNS(ctx context.Context, domain string) ([]*net.NS, error) {
-	if c := getFabricClient(); c != nil {
-		return FabricResolver{Client: c}.LookupNS(ctx, domain)
-	}
 	return r.getResolver(ctx, domain).LookupNS(ctx, domain)
 }
 
 func (r RootResolver) getResolver(ctx context.Context, domain string) Resolver {
-	ns, err := FindNSServers(ctx, domain, ResolverAt)
+	ns, err := FindNSServers(ctx, domain, r.resolverFn())
 	if err != nil {
 		return DirectResolver{}
 	}
@@ -192,21 +170,6 @@ func FindNSServers(ctx context.Context, domain string, resolverAt func(string) R
 
 func DirectResolverAt(nsServer string) Resolver {
 	return DirectResolver{NSServer: nsServer}
-}
-
-// resolverAt is the package-private function that produces a Resolver bound to
-// a given nameserver. It is swapped out by UseFabricResolver. All reads must go
-// through ResolverAt so they're synchronized with that write.
-var resolverAt = DirectResolverAt
-
-// ResolverAt returns a Resolver bound to nsServer. When UseFabricResolver has
-// wired in a fabric client, the returned Resolver issues remote RPCs;
-// otherwise it performs direct UDP DNS queries.
-func ResolverAt(nsServer string) Resolver {
-	fabricMu.RLock()
-	fn := resolverAt
-	fabricMu.RUnlock()
-	return fn(nsServer)
 }
 
 var ErrNoSuchHost = &net.DNSError{Err: "no such host", IsNotFound: true}

--- a/src/pkg/dns/resolver.go
+++ b/src/pkg/dns/resolver.go
@@ -169,6 +169,9 @@ func FindNSServers(ctx context.Context, domain string, resolverAt func(string) R
 }
 
 func DirectResolverAt(nsServer string) Resolver {
+	if nsServer == "" {
+		return RootResolver{}
+	}
 	return DirectResolver{NSServer: nsServer}
 }
 

--- a/src/pkg/dns/resolver_test.go
+++ b/src/pkg/dns/resolver_test.go
@@ -6,12 +6,8 @@ import (
 )
 
 func TestFindNSServer(t *testing.T) {
-	t.Cleanup(func() {
-		resolverAt = DirectResolverAt
-	})
-
 	t.Run("NS server not exist on domain", func(t *testing.T) {
-		resolverAt = func(nsServer string) Resolver {
+		resolverAt := func(nsServer string) Resolver {
 			if strings.Contains(nsServer, "root-servers.net") {
 				return MockResolver{Records: map[DNSRequest]DNSResponse{
 					{Type: "NS", Domain: "a.b.c.d"}: {Records: []string{"1.tld-servers.com", "2.tld-servers.com"}, Error: nil},
@@ -29,7 +25,7 @@ func TestFindNSServer(t *testing.T) {
 			return nil
 		}
 
-		ns, err := FindNSServers(t.Context(), "a.b.c.d")
+		ns, err := FindNSServers(t.Context(), "a.b.c.d", resolverAt)
 		if err != nil {
 			t.Errorf("Expected no error, got %v", err)
 		}
@@ -42,7 +38,7 @@ func TestFindNSServer(t *testing.T) {
 	})
 
 	t.Run("NS server exist on domain (delegarted apex domain)", func(t *testing.T) {
-		resolverAt = func(nsServer string) Resolver {
+		resolverAt := func(nsServer string) Resolver {
 			if strings.Contains(nsServer, "root-servers.net") {
 				return MockResolver{Records: map[DNSRequest]DNSResponse{
 					{Type: "NS", Domain: "a.b.c.d"}: {Records: []string{"1.tld-servers.com", "2.tld-servers.com"}, Error: nil},
@@ -64,7 +60,7 @@ func TestFindNSServer(t *testing.T) {
 			return nil
 		}
 
-		ns, err := FindNSServers(t.Context(), "a.b.c.d")
+		ns, err := FindNSServers(t.Context(), "a.b.c.d", resolverAt)
 		if err != nil {
 			t.Errorf("Expected no error, got %v", err)
 		}


### PR DESCRIPTION
## Summary

Replaces the global-mutable-state DNS wiring from the base branch with explicit dependency injection, and ensures every DNS lookup in the cert generation flow routes through the fabric resolver.

### Dependency injection

- Remove `UseFabricResolver`, `fabricClient`/`resolverAt` package vars, and `fabricMu`. The synchronization complexity those required is gone.
- `RootResolver` gains an optional `ResolverAt func(string) Resolver` field; a nil field falls back to `DirectResolverAt`.
- `FindNSServers`, `CheckDomainDNSReady`, and their helpers take an explicit `resolverAt func(string) Resolver` parameter.
- `ByocAws` carries a `fabricClient dns.FabricResolverClient` field; `PrepareDomainDelegation` builds its resolver closure from that field.
- `connect.go` no longer calls `dns.UseFabricResolver`; `NewProvider` and `cdCloudformationCmd` pass the gRPC client into `NewByocProvider`.
- `MockFabricClient` implements the three `Resolve*` methods.

### Complete fabric routing for cert generation

- `DirectResolverAt("")` returns `RootResolver{}` (recursive direct resolution), establishing `""` as the convention for "resolve from root." With a fabric `resolverAt`, `resolverAt("")` returns `FabricResolver{Client: c, NSServer: ""}` (server-side recursive resolution).
- `CheckDomainDNSReady` uses `resolverAt("")` for ALB and CNAME IP comparisons instead of a package-level `RootResolver{}`, so all lookups use the same resolver strategy.
- `cert.CheckTLSCert` accepts a `dns.Resolver` parameter.
- `cli/cert`: package-level `resolver`/`httpClient` globals replaced by `newCertHTTPClient(r dns.Resolver)`, which binds the resolver into the transport's `DialContext`. The resolver is threaded through `generateCert → triggerCertGeneration / waitForTLS / cert.CheckTLSCert`. `GenerateLetsEncryptCert` constructs `dns.FabricResolver{Client: client}` once and passes it down the call chain. `getWithRetries` takes an explicit `HTTPClient` parameter.

### Tests

- No more global-state saves/restores; each test passes its mock resolver directly.
- `TestGetWithRetries` passes the test client directly to `getWithRetries`.
- `TestHttpClient` uses `newCertHTTPClient(&mr)` to test DNS-caching behavior.

## Test plan

- [ ] `cd src && go test -short -race ./...` — all green
- [ ] `cd src && make lint` — 0 issues
- [ ] Verify `defang cert gen` works end-to-end in an environment where UDP 53 is restricted