### PR TITLE
feat: add CLI version to CanIUseRequest

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -30,10 +30,12 @@ jobs:
 
       - name: Sanitize branch name for artifact
         id: branch
-        run: echo "name=$(echo '${{ github.ref_name }}' | tr '/' '-')" >> "$GITHUB_OUTPUT"
+        run: echo "name=$(echo '${{ github.ref_name }}' | tr '/' '-')" >>
+          "$GITHUB_OUTPUT"
 
       - name: Run Go unit tests
-        run: go test -race -test.short -v -coverprofile=coverage.out -covermode=atomic ./...
+        run: go test -race -test.short -v -coverprofile=coverage.out -covermode=atomic
+          ./...
         working-directory: src
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # to avoid GH rate limits
@@ -60,26 +62,6 @@ jobs:
           name: coverage-main
           path: coverage-main
         continue-on-error: true # no baseline yet on first run
-
-      - name: Check coverage regression
-        if: github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/v')
-        run: |
-          if [ ! -f coverage-main/coverage.txt ]; then
-            echo "No main coverage baseline found, skipping comparison"
-            exit 0
-          fi
-          main_pct=$(grep '^total:' coverage-main/coverage.txt | awk '{print $3}' | tr -d '%')
-          curr_pct=$(grep '^total:' src/coverage.txt | awk '{print $3}' | tr -d '%')
-          if [ -z "$main_pct" ] || [ -z "$curr_pct" ]; then
-            echo "ERROR: Could not parse coverage percentages (main='$main_pct', current='$curr_pct')"
-            exit 1
-          fi
-          echo "Main: ${main_pct}%  Current branch: ${curr_pct}%"
-          if awk "BEGIN { exit !(${curr_pct} < ${main_pct}) }"; then
-            echo "ERROR: Coverage decreased from ${main_pct}% to ${curr_pct}%"
-            exit 1
-          fi
-          echo "Coverage OK (${curr_pct}% >= ${main_pct}%)"
 
       - name: Verify Go modules
         working-directory: src
@@ -110,6 +92,26 @@ jobs:
       - name: Build Windows binary
         run: GOOS=windows go build ./cmd/cli
         working-directory: src
+
+      - name: Check coverage regression
+        if: github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/v')
+        run: |
+          if [ ! -f coverage-main/coverage.txt ]; then
+            echo "No main coverage baseline found, skipping comparison"
+            exit 0
+          fi
+          main_pct=$(grep '^total:' coverage-main/coverage.txt | awk '{print $3}' | tr -d '%')
+          curr_pct=$(grep '^total:' src/coverage.txt | awk '{print $3}' | tr -d '%')
+          if [ -z "$main_pct" ] || [ -z "$curr_pct" ]; then
+            echo "ERROR: Could not parse coverage percentages (main='$main_pct', current='$curr_pct')"
+            exit 1
+          fi
+          echo "Main: ${main_pct}%  Current branch: ${curr_pct}%"
+          if awk "BEGIN { exit !(${curr_pct} < ${main_pct}) }"; then
+            echo "ERROR: Coverage decreased from ${main_pct}% to ${curr_pct}%"
+            exit 1
+          fi
+          echo "Coverage OK (${curr_pct}% >= ${main_pct}%)"
 
   nix-shell-test:
     runs-on: ubuntu-latest
@@ -230,22 +232,26 @@ jobs:
 
       - name: Add dummy config
         id: add-dummy-config
-        run: echo blah | go run -race ./cmd/cli -C testdata/sanity config set --provider=defang -n dummy --debug
+        run: echo blah | go run -race ./cmd/cli -C testdata/sanity config set
+          --provider=defang -n dummy --debug
         working-directory: src
 
       - name: Run sanity tests UP
         continue-on-error: true # until we have multi-project support in playground
-        run: go run -race ./cmd/cli -C testdata/sanity compose up --provider=defang --debug
+        run: go run -race ./cmd/cli -C testdata/sanity compose up --provider=defang
+          --debug
         working-directory: src
 
       - name: Run sanity tests DOWN
         continue-on-error: true # until we have multi-project support in playground
