### PR TITLE
Enable azure local cd running for debug

### DIFF
--- a/src/pkg/cli/client/byoc/azure/byoc.go
+++ b/src/pkg/cli/client/byoc/azure/byoc.go
@@ -408,6 +408,7 @@ func (b *ByocAzure) deploy(ctx context.Context, req *client.DeployRequest, verb 
 	if err != nil {
 		return nil, err
 	}
+	envMap["DEFANG_ETAG"] = etag // matches aws/byoc.go:549 — CD reads this for tags/revision suffix
 	if err := b.setUpJob(ctx, envMap); err != nil {
 		return nil, err
 	}
@@ -432,6 +433,23 @@ func (b *ByocAzure) deploy(ctx context.Context, req *client.DeployRequest, verb 
 			return nil, fmt.Errorf("unexpected status code during upload: %s", resp.Status)
 		}
 		payload = defanghttp.RemoveQueryParam(uploadURL) // managed identity provides blob read access
+	}
+
+	if os.Getenv("DEFANG_PULUMI_DIR") != "" {
+		// Run the cd binary locally from $DEFANG_PULUMI_DIR/cd instead of
+		// starting it as a Container Apps Job. Useful for iterating on cd
+		// code without rebuilding/pushing the cd image. Authentication uses
+		// the host's az login chain (DefaultAzureCredential).
+		debugEnv := []string{
+			"AZURE_LOCATION=" + b.driver.Location.String(),
+			"AZURE_SUBSCRIPTION_ID=" + b.driver.SubscriptionID,
+		}
+		for k, v := range envMap {
+			debugEnv = append(debugEnv, k+"="+v)
+		}
+		if err := byoc.DebugPulumiCD(ctx, debugEnv, verb, payload); err != nil {
+			return nil, err
+		}
 	}
 
 	execName, err := b.job.StartJobExecution(ctx, aca.JobRequest{

--- a/src/pkg/cli/client/byoc/common.go
+++ b/src/pkg/cli/client/byoc/common.go
@@ -77,6 +77,39 @@ func DebugPulumiNodeJS(ctx context.Context, env []string, cmd ...string) error {
 	return ErrLocalPulumiStopped
 }
 
+// DebugPulumiCD runs the multi-cloud cd binary (pulumi-defang/cd) locally
+// instead of starting it as a cloud task. Gated on DEFANG_PULUMI_DIR pointing
+// at the pulumi-defang repo root. Used to iterate on cd code without
+// rebuilding/pushing the cd container image.
+func DebugPulumiCD(ctx context.Context, env []string, cmd ...string) error {
+	localCmd := append([]string{"go", "run", "."}, cmd...)
+	term.Debug(strings.Join(append(env, localCmd...), " "))
+
+	dir := os.Getenv("DEFANG_PULUMI_DIR")
+	if dir == "" {
+		return nil
+	}
+
+	gopath, err := exec.Command("go", "env", "GOPATH").Output()
+	if err != nil {
+		return err
+	}
+
+	// Append host-side vars LAST so they override anything in env that's
+	// container-specific (HOME=/root from buildCdEnv would break go's build
+	// cache; PATH from the container image isn't on the host).
+	env = append(env,
+		"PATH="+os.Getenv("PATH"),
+		"HOME="+os.Getenv("HOME"),
+		"USER="+pkg.GetCurrentUser(),
+		"GOPATH="+strings.TrimSpace(string(gopath)),
+	)
+	if err := runLocalCommand(ctx, filepath.Join(dir, "cd"), env, localCmd...); err != nil {
+		return err
+	}
+	return ErrLocalPulumiStopped
+}
+
 func DebugPulumiGolang(ctx context.Context, env []string, cmd ...string) error {
 	localCmd := append([]string{"go", "run", "./..."}, cmd...)
 	term.Debug(strings.Join(append(env, localCmd...), " "))

--- a/src/pkg/cli/client/byoc/common_test.go
+++ b/src/pkg/cli/client/byoc/common_test.go
@@ -1,6 +1,7 @@
 package byoc
 
 import (
+	"errors"
 	"os"
 	"testing"
 )
@@ -79,6 +80,29 @@ func TestGetPulumiBackend(t *testing.T) {
 				t.Errorf("GetPulumiBackend() value = %v, want %v", v, tt.wantValue)
 			}
 		})
+	}
+}
+
+func TestDebugPulumiCDNoDir(t *testing.T) {
+	t.Setenv("DEFANG_PULUMI_DIR", "")
+	if err := DebugPulumiCD(t.Context(), nil, "up", "payload"); err != nil {
+		t.Errorf("DebugPulumiCD with empty DEFANG_PULUMI_DIR should return nil, got %v", err)
+	}
+}
+
+func TestDebugPulumiCDBadDir(t *testing.T) {
+	// Point at a path that exists but isn't a Go module — `go run .` will fail
+	// and the returned error should propagate. The key invariant: when
+	// DEFANG_PULUMI_DIR is set, DebugPulumiCD always returns a non-nil error
+	// (either ErrLocalPulumiStopped on success or the runLocalCommand error).
+	dir := t.TempDir()
+	t.Setenv("DEFANG_PULUMI_DIR", dir)
+	err := DebugPulumiCD(t.Context(), []string{"FOO=bar"}, "up", "payload")
+	if err == nil {
+		t.Fatal("DebugPulumiCD should return an error when go run fails")
+	}
+	if errors.Is(err, ErrLocalPulumiStopped) {
+		t.Errorf("DebugPulumiCD should not signal success for a bogus dir, got %v", err)
 	}
 }
 

