### PR TITLE
Use the standard prefix instead of lower case

### DIFF
--- a/src/pkg/cli/client/byoc/azure/byoc.go
+++ b/src/pkg/cli/client/byoc/azure/byoc.go
@@ -215,7 +215,7 @@ func (b *ByocAzure) setUpLocation() error {
 // Format: defang-{project}-{stack}-{location}, e.g. "defang-myapp-test-westus2".
 // This group is owned by one project+stack and is separate from the shared CD resource group.
 func (b *ByocAzure) projectResourceGroupName(projectName string) string {
-	return "defang-" + projectName + "-" + b.PulumiStack
+	return b.Prefix + "-" + projectName + "-" + b.PulumiStack
 }
 
 // findForConfig binds to a pre-existing project Key Vault without creating

--- a/src/pkg/cli/client/byoc/azure/byoc_test.go
+++ b/src/pkg/cli/client/byoc/azure/byoc_test.go
@@ -86,7 +86,7 @@ func TestProjectResourceGroupName(t *testing.T) {
 		t.Fatalf("setUpLocation: %v", err)
 	}
 	got := b.projectResourceGroupName("myapp")
-	want := "defang-myapp-test-stack"
+	want := "Defang-myapp-test-stack"
 	if got != want {
 		t.Errorf("projectResourceGroupName = %q, want %q", got, want)
 	}


### PR DESCRIPTION
## Description
Use the standard prefix instead of lower case

## Checklist

- [X] I have performed a self-review of my code
- [X] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Azure resource group naming to use a configurable prefix pattern instead of a fixed naming scheme, ensuring consistent resource organization across deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->