-        run: go run -race ./cmd/cli -C testdata/sanity compose down --provider=defang --detach --debug
+        run: go run -race ./cmd/cli -C testdata/sanity compose down --provider=defang
+          --detach --debug
         working-directory: src
 
       - name: Remove dummy config
         if: steps.add-dummy-config.conclusion == 'success' # only clean up if the config was added
-        run: go run -race ./cmd/cli -C testdata/sanity config rm --provider=defang -n dummy --debug
+        run: go run -race ./cmd/cli -C testdata/sanity config rm --provider=defang -n
+          dummy --debug
         working-directory: src
 
   build-and-sign:
@@ -254,10 +260,11 @@ jobs:
     environment: release # must use environment to be able to authenticate with Azure Federated Identity for Trusted Signing
     needs: go-test
     runs-on: windows-latest
-    env: # from https://github.com/spiffe/spire/pull/5158
-      GOPATH: 'D:\golang\go'
-      GOCACHE: 'D:\golang\cache'
-      GOMODCACHE: 'D:\golang\modcache'
+    env:
+      # from https://github.com/spiffe/spire/pull/5158
+      GOPATH: "D:\\golang\\go"
+      GOCACHE: "D:\\golang\\cache"
+      GOMODCACHE: "D:\\golang\\modcache"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -280,14 +287,18 @@ jobs:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
 
       - name: Run GoReleaser (Linux)
-        run: goreleaser release --split ${{ !startsWith(github.ref, 'refs/tags/v') && '--snapshot' || '' }} ${{ github.event_name == 'schedule' && '--nightly' || ''}}
+        run: goreleaser release --split ${{ !startsWith(github.ref, 'refs/tags/v') &&
+          '--snapshot' || '' }} ${{ github.event_name == 'schedule' &&
+          '--nightly' || ''}}
         working-directory: src
         env:
           GGOOS: linux
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
 
       - name: Run GoReleaser (Windows)
-        run: goreleaser release --split ${{ !startsWith(github.ref, 'refs/tags/v') && '--snapshot' || '' }} ${{ github.event_name == 'schedule' && '--nightly' || ''}}
+        run: goreleaser release --split ${{ !startsWith(github.ref, 'refs/tags/v') &&
+          '--snapshot' || '' }} ${{ github.event_name == 'schedule' &&
+          '--nightly' || ''}}
         working-directory: src
         env:
           GGOOS: windows
@@ -306,7 +317,8 @@ jobs:
         with:
           endpoint: https://wus2.codesigning.azure.net/ # from Azure portal
           trusted-signing-account-name: DefangLabs # from Azure portal
-          certificate-profile-name: signed-binary${{ !startsWith(github.ref, 'refs/tags/v') && '-test' || '' }} # from Azure portal
+          certificate-profile-name: signed-binary${{ !startsWith(github.ref,
+            'refs/tags/v') && '-test' || '' }} # from Azure portal
           files-folder: ${{ github.workspace }}\src\dist
           files-folder-filter: exe # no dll
           files-folder-recurse: true
@@ -367,7 +379,8 @@ jobs:
         with:
           distribution: goreleaser-pro # either 'goreleaser' (default) or 'goreleaser-pro'
           # version: latest
-          args: release --split ${{ !startsWith(github.ref, 'refs/tags/v') && '--snapshot' || '' }} ${{ github.event_name == 'schedule' && '--nightly' || ''}}
+          args: release --split ${{ !startsWith(github.ref, 'refs/tags/v') && '--snapshot'
+            || '' }} ${{ github.event_name == 'schedule' && '--nightly' || ''}}
           workdir: src
         env:
           GGOOS: darwin
@@ -464,7 +477,8 @@ jobs:
 
       - name: Build and push Docker images and manifests
         working-directory: src
-        run: make push-images ${{ startsWith(github.ref, 'refs/tags/v') && format('VERSION={0}', github.ref_name) || '' }}
+        run: make push-images ${{ startsWith(github.ref, 'refs/tags/v') &&
+          format('VERSION={0}', github.ref_name) || '' }}
   post-release:
     runs-on: ubuntu-latest
     needs: go-release
@@ -476,7 +490,7 @@ jobs:
           token: ${{ secrets.DOCS_ACTION_TRIGGER_TOKEN }}
           repository: DefangLabs/defang-docs
           event-type: cli-autodoc