--- a/src/pkg/clouds/azure/keyvault/keyvault.go
+++ b/src/pkg/clouds/azure/keyvault/keyvault.go
@@ -328,9 +328,16 @@ func (kv *KeyVault) PutSecret(ctx context.Context, name, value, originalKey stri
 
 // retryOnForbiddenByRbac retries op with exponential backoff while it fails
 // with 403 ForbiddenByRbac — the canonical signature of a freshly-assigned
-// Key Vault role that hasn't propagated yet. Gives up after ~60s total.
+// Key Vault role that hasn't propagated to the data plane yet. Gives up
+// after ~120s total.
+//
+// Detection: Key Vault returns top-level error.code="Forbidden" with
+// error.innererror.code="ForbiddenByRbac". azcore extracts the *top-level*
+// code into ResponseError.ErrorCode, so we can't rely on that field — the
+// actionable signal is in the response body, which lands in err.Error().
 func retryOnForbiddenByRbac(ctx context.Context, op func(context.Context) error) error {
-	const maxAttempts = 6
+	const maxAttempts = 8
+	const maxDelay = 30 * time.Second
 	delay := 2 * time.Second
 	for attempt := 0; ; attempt++ {
 		err := op(ctx)
@@ -338,7 +345,10 @@ func retryOnForbiddenByRbac(ctx context.Context, op func(context.Context) error)
 			return nil
 		}
 		var respErr *azcore.ResponseError
-		if !errors.As(err, &respErr) || respErr.ErrorCode != "ForbiddenByRbac" || attempt >= maxAttempts-1 {
+		retryable := errors.As(err, &respErr) &&
+			respErr.StatusCode == 403 &&
+			strings.Contains(err.Error(), "ForbiddenByRbac")
+		if !retryable || attempt >= maxAttempts-1 {
 			return err
 		}
 		term.Debugf("Key Vault returned ForbiddenByRbac (likely RBAC propagation), retrying in %s (attempt %d/%d)", delay, attempt+1, maxAttempts)
@@ -348,6 +358,9 @@ func retryOnForbiddenByRbac(ctx context.Context, op func(context.Context) error)
 		case <-time.After(delay):
 		}
 		delay *= 2
+		if delay > maxDelay {
+			delay = maxDelay
+		}
 	}
 }
 

