### PR TITLE
Do not add defang- prefix to azure keyvault

### DIFF
--- a/src/pkg/clouds/azure/keyvault/keyvault.go
+++ b/src/pkg/clouds/azure/keyvault/keyvault.go
@@ -32,7 +32,7 @@ const keyVaultSecretsOfficerRoleID = "b86a8fe4-44ce-4948-aee5-eccb2c155cd7" // n
 func VaultName(resourceGroupName, subscriptionID string) string {
 	h := sha256.Sum256([]byte(subscriptionID + "|" + resourceGroupName))
 	suffix := hex.EncodeToString(h[:])[:vaultNameSuffixLen]
-	name := "defang-config-" + suffix
+	name := "config-" + suffix
 	return name
 }
 

--- a/src/pkg/clouds/azure/keyvault/keyvault_test.go
+++ b/src/pkg/clouds/azure/keyvault/keyvault_test.go
@@ -38,8 +38,8 @@ func useFakeCred(t *testing.T, tok string, gerr error) {
 
 func TestVaultName(t *testing.T) {
 	name := VaultName("my-rg", "sub-id")
-	if !strings.HasPrefix(name, "defang-config-") {
-		t.Errorf("VaultName = %q, want defang-config- prefix", name)
+	if !strings.HasPrefix(name, "config-") {
+		t.Errorf("VaultName = %q, want config- prefix", name)
 	}
 	if len(name) > 24 {
 		t.Errorf("VaultName %q exceeds 24 chars", name)


### PR DESCRIPTION
https://github.com/DefangLabs/pulumi-defang/issues/207Do not add defang- prefix to azure keyvault

## Linked Issues
https://github.com/DefangLabs/pulumi-defang/issues/207

## Checklist

- [X] I have performed a self-review of my code
- [X] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Azure Key Vault naming convention. Vault name prefixes have been simplified to reflect the new naming standard.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->