### PR TITLE
Use simple kv key names since we use per project-stack key vault

### DIFF
--- a/src/pkg/cli/client/byoc/azure/byoc.go
+++ b/src/pkg/cli/client/byoc/azure/byoc.go
@@ -211,8 +211,7 @@ func (b *ByocAzure) DeleteConfig(ctx context.Context, secrets *defangv1.Secrets)
 		return nil // nothing configured yet, nothing to delete
 	}
 	for _, name := range secrets.Names {
-		key := b.StackDir(secrets.Project, name)
-		secretName := keyvault.ToSecretName(key)
+		secretName := keyvault.ToSecretName(name)
 		term.Debugf("Deleting Key Vault secret %q", secretName)
 		if err := b.kv.DeleteSecret(ctx, secretName); err != nil {
 			return fmt.Errorf("failed to delete Key Vault secret %q: %w", name, err)
@@ -652,8 +651,9 @@ func (b *ByocAzure) GetServices(ctx context.Context, req *defangv1.GetServicesRe
 }
 
 // ListConfig implements client.Provider. Read-only: when the project's
-// App Configuration store or Key Vault hasn't been provisioned yet, returns
-// an empty list instead of creating them.
+// Key Vault hasn't been provisioned yet, returns an empty list instead of
+// creating it. The vault is per-project-stack, so every secret in it belongs
+// to this project — no prefix filtering is needed.
 func (b *ByocAzure) ListConfig(ctx context.Context, req *defangv1.ListConfigsRequest) (*defangv1.Secrets, error) {
 	defer term.Timing()()
 	found, err := b.findForConfig(ctx, req.Project)
@@ -663,19 +663,19 @@ func (b *ByocAzure) ListConfig(ctx context.Context, req *defangv1.ListConfigsReq
 	if !found {
 		return &defangv1.Secrets{}, nil // nothing configured yet
 	}
-	prefix := b.StackDir(req.Project, "")
-	secretPrefix := keyvault.ToSecretName(prefix)
-	term.Debugf("Listing Key Vault secrets with prefix %q (sanitized: %q)", prefix, secretPrefix)
-	entries, err := b.kv.ListSecrets(ctx, secretPrefix)
+	entries, err := b.kv.ListSecrets(ctx, "")
 	if err != nil {
 		return nil, err
 	}
 	names := make([]string, 0, len(entries))
 	for _, e := range entries {
-		if e.OriginalKey == "" || !strings.HasPrefix(e.OriginalKey, prefix) {
-			continue
+		// Prefer the original-key tag (preserves underscores) but fall back to
+		// the secret name if the tag is missing for any reason.
+		if e.OriginalKey != "" {
+			names = append(names, e.OriginalKey)
+		} else {
+			names = append(names, e.Name)
 		}
-		names = append(names, strings.TrimPrefix(e.OriginalKey, prefix))
 	}
 	return &defangv1.Secrets{Names: names}, nil
 }
@@ -697,10 +697,9 @@ func (b *ByocAzure) PutConfig(ctx context.Context, req *defangv1.PutConfigReques
 	if err := b.setUpForConfig(ctx, req.Project); err != nil {
 		return err
 	}
-	key := b.StackDir(req.Project, req.Name)
-	secretName := keyvault.ToSecretName(key)
-	term.Debugf("Putting Key Vault secret %q (original key %q)", secretName, key)
-	if err := b.kv.PutSecret(ctx, secretName, req.Value, key); err != nil {
+	secretName := keyvault.ToSecretName(req.Name)
+	term.Debugf("Putting Key Vault secret %q (original key %q)", secretName, req.Name)
+	if err := b.kv.PutSecret(ctx, secretName, req.Value, req.Name); err != nil {
 		return fmt.Errorf("failed to put Key Vault secret: %w", err)
 	}
 	return nil

--- a/src/pkg/cli/client/byoc/azure/byoc.go
+++ b/src/pkg/cli/client/byoc/azure/byoc.go
@@ -669,8 +669,8 @@ func (b *ByocAzure) ListConfig(ctx context.Context, req *defangv1.ListConfigsReq
 	}
 	names := make([]string, 0, len(entries))
 	for _, e := range entries {
-		// Prefer the original-key tag (preserves underscores) but fall back to
-		// the secret name if the tag is missing for any reason.
+		// Prefer the defang-config tag (preserves underscores) but fall
+		// back to the secret name if the tag is missing for any reason.
 		if e.OriginalKey != "" {
 			names = append(names, e.OriginalKey)
 		} else {

--- a/src/pkg/clouds/azure/keyvault/keyvault.go
+++ b/src/pkg/clouds/azure/keyvault/keyvault.go
@@ -316,7 +316,7 @@ func (kv *KeyVault) PutSecret(ctx context.Context, name, value, originalKey stri
 	params := azsecrets.SetSecretParameters{
 		Value: to.Ptr(value),
 		Tags: map[string]*string{
-			"original-key": to.Ptr(originalKey),
+			"defang-config": to.Ptr(originalKey),
 		},
 	}
 	return retryOnForbiddenByRbac(ctx, func(ctx context.Context) error {
@@ -388,7 +388,7 @@ type SecretEntry struct {
 }
 
 // ListSecrets returns secrets whose names start with the given prefix.
-// It uses the "original-key" tag to recover the original config key name.
+// It uses the "defang-config" tag to recover the original config key name.
 func (kv *KeyVault) ListSecrets(ctx context.Context, prefix string) ([]SecretEntry, error) {
 	client, err := kv.newSecretsClient()
 	if err != nil {
@@ -414,7 +414,7 @@ func (kv *KeyVault) ListSecrets(ctx context.Context, prefix string) ([]SecretEnt
 				}
 				entry := SecretEntry{Name: name}
 				if props.Tags != nil {
-					if orig, ok := props.Tags["original-key"]; ok && orig != nil {
+					if orig, ok := props.Tags["defang-config"]; ok && orig != nil {
 						entry.OriginalKey = *orig
 					}
 				}

--- a/src/pkg/clouds/azure/keyvault/keyvault.go
+++ b/src/pkg/clouds/azure/keyvault/keyvault.go
@@ -41,13 +41,12 @@ func VaultURL(vaultName string) string {
 	return "https://" + vaultName + ".vault.azure.net"
 }
 
-// ToSecretName converts a config key path (e.g. "/Defang/myapp/test/POSTGRES_PASSWORD")
-// to a Key Vault-safe secret name. Slashes become "--", underscores become "-".
+// ToSecretName converts a config key (e.g. "POSTGRES_PASSWORD") to a Key
+// Vault-safe secret name. The vault is per-project-stack, so no prefix is
+// added; only underscores need to be replaced (Key Vault names allow only
+// alphanumeric characters and dashes).
 func ToSecretName(key string) string {
-	key = strings.TrimPrefix(key, "/")
-	key = strings.ReplaceAll(key, "/", "--")
-	key = strings.ReplaceAll(key, "_", "-")
-	return key
+	return strings.ReplaceAll(key, "_", "-")
 }
 
 // KeyVault wraps an Azure Key Vault for storing project config secrets.

--- a/src/pkg/clouds/azure/keyvault/keyvault_test.go
+++ b/src/pkg/clouds/azure/keyvault/keyvault_test.go
@@ -71,10 +71,9 @@ func TestToSecretName(t *testing.T) {
 	}{
 		{"", ""},
 		{"FOO", "FOO"},
-		{"/Defang", "Defang"},
-		{"/Defang/myapp/test/POSTGRES_PASSWORD", "Defang--myapp--test--POSTGRES-PASSWORD"},
+		{"POSTGRES_PASSWORD", "POSTGRES-PASSWORD"},
+		{"DB_USER_PASSWORD", "DB-USER-PASSWORD"},
 		{"foo_bar", "foo-bar"},
-		{"foo/bar", "foo--bar"},
 	}
 	for _, tt := range tests {
 		if got := ToSecretName(tt.in); got != tt.want {

--- a/src/pkg/clouds/azure/keyvault/keyvault_test.go
+++ b/src/pkg/clouds/azure/keyvault/keyvault_test.go
@@ -271,6 +271,65 @@ func TestRetryOnForbiddenByRbac(t *testing.T) {
 	})
 }
 
+func TestCurrentUserOID(t *testing.T) {
+	kv := New("rg", azure.Azure{Location: azure.LocationWestUS2, SubscriptionID: "sub"})
+
+	t.Run("token error returns empty", func(t *testing.T) {
+		cred := fakeCred{err: errors.New("denied")}
+		if got := kv.currentUserOID(t.Context(), cred); got != "" {
+			t.Errorf("currentUserOID = %q, want empty on token error", got)
+		}
+	})
+
+	t.Run("valid token returns oid", func(t *testing.T) {
+		payload := base64.RawURLEncoding.EncodeToString([]byte(`{"oid":"caller-oid"}`))
+		cred := fakeCred{tok: "h." + payload + ".s"}
+		if got := kv.currentUserOID(t.Context(), cred); got != "caller-oid" {
+			t.Errorf("currentUserOID = %q, want caller-oid", got)
+		}
+	})
+
+	t.Run("token without oid returns empty", func(t *testing.T) {
+		payload := base64.RawURLEncoding.EncodeToString([]byte(`{"sub":"x"}`))
+		cred := fakeCred{tok: "h." + payload + ".s"}
+		if got := kv.currentUserOID(t.Context(), cred); got != "" {
+			t.Errorf("currentUserOID = %q, want empty when oid claim missing", got)
+		}
+	})
+}
+
+func TestWrapRoleAssignmentError(t *testing.T) {
+	kv := New("rg", azure.Azure{Location: azure.LocationWestUS2, SubscriptionID: "sub-id"})
+	inner := errors.New("forbidden")
+	vaultID := "/subscriptions/sub-id/resourceGroups/rg/providers/Microsoft.KeyVault/vaults/v"
+
+	t.Run("with oid from token", func(t *testing.T) {
+		payload := base64.RawURLEncoding.EncodeToString([]byte(`{"oid":"caller-oid"}`))
+		cred := fakeCred{tok: "h." + payload + ".s"}
+		err := kv.wrapRoleAssignmentError(t.Context(), cred, vaultID, inner)
+		if !errors.Is(err, inner) {
+			t.Errorf("wrapped error should preserve inner: got %v", err)
+		}
+		if !strings.Contains(err.Error(), "caller-oid") {
+			t.Errorf("error should embed oid; got: %s", err.Error())
+		}
+		if !strings.Contains(err.Error(), "sub-id") {
+			t.Errorf("error should embed subscription ID; got: %s", err.Error())
+		}
+		if !strings.Contains(err.Error(), vaultID) {
+			t.Errorf("error should embed vault resource ID; got: %s", err.Error())
+		}
+	})
+
+	t.Run("falls back to placeholder when oid unavailable", func(t *testing.T) {
+		cred := fakeCred{err: errors.New("denied")}
+		err := kv.wrapRoleAssignmentError(t.Context(), cred, vaultID, inner)
+		if !strings.Contains(err.Error(), "<your-object-id>") {
+			t.Errorf("error should use placeholder when oid unavailable; got: %s", err.Error())
+		}
+	})
+}
+
 func TestObjectIDFromJWT(t *testing.T) {
 	// Build a fake JWT with {"oid":"test-oid-value"} payload.
 	payload := `{"sub":"x","oid":"test-oid-value","aud":"y"}`


### PR DESCRIPTION
## Description

<!-- Concise description of what this PR is tackling. -->

## Linked Issues
Requires to work with https://github.com/DefangLabs/pulumi-defang/pull/226
<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [X] I have performed a self-review of my code
- [X] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Azure Key Vault secret naming: underscores are now converted to hyphens.
  * Key Vault is ensured/initialized before storing or deleting config secrets.
  * Config listing now returns original config names when available.
  * Role-assignment errors surface clearer object-id/subscription/vault info when possible.

* **Refactor**
  * Simplified secret name transformation and how original keys are recorded for retrieval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->