--- a/src/pkg/clouds/azure/keyvault/keyvault_test.go
+++ b/src/pkg/clouds/azure/keyvault/keyvault_test.go
@@ -3,6 +3,9 @@ package keyvault
 import (
 	"context"
 	"encoding/base64"
+	"errors"
+	"io"
+	"net/http"
 	"strings"
 	"testing"
 	"time"
@@ -154,6 +157,119 @@ func TestPutDeleteListSecretNotSetUp(t *testing.T) {
 	if _, err := kv.ListSecrets(context.Background(), "prefix"); err == nil {
 		t.Error("ListSecrets should fail when vault not set up")
 	}
+}
+
+// makeResponseError builds an *azcore.ResponseError whose Error() message
+// embeds the given response body. retryOnForbiddenByRbac inspects err.Error()
+// to detect ForbiddenByRbac in the inner-error JSON, so the body must be set.
+func makeResponseError(t *testing.T, status int, body string) *azcore.ResponseError {
+	t.Helper()
+	return &azcore.ResponseError{
+		ErrorCode:  "Forbidden",
+		StatusCode: status,
+		RawResponse: &http.Response{
+			StatusCode: status,
+			Status:     http.StatusText(status),
+			Body:       io.NopCloser(strings.NewReader(body)),
+		},
+	}
+}
+
+func TestRetryOnForbiddenByRbac(t *testing.T) {
+	const forbiddenBody = `{"error":{"code":"Forbidden","innererror":{"code":"ForbiddenByRbac"}}}`
+	const otherForbiddenBody = `{"error":{"code":"Forbidden","message":"some other reason"}}`
+
+	t.Run("success on first try", func(t *testing.T) {
+		calls := 0
+		err := retryOnForbiddenByRbac(t.Context(), func(context.Context) error {
+			calls++
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if calls != 1 {
+			t.Errorf("calls = %d, want 1", calls)
+		}
+	})
+
+	t.Run("non-azcore error returned as-is, no retry", func(t *testing.T) {
+		want := errors.New("plain error")
+		calls := 0
+		err := retryOnForbiddenByRbac(t.Context(), func(context.Context) error {
+			calls++
+			return want
+		})
+		if !errors.Is(err, want) {
+			t.Errorf("err = %v, want %v", err, want)
+		}
+		if calls != 1 {
+			t.Errorf("calls = %d, want 1 (should not retry)", calls)
+		}
+	})
+
+	t.Run("non-403 ResponseError returned as-is, no retry", func(t *testing.T) {
+		respErr := makeResponseError(t, 500, forbiddenBody) // body says ForbiddenByRbac, but status is 500
+		calls := 0
+		err := retryOnForbiddenByRbac(t.Context(), func(context.Context) error {
+			calls++
+			return respErr
+		})
+		if !errors.Is(err, respErr) {
+			t.Errorf("err = %v, want %v", err, respErr)
+		}
+		if calls != 1 {
+			t.Errorf("calls = %d, want 1 (non-403 should not retry)", calls)
+		}
+	})
+
+	t.Run("403 without ForbiddenByRbac returned as-is, no retry", func(t *testing.T) {
+		respErr := makeResponseError(t, 403, otherForbiddenBody)
+		calls := 0
+		err := retryOnForbiddenByRbac(t.Context(), func(context.Context) error {
+			calls++
+			return respErr
+		})
+		if !errors.Is(err, respErr) {
+			t.Errorf("err = %v, want %v", err, respErr)
+		}
+		if calls != 1 {
+			t.Errorf("calls = %d, want 1 (403 without ForbiddenByRbac should not retry)", calls)
+		}
+	})
+
+	t.Run("retries 403 ForbiddenByRbac then succeeds", func(t *testing.T) {
+		calls := 0
+		err := retryOnForbiddenByRbac(t.Context(), func(context.Context) error {
+			calls++
+			if calls == 1 {
+				return makeResponseError(t, 403, forbiddenBody)
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if calls != 2 {
+			t.Errorf("calls = %d, want 2 (one failure then success)", calls)
+		}
+	})
+
+	t.Run("context cancellation aborts retry", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(t.Context())
+		calls := 0
+		err := retryOnForbiddenByRbac(ctx, func(context.Context) error {
+			calls++
+			cancel() // cancel before the function sleeps
+			return makeResponseError(t, 403, forbiddenBody)
+		})
+		if !errors.Is(err, context.Canceled) {
+			t.Errorf("err = %v, want context.Canceled", err)
+		}
+		if calls != 1 {
+			t.Errorf("calls = %d, want 1 (cancel should stop retries)", calls)
+		}
+	})
 }
 
 func TestObjectIDFromJWT(t *testing.T) {


### PR DESCRIPTION
## Description

- Enable azure local cd running for debug
- Pass etag as env for azure
- Wait longer for key vault to be ready

## Checklist

- [X] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deployment etag is now injected into the CD environment for improved tagging/revision tracking.
  * Local Pulumi CD execution option added to run the CD binary locally for debugging.

* **Bug Fixes**
  * Key Vault RBAC retry logic improved with better detection, a longer retry window, and capped backoff.

* **Tests**
  * Added tests covering local CD debugging and RBAC retry scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->