### PR TITLE
fix: warn when project or service name exceeds 16 characters

### DIFF
--- a/src/pkg/cli/compose/fixup.go
+++ b/src/pkg/cli/compose/fixup.go
@@ -43,6 +43,10 @@ func FixupServices(ctx context.Context, provider client.Provider, project *compo
 		accountInfo = &client.AccountInfo{}
 	}
 
+	if len(project.Name) > 16 {
+		term.Warnf("project name %q is longer than 16 characters, you may run into issues with resource name length", project.Name)
+	}
+
 	// Fixup any pseudo services (this might create port configs, which will affect service name replacement by ReplaceServiceNameWithDNS)
 	for _, svccfg := range project.Services {
 		repo := GetImageRepo(svccfg.Image)
@@ -66,6 +70,10 @@ func FixupServices(ctx context.Context, provider client.Provider, project *compo
 			if err := fixupMongoService(&svccfg, provider, upload); err != nil {
 				return fmt.Errorf("service %q: %w", svccfg.Name, err)
 			}
+		}
+
+		if len(svccfg.Name) > 16 {
+			term.Warnf("service %q: service name is longer than 16 characters, you may run into issues with resource name length", svccfg.Name)
 		}
 
 		if svccfg.Provider != nil && svccfg.Provider.Type == "model" && svccfg.Image == "" && svccfg.Build == nil {

--- a/src/testdata/ambiguous-strings/compose.yaml.warnings
+++ b/src/testdata/ambiguous-strings/compose.yaml.warnings
@@ -1,2 +1,3 @@
+ ! project name "ambiguous-strings" is longer than 16 characters, you may run into issues with resource name length
  ! service "a": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors
  ! service "b": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors

--- a/src/testdata/compose-go-warn/compose.yaml.warnings
+++ b/src/testdata/compose-go-warn/compose.yaml.warnings
@@ -1,3 +1,4 @@
  ! "yes" for boolean is not supported by YAML 1.2, please use `true`
+ ! project name "compose-go-warning" is longer than 16 characters, you may run into issues with resource name length
  ! service "echo": ingress port 80 without healthcheck; defaults to GET / HTTP/1.1
  ! service "echo": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors

--- a/src/testdata/dockerfile-validation-errors/compose.yaml.warnings
+++ b/src/testdata/dockerfile-validation-errors/compose.yaml.warnings
@@ -1,2 +1,4 @@
+ ! project name "dockerfile-validation-errors" is longer than 16 characters, you may run into issues with resource name length
  ! service "invalid-dockerfile": ingress port 8080 without healthcheck; defaults to GET / HTTP/1.1
  ! service "invalid-dockerfile": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors
+ ! service "invalid-dockerfile": service name is longer than 16 characters, you may run into issues with resource name length

--- a/src/testdata/fixupenv/compose.yaml.warnings
+++ b/src/testdata/fixupenv/compose.yaml.warnings
@@ -3,7 +3,9 @@
  ! service "ingress-service": ingress port 5432 without healthcheck; defaults to GET / HTTP/1.1
  ! service "ingress-service": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors
  ! service "refer-self-build-arg": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors
+ ! service "refer-self-build-arg": service name is longer than 16 characters, you may run into issues with resource name length
  ! service "refer-self-env": ingress port 5678 without healthcheck; defaults to GET / HTTP/1.1
  ! service "refer-self-env": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors
  ! service "ui": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors
  ! service "use-ingress-service": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors
+ ! service "use-ingress-service": service name is longer than 16 characters, you may run into issues with resource name length

--- a/src/testdata/llm/compose.yaml.warnings
+++ b/src/testdata/llm/compose.yaml.warnings
@@ -1,5 +1,7 @@
  ! service "alt-repo": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors
  ! service "gateway-with-ports": ingress port 5678 without healthcheck; defaults to GET / HTTP/1.1
  ! service "gateway-with-ports": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors
+ ! service "gateway-with-ports": service name is longer than 16 characters, you may run into issues with resource name length
  ! service "gateway-without-ports": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors
+ ! service "gateway-without-ports": service name is longer than 16 characters, you may run into issues with resource name length
  ! service "llm": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors

--- a/src/testdata/longname/compose.yaml.warnings
+++ b/src/testdata/longname/compose.yaml.warnings
@@ -1,1 +1,2 @@
  ! service "aVeryLongServiceNameThatIsDefinitelyTooLongThatWillCauseAnError": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors
+ ! service "aVeryLongServiceNameThatIsDefinitelyTooLongThatWillCauseAnError": service name is longer than 16 characters, you may run into issues with resource name length

--- a/src/testdata/mongo/compose.yaml.warnings
+++ b/src/testdata/mongo/compose.yaml.warnings
@@ -15,5 +15,6 @@
  ! service "mongo-unmanaged": stateful service will lose data on restart; use a managed service instead
  ! service "mongo-wrong-image": managed MongoDB service should use a mongo image
  ! service "mongo-wrong-image": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors
+ ! service "mongo-wrong-image": service name is longer than 16 characters, you may run into issues with resource name length
  ! service "short-ports": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors
  ! service "short-ports": stateful service will lose data on restart; use a managed service instead

--- a/src/testdata/networks/compose.yaml.warnings
+++ b/src/testdata/networks/compose.yaml.warnings
@@ -5,3 +5,4 @@
  ! service "service-private": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors
  ! service "service-public": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors
  ! service "service-public-list": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors
+ ! service "service-public-list": service name is longer than 16 characters, you may run into issues with resource name length

--- a/src/testdata/ports/compose.yaml.warnings
+++ b/src/testdata/ports/compose.yaml.warnings
@@ -15,3 +15,4 @@
  ! service "short-published": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors
  ! service "short-udp": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors
  ! service "short-udp-published": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors
+ ! service "short-udp-published": service name is longer than 16 characters, you may run into issues with resource name length

--- a/src/testdata/postgres/compose.yaml.warnings
+++ b/src/testdata/postgres/compose.yaml.warnings
@@ -2,6 +2,7 @@
  ! service "no-ext": stateful service will lose data on restart; use a managed service instead
  ! service "no-ports": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors
  ! service "no-ports-override": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors
+ ! service "no-ports-override": service name is longer than 16 characters, you may run into issues with resource name length
  ! service "short-ports": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors
  ! service "with-ext": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors
  ! service "wrong-image": managed Postgres service should use a postgres image

--- a/src/testdata/railpack/compose.yaml.warnings
+++ b/src/testdata/railpack/compose.yaml.warnings
@@ -1,3 +1,4 @@
  ! service "railpack-long": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors
  ! service "railpack-short": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors
  ! service "railpackwithdockerfile": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors
+ ! service "railpackwithdockerfile": service name is longer than 16 characters, you may run into issues with resource name length

--- a/src/testdata/redis/compose.yaml.warnings
+++ b/src/testdata/redis/compose.yaml.warnings
@@ -2,6 +2,7 @@
  ! service "no-ext": stateful service will lose data on restart; use a managed service instead
  ! service "no-ports": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors
  ! service "no-ports-override": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors
+ ! service "no-ports-override": service name is longer than 16 characters, you may run into issues with resource name length
  ! service "short-ports": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors
  ! service "valkey-service": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors
  ! service "with-ext": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors


### PR DESCRIPTION
## Description

<!-- Concise description of what this PR is tackling. -->

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [ ] I have performed a self-review of my code
- [x] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added warnings when project and service names exceed 16 characters to alert users of potential resource naming issues.

* **Tests**
  * Updated test fixtures to reflect new name-length validation warnings across multiple compose configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->