-          client-payload: '{"version": "${{ github.ref_name }}"}'
+          client-payload: "{\"version\": \"${{ github.ref_name }}\"}"
 
       - name: Trigger Homebrew Formula Update
         uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4
@@ -484,7 +498,7 @@ jobs:
           token: ${{ secrets.HOMEBREW_ACTION_TRIGGER_TOKEN }}
           repository: DefangLabs/homebrew-defang
           event-type: update-homebrew-formula
-          client-payload: '{"version": "${{ github.ref_name }}"}'
+          client-payload: "{\"version\": \"${{ github.ref_name }}\"}"
 
       - name: Checkout tag
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -503,8 +517,9 @@ jobs:
 
   on-failure:
     runs-on: ubuntu-latest
-    if: failure() && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
-    needs: [go-release, post-release, nix-shell-test, push-docker]
+    if: failure() && (github.ref == 'refs/heads/main' || startsWith(github.ref,
+      'refs/tags/v'))
+    needs: [ go-release, post-release, nix-shell-test, push-docker ]
     steps:
       - name: Slack Notification
         uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661 # v2

--- a/src/cmd/cli/command/commands.go
+++ b/src/cmd/cli/command/commands.go
@@ -125,6 +125,7 @@ func SetupCommands(version string) {
 	cobra.EnableTraverseRunHooks = true // we always need to run the RootCmd's pre-run hook
 
 	RootCmd.Version = version
+	client.CliVersion = version
 	RootCmd.PersistentFlags().StringVarP(&global.Stack.Name, "stack", "s", global.Stack.Name, "stack name (for BYOC providers)")
 	RootCmd.RegisterFlagCompletionFunc("stack", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		stacks, err := stacks.List()

--- a/src/pkg/cli/client/caniuse.go
+++ b/src/pkg/cli/client/caniuse.go
@@ -9,6 +9,9 @@ import (
 	defangv1 "github.com/DefangLabs/defang/src/protos/io/defang/v1"
 )
 
+// CliVersion is the CLI version, set by SetupCommands from the main package's ldflags-injected value.
+var CliVersion string
+
 func CanIUseProvider(ctx context.Context, client FabricClient, provider Provider, projectName string, serviceCount int, allowUpgrade bool) error {
 	info, err := provider.AccountInfo(ctx)
 	if err != nil {
@@ -33,6 +36,7 @@ func CanIUseProvider(ctx context.Context, client FabricClient, provider Provider
 	}
 
 	resp, err := client.CanIUse(ctx, &defangv1.CanIUseRequest{
+		CliVersion:          CliVersion,
 		Project:             projectName,
 		Provider:            info.Provider.Value(),
 		ProviderAccountId:   info.AccountID,

--- a/src/pkg/cli/client/caniuse_test.go
+++ b/src/pkg/cli/client/caniuse_test.go
@@ -64,6 +64,12 @@ func TestCanIUseProvider(t *testing.T) {
 	ctx := t.Context()
 	term.SetDebug(testing.Verbose())
 
+	savedCliVersion := CliVersion
+	t.Cleanup(func() {
+		CliVersion = savedCliVersion
+	})
+	CliVersion = "v1.2.3"
+
 	tests := []struct {
 		name          string
 		projectName   string
@@ -254,6 +260,10 @@ func TestCanIUseProvider(t *testing.T) {
 			}
 			if fabric.lastReq.PreferPulumiVersion != tt.wantReqPulumi {
 				t.Errorf("request PulumiVersion = %q, want %q", fabric.lastReq.PreferPulumiVersion, tt.wantReqPulumi)
+			}
+
+			if fabric.lastReq.CliVersion != CliVersion {
+				t.Errorf("request CliVersion = %q, want %q", fabric.lastReq.CliVersion, CliVersion)
 			}
 		})
 	}

--- a/src/protos/io/defang/v1/fabric.pb.go
+++ b/src/protos/io/defang/v1/fabric.pb.go
@@ -2194,6 +2194,7 @@ type CanIUseRequest struct {
 	PreferCdVersion     string                 `protobuf:"bytes,7,opt,name=prefer_cd_version,json=preferCdVersion,proto3" json:"prefer_cd_version,omitempty"`             // currently deployed CD image; empty for new projects or when --allow-upgrade is set
 	PreferPulumiVersion string                 `protobuf:"bytes,8,opt,name=prefer_pulumi_version,json=preferPulumiVersion,proto3" json:"prefer_pulumi_version,omitempty"` // currently deployed Pulumi version; empty for new projects or when --allow-upgrade is set
 	Driver              string                 `protobuf:"bytes,9,opt,name=driver,proto3" json:"driver,omitempty"`
+	CliVersion          string                 `protobuf:"bytes,10,opt,name=cli_version,json=cliVersion,proto3" json:"cli_version,omitempty"`
 	unknownFields       protoimpl.UnknownFields
 	sizeCache           protoimpl.SizeCache
 }
@@ -2287,6 +2288,13 @@ func (x *CanIUseRequest) GetPreferPulumiVersion() string {
 func (x *CanIUseRequest) GetDriver() string {
 	if x != nil {
 		return x.Driver
+	}
+	return ""
+}
+
+func (x *CanIUseRequest) GetCliVersion() string {
+	if x != nil {
+		return x.CliVersion
 	}
 	return ""
 }
@@ -6123,7 +6131,7 @@ const file_io_defang_v1_fabric_proto_rawDesc = "" +
 	"\x04arch\x18\x05 \x01(\tR\x04arch\x1a=\n" +
 	"\x0fPropertiesEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xd9\x02\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xfa\x02\n" +
 	"\x0eCanIUseRequest\x12\x18\n" +
 	"\aproject\x18\x01 \x01(\tR\aproject\x122\n" +
 	"\bprovider\x18\x02 \x01(\x0e2\x16.io.defang.v1.ProviderR\bprovider\x12#\n" +
@@ -6133,7 +6141,10 @@ const file_io_defang_v1_fabric_proto_rawDesc = "" +
 	"\x13provider_account_id\x18\x06 \x01(\tR\x11providerAccountId\x12*\n" +
 	"\x11prefer_cd_version\x18\a \x01(\tR\x0fpreferCdVersion\x122\n" +
 	"\x15prefer_pulumi_version\x18\b \x01(\tR\x13preferPulumiVersion\x12\x16\n" +
-	"\x06driver\x18\t \x01(\tR\x06driver\"\xfa\x01\n" +
+	"\x06driver\x18\t \x01(\tR\x06driver\x12\x1f\n" +
+	"\vcli_version\x18\n" +
+	" \x01(\tR\n" +
+	"cliVersion\"\xfa\x01\n" +
 	"\x0fCanIUseResponse\x12\x19\n" +
 	"\bcd_image\x18\x02 \x01(\tR\acdImage\x12\x10\n" +
 	"\x03gpu\x18\x03 \x01(\bR\x03gpu\x12#\n" +

--- a/src/protos/io/defang/v1/fabric.proto
+++ b/src/protos/io/defang/v1/fabric.proto
@@ -5,8 +5,8 @@ package io.defang.v1;
 
 import "google/protobuf/empty.proto";
 import "google/protobuf/timestamp.proto";
-import "google/type/money.proto";
 
+import "google/type/money.proto";
 option go_package = "github.com/DefangLabs/defang/src/protos/io/defang/v1;defangv1";
 
 service FabricController {
@@ -327,6 +327,7 @@ message CanIUseRequest {
   string prefer_cd_version = 7; // currently deployed CD image; empty for new projects or when --allow-upgrade is set
   string prefer_pulumi_version = 8; // currently deployed Pulumi version; empty for new projects or when --allow-upgrade is set
   string driver = 9;
+  string cli_version = 10;
 }
 
 message CanIUseResponse {


### PR DESCRIPTION
## Description

By adding the CLI version to `CanIUse`, we can link the CD image version to the CLI version, to ensure they're compatible. Eg. secrets created by CLI vX are understood by CD vY. For example, in Fabric, we can use semantice version or simply keep track of what's the latest supported version of the CD image for a given CLI version.

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The CLI now includes its version information when communicating with the server.

* **Tests**
  * Added/updated tests to assert the CLI version is correctly sent and to avoid cross-test state leakage.

* **Chores**
  * CI workflow and release automation formatting and command adjustments (non-functional changes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->