### PR TITLE
proto: add ResolveTXT RPC

### DIFF
--- a/src/protos/io/defang/v1/defangv1connect/fabric.connect.go
+++ b/src/protos/io/defang/v1/defangv1connect/fabric.connect.go
@@ -145,6 +145,9 @@ const (
 	// FabricControllerResolveNSProcedure is the fully-qualified name of the FabricController's
 	// ResolveNS RPC.
 	FabricControllerResolveNSProcedure = "/io.defang.v1.FabricController/ResolveNS"
+	// FabricControllerResolveTXTProcedure is the fully-qualified name of the FabricController's
+	// ResolveTXT RPC.
+	FabricControllerResolveTXTProcedure = "/io.defang.v1.FabricController/ResolveTXT"
 	// FabricControllerGetSelectedProviderProcedure is the fully-qualified name of the
 	// FabricController's GetSelectedProvider RPC.
 	FabricControllerGetSelectedProviderProcedure = "/io.defang.v1.FabricController/GetSelectedProvider"
@@ -228,6 +231,7 @@ type FabricControllerClient interface {
 	ResolveIPAddr(context.Context, *connect.Request[v1.ResolveIPAddrRequest]) (*connect.Response[v1.ResolveIPAddrResponse], error)
 	ResolveCNAME(context.Context, *connect.Request[v1.ResolveCNAMERequest]) (*connect.Response[v1.ResolveCNAMEResponse], error)
 	ResolveNS(context.Context, *connect.Request[v1.ResolveNSRequest]) (*connect.Response[v1.ResolveNSResponse], error)
+	ResolveTXT(context.Context, *connect.Request[v1.ResolveTXTRequest]) (*connect.Response[v1.ResolveTXTResponse], error)
 	// Deprecated: do not use.
 	GetSelectedProvider(context.Context, *connect.Request[v1.GetSelectedProviderRequest]) (*connect.Response[v1.GetSelectedProviderResponse], error)
 	// Deprecated: do not use.
@@ -515,6 +519,13 @@ func NewFabricControllerClient(httpClient connect.HTTPClient, baseURL string, op
 			connect.WithIdempotency(connect.IdempotencyNoSideEffects),
 			connect.WithClientOptions(opts...),
 		),
+		resolveTXT: connect.NewClient[v1.ResolveTXTRequest, v1.ResolveTXTResponse](
+			httpClient,
+			baseURL+FabricControllerResolveTXTProcedure,
+			connect.WithSchema(fabricControllerMethods.ByName("ResolveTXT")),
+			connect.WithIdempotency(connect.IdempotencyNoSideEffects),
+			connect.WithClientOptions(opts...),
+		),
 		getSelectedProvider: connect.NewClient[v1.GetSelectedProviderRequest, v1.GetSelectedProviderResponse](
 			httpClient,
 			baseURL+FabricControllerGetSelectedProviderProcedure,
@@ -635,6 +646,7 @@ type fabricControllerClient struct {
 	resolveIPAddr              *connect.Client[v1.ResolveIPAddrRequest, v1.ResolveIPAddrResponse]
 	resolveCNAME               *connect.Client[v1.ResolveCNAMERequest, v1.ResolveCNAMEResponse]
 	resolveNS                  *connect.Client[v1.ResolveNSRequest, v1.ResolveNSResponse]
+	resolveTXT                 *connect.Client[v1.ResolveTXTRequest, v1.ResolveTXTResponse]
 	getSelectedProvider        *connect.Client[v1.GetSelectedProviderRequest, v1.GetSelectedProviderResponse]
 	setSelectedProvider        *connect.Client[v1.SetSelectedProviderRequest, emptypb.Empty]
 	canIUse                    *connect.Client[v1.CanIUseRequest, v1.CanIUseResponse]
@@ -851,6 +863,11 @@ func (c *fabricControllerClient) ResolveNS(ctx context.Context, req *connect.Req
 	return c.resolveNS.CallUnary(ctx, req)
 }
 
+// ResolveTXT calls io.defang.v1.FabricController.ResolveTXT.
+func (c *fabricControllerClient) ResolveTXT(ctx context.Context, req *connect.Request[v1.ResolveTXTRequest]) (*connect.Response[v1.ResolveTXTResponse], error) {
+	return c.resolveTXT.CallUnary(ctx, req)
+}
+
 // GetSelectedProvider calls io.defang.v1.FabricController.GetSelectedProvider.
 //
 // Deprecated: do not use.
@@ -958,6 +975,7 @@ type FabricControllerHandler interface {
 	ResolveIPAddr(context.Context, *connect.Request[v1.ResolveIPAddrRequest]) (*connect.Response[v1.ResolveIPAddrResponse], error)
 	ResolveCNAME(context.Context, *connect.Request[v1.ResolveCNAMERequest]) (*connect.Response[v1.ResolveCNAMEResponse], error)
 	ResolveNS(context.Context, *connect.Request[v1.ResolveNSRequest]) (*connect.Response[v1.ResolveNSResponse], error)
+	ResolveTXT(context.Context, *connect.Request[v1.ResolveTXTRequest]) (*connect.Response[v1.ResolveTXTResponse], error)
 	// Deprecated: do not use.
 	GetSelectedProvider(context.Context, *connect.Request[v1.GetSelectedProviderRequest]) (*connect.Response[v1.GetSelectedProviderResponse], error)
 	// Deprecated: do not use.
@@ -1241,6 +1259,13 @@ func NewFabricControllerHandler(svc FabricControllerHandler, opts ...connect.Han
 		connect.WithIdempotency(connect.IdempotencyNoSideEffects),
 		connect.WithHandlerOptions(opts...),
 	)
+	fabricControllerResolveTXTHandler := connect.NewUnaryHandler(
+		FabricControllerResolveTXTProcedure,
+		svc.ResolveTXT,
+		connect.WithSchema(fabricControllerMethods.ByName("ResolveTXT")),
+		connect.WithIdempotency(connect.IdempotencyNoSideEffects),
+		connect.WithHandlerOptions(opts...),
+	)
 	fabricControllerGetSelectedProviderHandler := connect.NewUnaryHandler(
 		FabricControllerGetSelectedProviderProcedure,
 		svc.GetSelectedProvider,
@@ -1397,6 +1422,8 @@ func NewFabricControllerHandler(svc FabricControllerHandler, opts ...connect.Han
 			fabricControllerResolveCNAMEHandler.ServeHTTP(w, r)
 		case FabricControllerResolveNSProcedure:
 			fabricControllerResolveNSHandler.ServeHTTP(w, r)
+		case FabricControllerResolveTXTProcedure:
+			fabricControllerResolveTXTHandler.ServeHTTP(w, r)
 		case FabricControllerGetSelectedProviderProcedure:
 			fabricControllerGetSelectedProviderHandler.ServeHTTP(w, r)
 		case FabricControllerSetSelectedProviderProcedure:
@@ -1582,6 +1609,10 @@ func (UnimplementedFabricControllerHandler) ResolveCNAME(context.Context, *conne
 
 func (UnimplementedFabricControllerHandler) ResolveNS(context.Context, *connect.Request[v1.ResolveNSRequest]) (*connect.Response[v1.ResolveNSResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("io.defang.v1.FabricController.ResolveNS is not implemented"))
+}
+
+func (UnimplementedFabricControllerHandler) ResolveTXT(context.Context, *connect.Request[v1.ResolveTXTRequest]) (*connect.Response[v1.ResolveTXTResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("io.defang.v1.FabricController.ResolveTXT is not implemented"))
 }
 
 func (UnimplementedFabricControllerHandler) GetSelectedProvider(context.Context, *connect.Request[v1.GetSelectedProviderRequest]) (*connect.Response[v1.GetSelectedProviderResponse], error) {

--- a/src/protos/io/defang/v1/fabric.pb.go
+++ b/src/protos/io/defang/v1/fabric.pb.go
@@ -791,7 +791,7 @@ func (x TailRequest_LogType) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use TailRequest_LogType.Descriptor instead.
 func (TailRequest_LogType) EnumDescriptor() ([]byte, []int) {
-	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{58, 0}
+	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{60, 0}
 }
 
 type Stack struct {
@@ -1723,6 +1723,102 @@ func (x *ResolveNSResponse) GetHosts() []string {
 	return nil
 }
 
+type ResolveTXTRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Domain        string                 `protobuf:"bytes,1,opt,name=domain,proto3" json:"domain,omitempty"`
+	NsServer      string                 `protobuf:"bytes,2,opt,name=ns_server,json=nsServer,proto3" json:"ns_server,omitempty"` // optional; if empty, resolve from root
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ResolveTXTRequest) Reset() {
+	*x = ResolveTXTRequest{}
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[18]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ResolveTXTRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ResolveTXTRequest) ProtoMessage() {}
+
+func (x *ResolveTXTRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[18]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ResolveTXTRequest.ProtoReflect.Descriptor instead.
+func (*ResolveTXTRequest) Descriptor() ([]byte, []int) {
+	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{18}
+}
+
+func (x *ResolveTXTRequest) GetDomain() string {
+	if x != nil {
+		return x.Domain
+	}
+	return ""
+}
+
+func (x *ResolveTXTRequest) GetNsServer() string {
+	if x != nil {
+		return x.NsServer
+	}
+	return ""
+}
+
+type ResolveTXTResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Txts          []string               `protobuf:"bytes,1,rep,name=txts,proto3" json:"txts,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ResolveTXTResponse) Reset() {
+	*x = ResolveTXTResponse{}
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[19]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ResolveTXTResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ResolveTXTResponse) ProtoMessage() {}
+
+func (x *ResolveTXTResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[19]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ResolveTXTResponse.ProtoReflect.Descriptor instead.
+func (*ResolveTXTResponse) Descriptor() ([]byte, []int) {
+	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{19}
+}
+
+func (x *ResolveTXTResponse) GetTxts() []string {
+	if x != nil {
+		return x.Txts
+	}
+	return nil
+}
+
 type DestroyRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Project       string                 `protobuf:"bytes,1,opt,name=project,proto3" json:"project,omitempty"` // defaults to tenant ID
@@ -1732,7 +1828,7 @@ type DestroyRequest struct {
 
 func (x *DestroyRequest) Reset() {
 	*x = DestroyRequest{}
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[18]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1744,7 +1840,7 @@ func (x *DestroyRequest) String() string {
 func (*DestroyRequest) ProtoMessage() {}
 
 func (x *DestroyRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[18]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1757,7 +1853,7 @@ func (x *DestroyRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DestroyRequest.ProtoReflect.Descriptor instead.
 func (*DestroyRequest) Descriptor() ([]byte, []int) {
-	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{18}
+	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *DestroyRequest) GetProject() string {
@@ -1776,7 +1872,7 @@ type DestroyResponse struct {
 
 func (x *DestroyResponse) Reset() {
 	*x = DestroyResponse{}
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[19]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1788,7 +1884,7 @@ func (x *DestroyResponse) String() string {
 func (*DestroyResponse) ProtoMessage() {}
 
 func (x *DestroyResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[19]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1801,7 +1897,7 @@ func (x *DestroyResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DestroyResponse.ProtoReflect.Descriptor instead.
 func (*DestroyResponse) Descriptor() ([]byte, []int) {
-	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{19}
+	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *DestroyResponse) GetEtag() string {
@@ -1828,7 +1924,7 @@ type DebugRequest struct {
 
 func (x *DebugRequest) Reset() {
 	*x = DebugRequest{}
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[20]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1840,7 +1936,7 @@ func (x *DebugRequest) String() string {
 func (*DebugRequest) ProtoMessage() {}
 
 func (x *DebugRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[20]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1853,7 +1949,7 @@ func (x *DebugRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DebugRequest.ProtoReflect.Descriptor instead.
 func (*DebugRequest) Descriptor() ([]byte, []int) {
-	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{20}
+	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *DebugRequest) GetFiles() []*File {
@@ -1931,7 +2027,7 @@ type DebugResponse struct {
 
 func (x *DebugResponse) Reset() {
 	*x = DebugResponse{}
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[21]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1943,7 +2039,7 @@ func (x *DebugResponse) String() string {
 func (*DebugResponse) ProtoMessage() {}
 
 func (x *DebugResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[21]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1956,7 +2052,7 @@ func (x *DebugResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DebugResponse.ProtoReflect.Descriptor instead.
 func (*DebugResponse) Descriptor() ([]byte, []int) {
-	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{21}
+	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *DebugResponse) GetGeneral() string {
@@ -1999,7 +2095,7 @@ type Issue struct {
 
 func (x *Issue) Reset() {
 	*x = Issue{}
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[22]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2011,7 +2107,7 @@ func (x *Issue) String() string {
 func (*Issue) ProtoMessage() {}
 
 func (x *Issue) ProtoReflect() protoreflect.Message {
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[22]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2024,7 +2120,7 @@ func (x *Issue) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Issue.ProtoReflect.Descriptor instead.
 func (*Issue) Descriptor() ([]byte, []int) {
-	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{22}
+	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *Issue) GetType() string {
@@ -2065,7 +2161,7 @@ type CodeChange struct {
 
 func (x *CodeChange) Reset() {
 	*x = CodeChange{}
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[23]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2077,7 +2173,7 @@ func (x *CodeChange) String() string {
 func (*CodeChange) ProtoMessage() {}
 
 func (x *CodeChange) ProtoReflect() protoreflect.Message {
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[23]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2090,7 +2186,7 @@ func (x *CodeChange) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CodeChange.ProtoReflect.Descriptor instead.
 func (*CodeChange) Descriptor() ([]byte, []int) {
-	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{23}
+	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *CodeChange) GetFile() string {
@@ -2120,7 +2216,7 @@ type TrackRequest struct {
 
 func (x *TrackRequest) Reset() {
 	*x = TrackRequest{}
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[24]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2132,7 +2228,7 @@ func (x *TrackRequest) String() string {
 func (*TrackRequest) ProtoMessage() {}
 
 func (x *TrackRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[24]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2145,7 +2241,7 @@ func (x *TrackRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TrackRequest.ProtoReflect.Descriptor instead.
 func (*TrackRequest) Descriptor() ([]byte, []int) {
-	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{24}
+	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *TrackRequest) GetAnonId() string {
@@ -2201,7 +2297,7 @@ type CanIUseRequest struct {
 
 func (x *CanIUseRequest) Reset() {
 	*x = CanIUseRequest{}
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[25]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2213,7 +2309,7 @@ func (x *CanIUseRequest) String() string {
 func (*CanIUseRequest) ProtoMessage() {}
 
 func (x *CanIUseRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[25]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2226,7 +2322,7 @@ func (x *CanIUseRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CanIUseRequest.ProtoReflect.Descriptor instead.
 func (*CanIUseRequest) Descriptor() ([]byte, []int) {
-	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{25}
+	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *CanIUseRequest) GetProject() string {
@@ -2314,7 +2410,7 @@ type CanIUseResponse struct {
 
 func (x *CanIUseResponse) Reset() {
 	*x = CanIUseResponse{}
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[26]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2326,7 +2422,7 @@ func (x *CanIUseResponse) String() string {
 func (*CanIUseResponse) ProtoMessage() {}
 
 func (x *CanIUseResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[26]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2339,7 +2435,7 @@ func (x *CanIUseResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CanIUseResponse.ProtoReflect.Descriptor instead.
 func (*CanIUseResponse) Descriptor() ([]byte, []int) {
-	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{26}
+	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *CanIUseResponse) GetCdImage() string {
@@ -2408,7 +2504,7 @@ type DeployRequest struct {
 
 func (x *DeployRequest) Reset() {
 	*x = DeployRequest{}
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[27]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2420,7 +2516,7 @@ func (x *DeployRequest) String() string {
 func (*DeployRequest) ProtoMessage() {}
 
 func (x *DeployRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[27]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2433,7 +2529,7 @@ func (x *DeployRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeployRequest.ProtoReflect.Descriptor instead.
 func (*DeployRequest) Descriptor() ([]byte, []int) {
-	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{27}
+	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{29}
 }
 
 // Deprecated: Marked as deprecated in io/defang/v1/fabric.proto.
@@ -2497,7 +2593,7 @@ type DeployResponse struct {
 
 func (x *DeployResponse) Reset() {
 	*x = DeployResponse{}
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[28]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2509,7 +2605,7 @@ func (x *DeployResponse) String() string {
 func (*DeployResponse) ProtoMessage() {}
 
 func (x *DeployResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[28]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2522,7 +2618,7 @@ func (x *DeployResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeployResponse.ProtoReflect.Descriptor instead.
 func (*DeployResponse) Descriptor() ([]byte, []int) {
-	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{28}
+	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *DeployResponse) GetServices() []*ServiceInfo {
@@ -2550,7 +2646,7 @@ type DeleteRequest struct {
 
 func (x *DeleteRequest) Reset() {
 	*x = DeleteRequest{}
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[29]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2562,7 +2658,7 @@ func (x *DeleteRequest) String() string {
 func (*DeleteRequest) ProtoMessage() {}
 
 func (x *DeleteRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[29]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2575,7 +2671,7 @@ func (x *DeleteRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteRequest.ProtoReflect.Descriptor instead.
 func (*DeleteRequest) Descriptor() ([]byte, []int) {
-	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{29}
+	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *DeleteRequest) GetNames() []string {
@@ -2608,7 +2704,7 @@ type DeleteResponse struct {
 
 func (x *DeleteResponse) Reset() {
 	*x = DeleteResponse{}
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[30]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2620,7 +2716,7 @@ func (x *DeleteResponse) String() string {
 func (*DeleteResponse) ProtoMessage() {}
 
 func (x *DeleteResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[30]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2633,7 +2729,7 @@ func (x *DeleteResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteResponse.ProtoReflect.Descriptor instead.
 func (*DeleteResponse) Descriptor() ([]byte, []int) {
-	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{30}
+	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *DeleteResponse) GetEtag() string {
@@ -2656,7 +2752,7 @@ type GenerateFilesRequest struct {
 
 func (x *GenerateFilesRequest) Reset() {
 	*x = GenerateFilesRequest{}
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[31]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2668,7 +2764,7 @@ func (x *GenerateFilesRequest) String() string {
 func (*GenerateFilesRequest) ProtoMessage() {}
 
 func (x *GenerateFilesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[31]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2681,7 +2777,7 @@ func (x *GenerateFilesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GenerateFilesRequest.ProtoReflect.Descriptor instead.
 func (*GenerateFilesRequest) Descriptor() ([]byte, []int) {
-	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{31}
+	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *GenerateFilesRequest) GetPrompt() string {
@@ -2729,7 +2825,7 @@ type File struct {
 
 func (x *File) Reset() {
 	*x = File{}
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[32]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2741,7 +2837,7 @@ func (x *File) String() string {
 func (*File) ProtoMessage() {}
 
 func (x *File) ProtoReflect() protoreflect.Message {
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[32]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2754,7 +2850,7 @@ func (x *File) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use File.ProtoReflect.Descriptor instead.
 func (*File) Descriptor() ([]byte, []int) {
-	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{32}
+	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{34}
 }
 
 func (x *File) GetName() string {
@@ -2780,7 +2876,7 @@ type GenerateFilesResponse struct {
 
 func (x *GenerateFilesResponse) Reset() {
 	*x = GenerateFilesResponse{}
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[33]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2792,7 +2888,7 @@ func (x *GenerateFilesResponse) String() string {
 func (*GenerateFilesResponse) ProtoMessage() {}
 
 func (x *GenerateFilesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[33]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2805,7 +2901,7 @@ func (x *GenerateFilesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GenerateFilesResponse.ProtoReflect.Descriptor instead.
 func (*GenerateFilesResponse) Descriptor() ([]byte, []int) {
-	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{33}
+	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{35}
 }
 
 func (x *GenerateFilesResponse) GetFiles() []*File {
@@ -2824,7 +2920,7 @@ type StartGenerateResponse struct {
 
 func (x *StartGenerateResponse) Reset() {
 	*x = StartGenerateResponse{}
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[34]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2836,7 +2932,7 @@ func (x *StartGenerateResponse) String() string {
 func (*StartGenerateResponse) ProtoMessage() {}
 
 func (x *StartGenerateResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[34]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2849,7 +2945,7 @@ func (x *StartGenerateResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StartGenerateResponse.ProtoReflect.Descriptor instead.
 func (*StartGenerateResponse) Descriptor() ([]byte, []int) {
-	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{34}
+	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{36}
 }
 
 func (x *StartGenerateResponse) GetUuid() string {
@@ -2868,7 +2964,7 @@ type GenerateStatusRequest struct {
 
 func (x *GenerateStatusRequest) Reset() {
 	*x = GenerateStatusRequest{}
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[35]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2880,7 +2976,7 @@ func (x *GenerateStatusRequest) String() string {
 func (*GenerateStatusRequest) ProtoMessage() {}
 
 func (x *GenerateStatusRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[35]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2893,7 +2989,7 @@ func (x *GenerateStatusRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GenerateStatusRequest.ProtoReflect.Descriptor instead.
 func (*GenerateStatusRequest) Descriptor() ([]byte, []int) {
-	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{35}
+	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{37}
 }
 
 func (x *GenerateStatusRequest) GetUuid() string {
@@ -2915,7 +3011,7 @@ type UploadURLRequest struct {
 
 func (x *UploadURLRequest) Reset() {
 	*x = UploadURLRequest{}
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[36]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2927,7 +3023,7 @@ func (x *UploadURLRequest) String() string {
 func (*UploadURLRequest) ProtoMessage() {}
 
 func (x *UploadURLRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[36]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2940,7 +3036,7 @@ func (x *UploadURLRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UploadURLRequest.ProtoReflect.Descriptor instead.
 func (*UploadURLRequest) Descriptor() ([]byte, []int) {
-	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{36}
+	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{38}
 }
 
 func (x *UploadURLRequest) GetDigest() string {
@@ -2980,7 +3076,7 @@ type UploadURLResponse struct {
 
 func (x *UploadURLResponse) Reset() {
 	*x = UploadURLResponse{}
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[37]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2992,7 +3088,7 @@ func (x *UploadURLResponse) String() string {
 func (*UploadURLResponse) ProtoMessage() {}
 
 func (x *UploadURLResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[37]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3005,7 +3101,7 @@ func (x *UploadURLResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UploadURLResponse.ProtoReflect.Descriptor instead.
 func (*UploadURLResponse) Descriptor() ([]byte, []int) {
-	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{37}
+	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{39}
 }
 
 func (x *UploadURLResponse) GetUrl() string {
@@ -3042,7 +3138,7 @@ type ServiceInfo struct {
 
 func (x *ServiceInfo) Reset() {
 	*x = ServiceInfo{}
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[38]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3054,7 +3150,7 @@ func (x *ServiceInfo) String() string {
 func (*ServiceInfo) ProtoMessage() {}
 
 func (x *ServiceInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[38]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3067,7 +3163,7 @@ func (x *ServiceInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ServiceInfo.ProtoReflect.Descriptor instead.
 func (*ServiceInfo) Descriptor() ([]byte, []int) {
-	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{38}
+	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{40}
 }
 
 func (x *ServiceInfo) GetService() *Service {
@@ -3214,7 +3310,7 @@ type Secrets struct {
 
 func (x *Secrets) Reset() {
 	*x = Secrets{}
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[39]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3226,7 +3322,7 @@ func (x *Secrets) String() string {
 func (*Secrets) ProtoMessage() {}
 
 func (x *Secrets) ProtoReflect() protoreflect.Message {
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[39]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3239,7 +3335,7 @@ func (x *Secrets) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Secrets.ProtoReflect.Descriptor instead.
 func (*Secrets) Descriptor() ([]byte, []int) {
-	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{39}
+	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{41}
 }
 
 func (x *Secrets) GetNames() []string {
@@ -3268,7 +3364,7 @@ type SecretValue struct {
 
 func (x *SecretValue) Reset() {
 	*x = SecretValue{}
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[40]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3280,7 +3376,7 @@ func (x *SecretValue) String() string {
 func (*SecretValue) ProtoMessage() {}
 
 func (x *SecretValue) ProtoReflect() protoreflect.Message {
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[40]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3293,7 +3389,7 @@ func (x *SecretValue) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SecretValue.ProtoReflect.Descriptor instead.
 func (*SecretValue) Descriptor() ([]byte, []int) {
-	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{40}
+	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{42}
 }
 
 func (x *SecretValue) GetName() string {
@@ -3329,7 +3425,7 @@ type Config struct {
 
 func (x *Config) Reset() {
 	*x = Config{}
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[41]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3341,7 +3437,7 @@ func (x *Config) String() string {
 func (*Config) ProtoMessage() {}
 
 func (x *Config) ProtoReflect() protoreflect.Message {
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[41]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3354,7 +3450,7 @@ func (x *Config) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Config.ProtoReflect.Descriptor instead.
 func (*Config) Descriptor() ([]byte, []int) {
-	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{41}
+	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{43}
 }
 
 func (x *Config) GetName() string {
@@ -3395,7 +3491,7 @@ type ConfigKey struct {
 
 func (x *ConfigKey) Reset() {
 	*x = ConfigKey{}
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[42]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[44]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3407,7 +3503,7 @@ func (x *ConfigKey) String() string {
 func (*ConfigKey) ProtoMessage() {}
 
 func (x *ConfigKey) ProtoReflect() protoreflect.Message {
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[42]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[44]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3420,7 +3516,7 @@ func (x *ConfigKey) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ConfigKey.ProtoReflect.Descriptor instead.
 func (*ConfigKey) Descriptor() ([]byte, []int) {
-	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{42}
+	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{44}
 }
 
 func (x *ConfigKey) GetName() string {
@@ -3449,7 +3545,7 @@ type PutConfigRequest struct {
 
 func (x *PutConfigRequest) Reset() {
 	*x = PutConfigRequest{}
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[43]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[45]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3461,7 +3557,7 @@ func (x *PutConfigRequest) String() string {
 func (*PutConfigRequest) ProtoMessage() {}
 
 func (x *PutConfigRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[43]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[45]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3474,7 +3570,7 @@ func (x *PutConfigRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PutConfigRequest.ProtoReflect.Descriptor instead.
 func (*PutConfigRequest) Descriptor() ([]byte, []int) {
-	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{43}
+	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{45}
 }
 
 func (x *PutConfigRequest) GetName() string {
@@ -3514,7 +3610,7 @@ type GetConfigsRequest struct {
 
 func (x *GetConfigsRequest) Reset() {
 	*x = GetConfigsRequest{}
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[44]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[46]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3526,7 +3622,7 @@ func (x *GetConfigsRequest) String() string {
 func (*GetConfigsRequest) ProtoMessage() {}
 
 func (x *GetConfigsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[44]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[46]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3539,7 +3635,7 @@ func (x *GetConfigsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetConfigsRequest.ProtoReflect.Descriptor instead.
 func (*GetConfigsRequest) Descriptor() ([]byte, []int) {
-	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{44}
+	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{46}
 }
 
 func (x *GetConfigsRequest) GetConfigs() []*ConfigKey {
@@ -3558,7 +3654,7 @@ type GetConfigsResponse struct {
 
 func (x *GetConfigsResponse) Reset() {
 	*x = GetConfigsResponse{}
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[45]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[47]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3570,7 +3666,7 @@ func (x *GetConfigsResponse) String() string {
 func (*GetConfigsResponse) ProtoMessage() {}
 
 func (x *GetConfigsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[45]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[47]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3583,7 +3679,7 @@ func (x *GetConfigsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetConfigsResponse.ProtoReflect.Descriptor instead.
 func (*GetConfigsResponse) Descriptor() ([]byte, []int) {
-	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{45}
+	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{47}
 }
 
 func (x *GetConfigsResponse) GetConfigs() []*Config {
@@ -3602,7 +3698,7 @@ type GetPlaygroundProjectDomainResponse struct {
 
 func (x *GetPlaygroundProjectDomainResponse) Reset() {
 	*x = GetPlaygroundProjectDomainResponse{}
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[46]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[48]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3614,7 +3710,7 @@ func (x *GetPlaygroundProjectDomainResponse) String() string {
 func (*GetPlaygroundProjectDomainResponse) ProtoMessage() {}
 
 func (x *GetPlaygroundProjectDomainResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[46]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[48]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3627,7 +3723,7 @@ func (x *GetPlaygroundProjectDomainResponse) ProtoReflect() protoreflect.Message
 
 // Deprecated: Use GetPlaygroundProjectDomainResponse.ProtoReflect.Descriptor instead.
 func (*GetPlaygroundProjectDomainResponse) Descriptor() ([]byte, []int) {
-	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{46}
+	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{48}
 }
 
 func (x *GetPlaygroundProjectDomainResponse) GetDomain() string {
@@ -3646,7 +3742,7 @@ type DeleteConfigsRequest struct {
 
 func (x *DeleteConfigsRequest) Reset() {
 	*x = DeleteConfigsRequest{}
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[47]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[49]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3658,7 +3754,7 @@ func (x *DeleteConfigsRequest) String() string {
 func (*DeleteConfigsRequest) ProtoMessage() {}
 
 func (x *DeleteConfigsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[47]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[49]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3671,7 +3767,7 @@ func (x *DeleteConfigsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteConfigsRequest.ProtoReflect.Descriptor instead.
 func (*DeleteConfigsRequest) Descriptor() ([]byte, []int) {
-	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{47}
+	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{49}
 }
 
 func (x *DeleteConfigsRequest) GetConfigs() []*ConfigKey {
@@ -3690,7 +3786,7 @@ type ListConfigsRequest struct {
 
 func (x *ListConfigsRequest) Reset() {
 	*x = ListConfigsRequest{}
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[48]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[50]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3702,7 +3798,7 @@ func (x *ListConfigsRequest) String() string {
 func (*ListConfigsRequest) ProtoMessage() {}
 
 func (x *ListConfigsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[48]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[50]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3715,7 +3811,7 @@ func (x *ListConfigsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListConfigsRequest.ProtoReflect.Descriptor instead.
 func (*ListConfigsRequest) Descriptor() ([]byte, []int) {
-	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{48}
+	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{50}
 }
 
 func (x *ListConfigsRequest) GetProject() string {
@@ -3734,7 +3830,7 @@ type ListConfigsResponse struct {
 
 func (x *ListConfigsResponse) Reset() {
 	*x = ListConfigsResponse{}
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[49]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[51]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3746,7 +3842,7 @@ func (x *ListConfigsResponse) String() string {
 func (*ListConfigsResponse) ProtoMessage() {}
 
 func (x *ListConfigsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[49]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[51]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3759,7 +3855,7 @@ func (x *ListConfigsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListConfigsResponse.ProtoReflect.Descriptor instead.
 func (*ListConfigsResponse) Descriptor() ([]byte, []int) {
-	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{49}
+	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{51}
 }
 
 func (x *ListConfigsResponse) GetConfigs() []*ConfigKey {
@@ -3798,7 +3894,7 @@ type Deployment struct {
 
 func (x *Deployment) Reset() {
 	*x = Deployment{}
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[50]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[52]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3810,7 +3906,7 @@ func (x *Deployment) String() string {
 func (*Deployment) ProtoMessage() {}
 
 func (x *Deployment) ProtoReflect() protoreflect.Message {
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[50]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[52]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3823,7 +3919,7 @@ func (x *Deployment) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Deployment.ProtoReflect.Descriptor instead.
 func (*Deployment) Descriptor() ([]byte, []int) {
-	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{50}
+	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{52}
 }
 
 func (x *Deployment) GetId() string {
@@ -3976,7 +4072,7 @@ type PutDeploymentRequest struct {
 
 func (x *PutDeploymentRequest) Reset() {
 	*x = PutDeploymentRequest{}
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[51]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[53]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3988,7 +4084,7 @@ func (x *PutDeploymentRequest) String() string {
 func (*PutDeploymentRequest) ProtoMessage() {}
 
 func (x *PutDeploymentRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[51]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[53]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4001,7 +4097,7 @@ func (x *PutDeploymentRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PutDeploymentRequest.ProtoReflect.Descriptor instead.
 func (*PutDeploymentRequest) Descriptor() ([]byte, []int) {
-	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{51}
+	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{53}
 }
 
 func (x *PutDeploymentRequest) GetDeployment() *Deployment {
@@ -4024,7 +4120,7 @@ type ListDeploymentsRequest struct {
 
 func (x *ListDeploymentsRequest) Reset() {
 	*x = ListDeploymentsRequest{}
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[52]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[54]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4036,7 +4132,7 @@ func (x *ListDeploymentsRequest) String() string {
 func (*ListDeploymentsRequest) ProtoMessage() {}
 
 func (x *ListDeploymentsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[52]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[54]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4049,7 +4145,7 @@ func (x *ListDeploymentsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListDeploymentsRequest.ProtoReflect.Descriptor instead.
 func (*ListDeploymentsRequest) Descriptor() ([]byte, []int) {
-	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{52}
+	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{54}
 }
 
 func (x *ListDeploymentsRequest) GetProject() string {
@@ -4096,7 +4192,7 @@ type ListDeploymentsResponse struct {
 
 func (x *ListDeploymentsResponse) Reset() {
 	*x = ListDeploymentsResponse{}
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[53]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[55]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4108,7 +4204,7 @@ func (x *ListDeploymentsResponse) String() string {
 func (*ListDeploymentsResponse) ProtoMessage() {}
 
 func (x *ListDeploymentsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[53]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[55]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4121,7 +4217,7 @@ func (x *ListDeploymentsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListDeploymentsResponse.ProtoReflect.Descriptor instead.
 func (*ListDeploymentsResponse) Descriptor() ([]byte, []int) {
-	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{53}
+	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{55}
 }
 
 func (x *ListDeploymentsResponse) GetDeployments() []*Deployment {
@@ -4146,7 +4242,7 @@ type TokenRequest struct {
 
 func (x *TokenRequest) Reset() {
 	*x = TokenRequest{}
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[54]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[56]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4158,7 +4254,7 @@ func (x *TokenRequest) String() string {
 func (*TokenRequest) ProtoMessage() {}
 
 func (x *TokenRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[54]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[56]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4171,7 +4267,7 @@ func (x *TokenRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TokenRequest.ProtoReflect.Descriptor instead.
 func (*TokenRequest) Descriptor() ([]byte, []int) {
-	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{54}
+	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{56}
 }
 
 func (x *TokenRequest) GetTenant() string {
@@ -4233,7 +4329,7 @@ type TokenResponse struct {
 
 func (x *TokenResponse) Reset() {
 	*x = TokenResponse{}
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[55]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[57]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4245,7 +4341,7 @@ func (x *TokenResponse) String() string {
 func (*TokenResponse) ProtoMessage() {}
 
 func (x *TokenResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[55]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[57]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4258,7 +4354,7 @@ func (x *TokenResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TokenResponse.ProtoReflect.Descriptor instead.
 func (*TokenResponse) Descriptor() ([]byte, []int) {
-	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{55}
+	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{57}
 }
 
 func (x *TokenResponse) GetAccessToken() string {
@@ -4284,7 +4380,7 @@ type Status struct {
 
 func (x *Status) Reset() {
 	*x = Status{}
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[56]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[58]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4296,7 +4392,7 @@ func (x *Status) String() string {
 func (*Status) ProtoMessage() {}
 
 func (x *Status) ProtoReflect() protoreflect.Message {
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[56]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[58]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4309,7 +4405,7 @@ func (x *Status) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Status.ProtoReflect.Descriptor instead.
 func (*Status) Descriptor() ([]byte, []int) {
-	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{56}
+	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{58}
 }
 
 func (x *Status) GetVersion() string {
@@ -4330,7 +4426,7 @@ type Version struct {
 
 func (x *Version) Reset() {
 	*x = Version{}
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[57]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[59]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4342,7 +4438,7 @@ func (x *Version) String() string {
 func (*Version) ProtoMessage() {}
 
 func (x *Version) ProtoReflect() protoreflect.Message {
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[57]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[59]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4355,7 +4451,7 @@ func (x *Version) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Version.ProtoReflect.Descriptor instead.
 func (*Version) Descriptor() ([]byte, []int) {
-	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{57}
+	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{59}
 }
 
 func (x *Version) GetFabric() string {
@@ -4396,7 +4492,7 @@ type TailRequest struct {
 
 func (x *TailRequest) Reset() {
 	*x = TailRequest{}
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[58]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[60]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4408,7 +4504,7 @@ func (x *TailRequest) String() string {
 func (*TailRequest) ProtoMessage() {}
 
 func (x *TailRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[58]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[60]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4421,7 +4517,7 @@ func (x *TailRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TailRequest.ProtoReflect.Descriptor instead.
 func (*TailRequest) Descriptor() ([]byte, []int) {
-	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{58}
+	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{60}
 }
 
 func (x *TailRequest) GetServices() []string {
@@ -4501,7 +4597,7 @@ type LogEntry struct {
 
 func (x *LogEntry) Reset() {
 	*x = LogEntry{}
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[59]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[61]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4513,7 +4609,7 @@ func (x *LogEntry) String() string {
 func (*LogEntry) ProtoMessage() {}
 
 func (x *LogEntry) ProtoReflect() protoreflect.Message {
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[59]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[61]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4526,7 +4622,7 @@ func (x *LogEntry) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LogEntry.ProtoReflect.Descriptor instead.
 func (*LogEntry) Descriptor() ([]byte, []int) {
-	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{59}
+	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{61}
 }
 
 func (x *LogEntry) GetMessage() string {
@@ -4583,7 +4679,7 @@ type TailResponse struct {
 
 func (x *TailResponse) Reset() {
 	*x = TailResponse{}
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[60]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[62]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4595,7 +4691,7 @@ func (x *TailResponse) String() string {
 func (*TailResponse) ProtoMessage() {}
 
 func (x *TailResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[60]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[62]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4608,7 +4704,7 @@ func (x *TailResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TailResponse.ProtoReflect.Descriptor instead.
 func (*TailResponse) Descriptor() ([]byte, []int) {
-	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{60}
+	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{62}
 }
 
 func (x *TailResponse) GetEntries() []*LogEntry {
@@ -4650,7 +4746,7 @@ type GetServicesResponse struct {
 
 func (x *GetServicesResponse) Reset() {
 	*x = GetServicesResponse{}
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[61]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[63]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4662,7 +4758,7 @@ func (x *GetServicesResponse) String() string {
 func (*GetServicesResponse) ProtoMessage() {}
 
 func (x *GetServicesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[61]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[63]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4675,7 +4771,7 @@ func (x *GetServicesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetServicesResponse.ProtoReflect.Descriptor instead.
 func (*GetServicesResponse) Descriptor() ([]byte, []int) {
-	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{61}
+	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{63}
 }
 
 func (x *GetServicesResponse) GetServices() []*ServiceInfo {
@@ -4722,7 +4818,7 @@ type ProjectUpdate struct {
 
 func (x *ProjectUpdate) Reset() {
 	*x = ProjectUpdate{}
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[62]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[64]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4734,7 +4830,7 @@ func (x *ProjectUpdate) String() string {
 func (*ProjectUpdate) ProtoMessage() {}
 
 func (x *ProjectUpdate) ProtoReflect() protoreflect.Message {
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[62]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[64]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4747,7 +4843,7 @@ func (x *ProjectUpdate) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ProjectUpdate.ProtoReflect.Descriptor instead.
 func (*ProjectUpdate) Descriptor() ([]byte, []int) {
-	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{62}
+	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{64}
 }
 
 func (x *ProjectUpdate) GetServices() []*ServiceInfo {
@@ -4859,7 +4955,7 @@ type GetRequest struct {
 
 func (x *GetRequest) Reset() {
 	*x = GetRequest{}
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[63]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[65]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4871,7 +4967,7 @@ func (x *GetRequest) String() string {
 func (*GetRequest) ProtoMessage() {}
 
 func (x *GetRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[63]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[65]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4884,7 +4980,7 @@ func (x *GetRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetRequest.ProtoReflect.Descriptor instead.
 func (*GetRequest) Descriptor() ([]byte, []int) {
-	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{63}
+	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{65}
 }
 
 func (x *GetRequest) GetName() string {
@@ -4911,7 +5007,7 @@ type Service struct {
 
 func (x *Service) Reset() {
 	*x = Service{}
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[64]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[66]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4923,7 +5019,7 @@ func (x *Service) String() string {
 func (*Service) ProtoMessage() {}
 
 func (x *Service) ProtoReflect() protoreflect.Message {
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[64]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[66]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4936,7 +5032,7 @@ func (x *Service) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Service.ProtoReflect.Descriptor instead.
 func (*Service) Descriptor() ([]byte, []int) {
-	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{64}
+	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{66}
 }
 
 func (x *Service) GetName() string {
@@ -4964,7 +5060,7 @@ type DeployEvent struct {
 
 func (x *DeployEvent) Reset() {
 	*x = DeployEvent{}
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[65]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[67]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4976,7 +5072,7 @@ func (x *DeployEvent) String() string {
 func (*DeployEvent) ProtoMessage() {}
 
 func (x *DeployEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[65]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[67]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4989,7 +5085,7 @@ func (x *DeployEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeployEvent.ProtoReflect.Descriptor instead.
 func (*DeployEvent) Descriptor() ([]byte, []int) {
-	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{65}
+	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{67}
 }
 
 func (x *DeployEvent) GetMode() DeploymentMode {
@@ -5066,7 +5162,7 @@ type SubscribeRequest struct {
 
 func (x *SubscribeRequest) Reset() {
 	*x = SubscribeRequest{}
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[66]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[68]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5078,7 +5174,7 @@ func (x *SubscribeRequest) String() string {
 func (*SubscribeRequest) ProtoMessage() {}
 
 func (x *SubscribeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[66]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[68]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5091,7 +5187,7 @@ func (x *SubscribeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SubscribeRequest.ProtoReflect.Descriptor instead.
 func (*SubscribeRequest) Descriptor() ([]byte, []int) {
-	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{66}
+	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{68}
 }
 
 func (x *SubscribeRequest) GetServices() []string {
@@ -5128,7 +5224,7 @@ type SubscribeResponse struct {
 
 func (x *SubscribeResponse) Reset() {
 	*x = SubscribeResponse{}
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[67]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[69]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5140,7 +5236,7 @@ func (x *SubscribeResponse) String() string {
 func (*SubscribeResponse) ProtoMessage() {}
 
 func (x *SubscribeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[67]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[69]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5153,7 +5249,7 @@ func (x *SubscribeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SubscribeResponse.ProtoReflect.Descriptor instead.
 func (*SubscribeResponse) Descriptor() ([]byte, []int) {
-	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{67}
+	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{69}
 }
 
 // Deprecated: Marked as deprecated in io/defang/v1/fabric.proto.
@@ -5194,7 +5290,7 @@ type GetServicesRequest struct {
 
 func (x *GetServicesRequest) Reset() {
 	*x = GetServicesRequest{}
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[68]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[70]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5206,7 +5302,7 @@ func (x *GetServicesRequest) String() string {
 func (*GetServicesRequest) ProtoMessage() {}
 
 func (x *GetServicesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[68]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[70]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5219,7 +5315,7 @@ func (x *GetServicesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetServicesRequest.ProtoReflect.Descriptor instead.
 func (*GetServicesRequest) Descriptor() ([]byte, []int) {
-	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{68}
+	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{70}
 }
 
 func (x *GetServicesRequest) GetProject() string {
@@ -5240,7 +5336,7 @@ type DelegateSubdomainZoneRequest struct {
 
 func (x *DelegateSubdomainZoneRequest) Reset() {
 	*x = DelegateSubdomainZoneRequest{}
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[69]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[71]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5252,7 +5348,7 @@ func (x *DelegateSubdomainZoneRequest) String() string {
 func (*DelegateSubdomainZoneRequest) ProtoMessage() {}
 
 func (x *DelegateSubdomainZoneRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[69]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[71]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5265,7 +5361,7 @@ func (x *DelegateSubdomainZoneRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DelegateSubdomainZoneRequest.ProtoReflect.Descriptor instead.
 func (*DelegateSubdomainZoneRequest) Descriptor() ([]byte, []int) {
-	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{69}
+	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{71}
 }
 
 func (x *DelegateSubdomainZoneRequest) GetNameServerRecords() []string {
@@ -5298,7 +5394,7 @@ type DelegateSubdomainZoneResponse struct {
 
 func (x *DelegateSubdomainZoneResponse) Reset() {
 	*x = DelegateSubdomainZoneResponse{}
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[70]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[72]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5310,7 +5406,7 @@ func (x *DelegateSubdomainZoneResponse) String() string {
 func (*DelegateSubdomainZoneResponse) ProtoMessage() {}
 
 func (x *DelegateSubdomainZoneResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[70]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[72]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5323,7 +5419,7 @@ func (x *DelegateSubdomainZoneResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DelegateSubdomainZoneResponse.ProtoReflect.Descriptor instead.
 func (*DelegateSubdomainZoneResponse) Descriptor() ([]byte, []int) {
-	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{70}
+	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{72}
 }
 
 func (x *DelegateSubdomainZoneResponse) GetZone() string {
@@ -5343,7 +5439,7 @@ type DeleteSubdomainZoneRequest struct {
 
 func (x *DeleteSubdomainZoneRequest) Reset() {
 	*x = DeleteSubdomainZoneRequest{}
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[71]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[73]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5355,7 +5451,7 @@ func (x *DeleteSubdomainZoneRequest) String() string {
 func (*DeleteSubdomainZoneRequest) ProtoMessage() {}
 
 func (x *DeleteSubdomainZoneRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[71]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[73]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5368,7 +5464,7 @@ func (x *DeleteSubdomainZoneRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteSubdomainZoneRequest.ProtoReflect.Descriptor instead.
 func (*DeleteSubdomainZoneRequest) Descriptor() ([]byte, []int) {
-	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{71}
+	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{73}
 }
 
 func (x *DeleteSubdomainZoneRequest) GetProject() string {
@@ -5395,7 +5491,7 @@ type GetDelegateSubdomainZoneRequest struct {
 
 func (x *GetDelegateSubdomainZoneRequest) Reset() {
 	*x = GetDelegateSubdomainZoneRequest{}
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[72]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[74]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5407,7 +5503,7 @@ func (x *GetDelegateSubdomainZoneRequest) String() string {
 func (*GetDelegateSubdomainZoneRequest) ProtoMessage() {}
 
 func (x *GetDelegateSubdomainZoneRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[72]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[74]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5420,7 +5516,7 @@ func (x *GetDelegateSubdomainZoneRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetDelegateSubdomainZoneRequest.ProtoReflect.Descriptor instead.
 func (*GetDelegateSubdomainZoneRequest) Descriptor() ([]byte, []int) {
-	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{72}
+	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{74}
 }
 
 func (x *GetDelegateSubdomainZoneRequest) GetProject() string {
@@ -5447,7 +5543,7 @@ type SetOptionsRequest struct {
 
 func (x *SetOptionsRequest) Reset() {
 	*x = SetOptionsRequest{}
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[73]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[75]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5459,7 +5555,7 @@ func (x *SetOptionsRequest) String() string {
 func (*SetOptionsRequest) ProtoMessage() {}
 
 func (x *SetOptionsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[73]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[75]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5472,7 +5568,7 @@ func (x *SetOptionsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetOptionsRequest.ProtoReflect.Descriptor instead.
 func (*SetOptionsRequest) Descriptor() ([]byte, []int) {
-	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{73}
+	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{75}
 }
 
 func (x *SetOptionsRequest) GetTrainingOptOut() bool {
@@ -5506,7 +5602,7 @@ type WhoAmIResponse struct {
 
 func (x *WhoAmIResponse) Reset() {
 	*x = WhoAmIResponse{}
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[74]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[76]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5518,7 +5614,7 @@ func (x *WhoAmIResponse) String() string {
 func (*WhoAmIResponse) ProtoMessage() {}
 
 func (x *WhoAmIResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[74]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[76]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5531,7 +5627,7 @@ func (x *WhoAmIResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WhoAmIResponse.ProtoReflect.Descriptor instead.
 func (*WhoAmIResponse) Descriptor() ([]byte, []int) {
-	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{74}
+	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{76}
 }
 
 func (x *WhoAmIResponse) GetTenant() string {
@@ -5608,7 +5704,7 @@ type EstimateRequest struct {
 
 func (x *EstimateRequest) Reset() {
 	*x = EstimateRequest{}
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[75]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[77]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5620,7 +5716,7 @@ func (x *EstimateRequest) String() string {
 func (*EstimateRequest) ProtoMessage() {}
 
 func (x *EstimateRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[75]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[77]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5633,7 +5729,7 @@ func (x *EstimateRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EstimateRequest.ProtoReflect.Descriptor instead.
 func (*EstimateRequest) Descriptor() ([]byte, []int) {
-	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{75}
+	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{77}
 }
 
 func (x *EstimateRequest) GetProvider() Provider {
@@ -5670,7 +5766,7 @@ type EstimateLineItem struct {
 
 func (x *EstimateLineItem) Reset() {
 	*x = EstimateLineItem{}
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[76]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[78]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5682,7 +5778,7 @@ func (x *EstimateLineItem) String() string {
 func (*EstimateLineItem) ProtoMessage() {}
 
 func (x *EstimateLineItem) ProtoReflect() protoreflect.Message {
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[76]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[78]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5695,7 +5791,7 @@ func (x *EstimateLineItem) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EstimateLineItem.ProtoReflect.Descriptor instead.
 func (*EstimateLineItem) Descriptor() ([]byte, []int) {
-	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{76}
+	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{78}
 }
 
 func (x *EstimateLineItem) GetDescription() string {
@@ -5745,7 +5841,7 @@ type EstimateResponse struct {
 
 func (x *EstimateResponse) Reset() {
 	*x = EstimateResponse{}
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[77]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[79]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5757,7 +5853,7 @@ func (x *EstimateResponse) String() string {
 func (*EstimateResponse) ProtoMessage() {}
 
 func (x *EstimateResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[77]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[79]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5770,7 +5866,7 @@ func (x *EstimateResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EstimateResponse.ProtoReflect.Descriptor instead.
 func (*EstimateResponse) Descriptor() ([]byte, []int) {
-	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{77}
+	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{79}
 }
 
 func (x *EstimateResponse) GetProvider() Provider {
@@ -5815,7 +5911,7 @@ type PreviewRequest struct {
 
 func (x *PreviewRequest) Reset() {
 	*x = PreviewRequest{}
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[78]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[80]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5827,7 +5923,7 @@ func (x *PreviewRequest) String() string {
 func (*PreviewRequest) ProtoMessage() {}
 
 func (x *PreviewRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[78]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[80]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5840,7 +5936,7 @@ func (x *PreviewRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PreviewRequest.ProtoReflect.Descriptor instead.
 func (*PreviewRequest) Descriptor() ([]byte, []int) {
-	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{78}
+	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{80}
 }
 
 func (x *PreviewRequest) GetProvider() Provider {
@@ -5894,7 +5990,7 @@ type PreviewResponse struct {
 
 func (x *PreviewResponse) Reset() {
 	*x = PreviewResponse{}
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[79]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[81]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5906,7 +6002,7 @@ func (x *PreviewResponse) String() string {
 func (*PreviewResponse) ProtoMessage() {}
 
 func (x *PreviewResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[79]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[81]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5919,7 +6015,7 @@ func (x *PreviewResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PreviewResponse.ProtoReflect.Descriptor instead.
 func (*PreviewResponse) Descriptor() ([]byte, []int) {
-	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{79}
+	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{81}
 }
 
 func (x *PreviewResponse) GetEtag() string {
@@ -5940,7 +6036,7 @@ type GenerateComposeRequest struct {
 
 func (x *GenerateComposeRequest) Reset() {
 	*x = GenerateComposeRequest{}
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[80]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[82]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5952,7 +6048,7 @@ func (x *GenerateComposeRequest) String() string {
 func (*GenerateComposeRequest) ProtoMessage() {}
 
 func (x *GenerateComposeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[80]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[82]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5965,7 +6061,7 @@ func (x *GenerateComposeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GenerateComposeRequest.ProtoReflect.Descriptor instead.
 func (*GenerateComposeRequest) Descriptor() ([]byte, []int) {
-	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{80}
+	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{82}
 }
 
 func (x *GenerateComposeRequest) GetPlatform() SourcePlatform {
@@ -5998,7 +6094,7 @@ type GenerateComposeResponse struct {
 
 func (x *GenerateComposeResponse) Reset() {
 	*x = GenerateComposeResponse{}
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[81]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[83]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6010,7 +6106,7 @@ func (x *GenerateComposeResponse) String() string {
 func (*GenerateComposeResponse) ProtoMessage() {}
 
 func (x *GenerateComposeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_io_defang_v1_fabric_proto_msgTypes[81]
+	mi := &file_io_defang_v1_fabric_proto_msgTypes[83]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6023,7 +6119,7 @@ func (x *GenerateComposeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GenerateComposeResponse.ProtoReflect.Descriptor instead.
 func (*GenerateComposeResponse) Descriptor() ([]byte, []int) {
-	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{81}
+	return file_io_defang_v1_fabric_proto_rawDescGZIP(), []int{83}
 }
 
 func (x *GenerateComposeResponse) GetCompose() []byte {
@@ -6092,7 +6188,12 @@ const file_io_defang_v1_fabric_proto_rawDesc = "" +
 	"\x06domain\x18\x01 \x01(\tR\x06domain\x12\x1b\n" +
 	"\tns_server\x18\x02 \x01(\tR\bnsServer\")\n" +
 	"\x11ResolveNSResponse\x12\x14\n" +
-	"\x05hosts\x18\x01 \x03(\tR\x05hosts\"*\n" +
+	"\x05hosts\x18\x01 \x03(\tR\x05hosts\"H\n" +
+	"\x11ResolveTXTRequest\x12\x16\n" +
+	"\x06domain\x18\x01 \x01(\tR\x06domain\x12\x1b\n" +
+	"\tns_server\x18\x02 \x01(\tR\bnsServer\"(\n" +
+	"\x12ResolveTXTResponse\x12\x12\n" +
+	"\x04txts\x18\x01 \x03(\tR\x04txts\"*\n" +
 	"\x0eDestroyRequest\x12\x18\n" +
 	"\aproject\x18\x01 \x01(\tR\aproject\"%\n" +
 	"\x0fDestroyResponse\x12\x12\n" +
@@ -6541,7 +6642,7 @@ const file_io_defang_v1_fabric_proto_rawDesc = "" +
 	"\aEXPIRED\x10\xff\xff\xff\xff\xff\xff\xff\xff\xff\x01*M\n" +
 	"\x0eSourcePlatform\x12\x1f\n" +
 	"\x1bSOURCE_PLATFORM_UNSPECIFIED\x10\x00\x12\x1a\n" +
-	"\x16SOURCE_PLATFORM_HEROKU\x10\x012\x94 \n" +
+	"\x16SOURCE_PLATFORM_HEROKU\x10\x012\xea \n" +
 	"\x10FabricController\x12>\n" +
 	"\tGetStatus\x12\x16.google.protobuf.Empty\x1a\x14.io.defang.v1.Status\"\x03\x90\x02\x01\x12@\n" +
 	"\n" +
@@ -6584,7 +6685,9 @@ const file_io_defang_v1_fabric_proto_rawDesc = "" +
 	"\x0eVerifyDNSSetup\x12#.io.defang.v1.VerifyDNSSetupRequest\x1a\x16.google.protobuf.Empty\"\x03\x90\x02\x01\x12]\n" +
 	"\rResolveIPAddr\x12\".io.defang.v1.ResolveIPAddrRequest\x1a#.io.defang.v1.ResolveIPAddrResponse\"\x03\x90\x02\x01\x12Z\n" +
 	"\fResolveCNAME\x12!.io.defang.v1.ResolveCNAMERequest\x1a\".io.defang.v1.ResolveCNAMEResponse\"\x03\x90\x02\x01\x12Q\n" +
-	"\tResolveNS\x12\x1e.io.defang.v1.ResolveNSRequest\x1a\x1f.io.defang.v1.ResolveNSResponse\"\x03\x90\x02\x01\x12r\n" +
+	"\tResolveNS\x12\x1e.io.defang.v1.ResolveNSRequest\x1a\x1f.io.defang.v1.ResolveNSResponse\"\x03\x90\x02\x01\x12T\n" +
+	"\n" +
+	"ResolveTXT\x12\x1f.io.defang.v1.ResolveTXTRequest\x1a .io.defang.v1.ResolveTXTResponse\"\x03\x90\x02\x01\x12r\n" +
 	"\x13GetSelectedProvider\x12(.io.defang.v1.GetSelectedProviderRequest\x1a).io.defang.v1.GetSelectedProviderResponse\"\x06\x88\x02\x01\x90\x02\x01\x12_\n" +
 	"\x13SetSelectedProvider\x12(.io.defang.v1.SetSelectedProviderRequest\x1a\x16.google.protobuf.Empty\"\x06\x88\x02\x01\x90\x02\x02\x12K\n" +
 	"\aCanIUse\x12\x1c.io.defang.v1.CanIUseRequest\x1a\x1d.io.defang.v1.CanIUseResponse\"\x03\x90\x02\x01\x12N\n" +
@@ -6611,7 +6714,7 @@ func file_io_defang_v1_fabric_proto_rawDescGZIP() []byte {
 }
 
 var file_io_defang_v1_fabric_proto_enumTypes = make([]protoimpl.EnumInfo, 13)
-var file_io_defang_v1_fabric_proto_msgTypes = make([]protoimpl.MessageInfo, 84)
+var file_io_defang_v1_fabric_proto_msgTypes = make([]protoimpl.MessageInfo, 86)
 var file_io_defang_v1_fabric_proto_goTypes = []any{
 	(Provider)(0),                              // 0: io.defang.v1.Provider
 	(DeploymentMode)(0),                        // 1: io.defang.v1.DeploymentMode
@@ -6644,247 +6747,251 @@ var file_io_defang_v1_fabric_proto_goTypes = []any{
 	(*ResolveCNAMEResponse)(nil),               // 28: io.defang.v1.ResolveCNAMEResponse
 	(*ResolveNSRequest)(nil),                   // 29: io.defang.v1.ResolveNSRequest
 	(*ResolveNSResponse)(nil),                  // 30: io.defang.v1.ResolveNSResponse
-	(*DestroyRequest)(nil),                     // 31: io.defang.v1.DestroyRequest
-	(*DestroyResponse)(nil),                    // 32: io.defang.v1.DestroyResponse
-	(*DebugRequest)(nil),                       // 33: io.defang.v1.DebugRequest
-	(*DebugResponse)(nil),                      // 34: io.defang.v1.DebugResponse
-	(*Issue)(nil),                              // 35: io.defang.v1.Issue
-	(*CodeChange)(nil),                         // 36: io.defang.v1.CodeChange
-	(*TrackRequest)(nil),                       // 37: io.defang.v1.TrackRequest
-	(*CanIUseRequest)(nil),                     // 38: io.defang.v1.CanIUseRequest
-	(*CanIUseResponse)(nil),                    // 39: io.defang.v1.CanIUseResponse
-	(*DeployRequest)(nil),                      // 40: io.defang.v1.DeployRequest
-	(*DeployResponse)(nil),                     // 41: io.defang.v1.DeployResponse
-	(*DeleteRequest)(nil),                      // 42: io.defang.v1.DeleteRequest
-	(*DeleteResponse)(nil),                     // 43: io.defang.v1.DeleteResponse
-	(*GenerateFilesRequest)(nil),               // 44: io.defang.v1.GenerateFilesRequest
-	(*File)(nil),                               // 45: io.defang.v1.File
-	(*GenerateFilesResponse)(nil),              // 46: io.defang.v1.GenerateFilesResponse
-	(*StartGenerateResponse)(nil),              // 47: io.defang.v1.StartGenerateResponse
-	(*GenerateStatusRequest)(nil),              // 48: io.defang.v1.GenerateStatusRequest
-	(*UploadURLRequest)(nil),                   // 49: io.defang.v1.UploadURLRequest
-	(*UploadURLResponse)(nil),                  // 50: io.defang.v1.UploadURLResponse
-	(*ServiceInfo)(nil),                        // 51: io.defang.v1.ServiceInfo
-	(*Secrets)(nil),                            // 52: io.defang.v1.Secrets
-	(*SecretValue)(nil),                        // 53: io.defang.v1.SecretValue
-	(*Config)(nil),                             // 54: io.defang.v1.Config
-	(*ConfigKey)(nil),                          // 55: io.defang.v1.ConfigKey
-	(*PutConfigRequest)(nil),                   // 56: io.defang.v1.PutConfigRequest
-	(*GetConfigsRequest)(nil),                  // 57: io.defang.v1.GetConfigsRequest
-	(*GetConfigsResponse)(nil),                 // 58: io.defang.v1.GetConfigsResponse
-	(*GetPlaygroundProjectDomainResponse)(nil), // 59: io.defang.v1.GetPlaygroundProjectDomainResponse
-	(*DeleteConfigsRequest)(nil),               // 60: io.defang.v1.DeleteConfigsRequest
-	(*ListConfigsRequest)(nil),                 // 61: io.defang.v1.ListConfigsRequest
-	(*ListConfigsResponse)(nil),                // 62: io.defang.v1.ListConfigsResponse
-	(*Deployment)(nil),                         // 63: io.defang.v1.Deployment
-	(*PutDeploymentRequest)(nil),               // 64: io.defang.v1.PutDeploymentRequest
-	(*ListDeploymentsRequest)(nil),             // 65: io.defang.v1.ListDeploymentsRequest
-	(*ListDeploymentsResponse)(nil),            // 66: io.defang.v1.ListDeploymentsResponse
-	(*TokenRequest)(nil),                       // 67: io.defang.v1.TokenRequest
-	(*TokenResponse)(nil),                      // 68: io.defang.v1.TokenResponse
-	(*Status)(nil),                             // 69: io.defang.v1.Status
-	(*Version)(nil),                            // 70: io.defang.v1.Version
-	(*TailRequest)(nil),                        // 71: io.defang.v1.TailRequest
-	(*LogEntry)(nil),                           // 72: io.defang.v1.LogEntry
-	(*TailResponse)(nil),                       // 73: io.defang.v1.TailResponse
-	(*GetServicesResponse)(nil),                // 74: io.defang.v1.GetServicesResponse
-	(*ProjectUpdate)(nil),                      // 75: io.defang.v1.ProjectUpdate
-	(*GetRequest)(nil),                         // 76: io.defang.v1.GetRequest
-	(*Service)(nil),                            // 77: io.defang.v1.Service
-	(*DeployEvent)(nil),                        // 78: io.defang.v1.DeployEvent
-	(*SubscribeRequest)(nil),                   // 79: io.defang.v1.SubscribeRequest
-	(*SubscribeResponse)(nil),                  // 80: io.defang.v1.SubscribeResponse
-	(*GetServicesRequest)(nil),                 // 81: io.defang.v1.GetServicesRequest
-	(*DelegateSubdomainZoneRequest)(nil),       // 82: io.defang.v1.DelegateSubdomainZoneRequest
-	(*DelegateSubdomainZoneResponse)(nil),      // 83: io.defang.v1.DelegateSubdomainZoneResponse
-	(*DeleteSubdomainZoneRequest)(nil),         // 84: io.defang.v1.DeleteSubdomainZoneRequest
-	(*GetDelegateSubdomainZoneRequest)(nil),    // 85: io.defang.v1.GetDelegateSubdomainZoneRequest
-	(*SetOptionsRequest)(nil),                  // 86: io.defang.v1.SetOptionsRequest
-	(*WhoAmIResponse)(nil),                     // 87: io.defang.v1.WhoAmIResponse
-	(*EstimateRequest)(nil),                    // 88: io.defang.v1.EstimateRequest
-	(*EstimateLineItem)(nil),                   // 89: io.defang.v1.EstimateLineItem
-	(*EstimateResponse)(nil),                   // 90: io.defang.v1.EstimateResponse
-	(*PreviewRequest)(nil),                     // 91: io.defang.v1.PreviewRequest
-	(*PreviewResponse)(nil),                    // 92: io.defang.v1.PreviewResponse
-	(*GenerateComposeRequest)(nil),             // 93: io.defang.v1.GenerateComposeRequest
-	(*GenerateComposeResponse)(nil),            // 94: io.defang.v1.GenerateComposeResponse
-	nil,                                        // 95: io.defang.v1.TrackRequest.PropertiesEntry
-	nil,                                        // 96: io.defang.v1.Deployment.OriginMetadataEntry
-	(*timestamppb.Timestamp)(nil),              // 97: google.protobuf.Timestamp
-	(*_type.Money)(nil),                        // 98: google.type.Money
-	(*emptypb.Empty)(nil),                      // 99: google.protobuf.Empty
+	(*ResolveTXTRequest)(nil),                  // 31: io.defang.v1.ResolveTXTRequest
+	(*ResolveTXTResponse)(nil),                 // 32: io.defang.v1.ResolveTXTResponse
+	(*DestroyRequest)(nil),                     // 33: io.defang.v1.DestroyRequest
+	(*DestroyResponse)(nil),                    // 34: io.defang.v1.DestroyResponse
+	(*DebugRequest)(nil),                       // 35: io.defang.v1.DebugRequest
+	(*DebugResponse)(nil),                      // 36: io.defang.v1.DebugResponse
+	(*Issue)(nil),                              // 37: io.defang.v1.Issue
+	(*CodeChange)(nil),                         // 38: io.defang.v1.CodeChange
+	(*TrackRequest)(nil),                       // 39: io.defang.v1.TrackRequest
+	(*CanIUseRequest)(nil),                     // 40: io.defang.v1.CanIUseRequest
+	(*CanIUseResponse)(nil),                    // 41: io.defang.v1.CanIUseResponse
+	(*DeployRequest)(nil),                      // 42: io.defang.v1.DeployRequest
+	(*DeployResponse)(nil),                     // 43: io.defang.v1.DeployResponse
+	(*DeleteRequest)(nil),                      // 44: io.defang.v1.DeleteRequest
+	(*DeleteResponse)(nil),                     // 45: io.defang.v1.DeleteResponse
+	(*GenerateFilesRequest)(nil),               // 46: io.defang.v1.GenerateFilesRequest
+	(*File)(nil),                               // 47: io.defang.v1.File
+	(*GenerateFilesResponse)(nil),              // 48: io.defang.v1.GenerateFilesResponse
+	(*StartGenerateResponse)(nil),              // 49: io.defang.v1.StartGenerateResponse
+	(*GenerateStatusRequest)(nil),              // 50: io.defang.v1.GenerateStatusRequest
+	(*UploadURLRequest)(nil),                   // 51: io.defang.v1.UploadURLRequest
+	(*UploadURLResponse)(nil),                  // 52: io.defang.v1.UploadURLResponse
+	(*ServiceInfo)(nil),                        // 53: io.defang.v1.ServiceInfo
+	(*Secrets)(nil),                            // 54: io.defang.v1.Secrets
+	(*SecretValue)(nil),                        // 55: io.defang.v1.SecretValue
+	(*Config)(nil),                             // 56: io.defang.v1.Config
+	(*ConfigKey)(nil),                          // 57: io.defang.v1.ConfigKey
+	(*PutConfigRequest)(nil),                   // 58: io.defang.v1.PutConfigRequest
+	(*GetConfigsRequest)(nil),                  // 59: io.defang.v1.GetConfigsRequest
+	(*GetConfigsResponse)(nil),                 // 60: io.defang.v1.GetConfigsResponse
+	(*GetPlaygroundProjectDomainResponse)(nil), // 61: io.defang.v1.GetPlaygroundProjectDomainResponse
+	(*DeleteConfigsRequest)(nil),               // 62: io.defang.v1.DeleteConfigsRequest
+	(*ListConfigsRequest)(nil),                 // 63: io.defang.v1.ListConfigsRequest
+	(*ListConfigsResponse)(nil),                // 64: io.defang.v1.ListConfigsResponse
+	(*Deployment)(nil),                         // 65: io.defang.v1.Deployment
+	(*PutDeploymentRequest)(nil),               // 66: io.defang.v1.PutDeploymentRequest
+	(*ListDeploymentsRequest)(nil),             // 67: io.defang.v1.ListDeploymentsRequest
+	(*ListDeploymentsResponse)(nil),            // 68: io.defang.v1.ListDeploymentsResponse
+	(*TokenRequest)(nil),                       // 69: io.defang.v1.TokenRequest
+	(*TokenResponse)(nil),                      // 70: io.defang.v1.TokenResponse
+	(*Status)(nil),                             // 71: io.defang.v1.Status
+	(*Version)(nil),                            // 72: io.defang.v1.Version
+	(*TailRequest)(nil),                        // 73: io.defang.v1.TailRequest
+	(*LogEntry)(nil),                           // 74: io.defang.v1.LogEntry
+	(*TailResponse)(nil),                       // 75: io.defang.v1.TailResponse
+	(*GetServicesResponse)(nil),                // 76: io.defang.v1.GetServicesResponse
+	(*ProjectUpdate)(nil),                      // 77: io.defang.v1.ProjectUpdate
+	(*GetRequest)(nil),                         // 78: io.defang.v1.GetRequest
+	(*Service)(nil),                            // 79: io.defang.v1.Service
+	(*DeployEvent)(nil),                        // 80: io.defang.v1.DeployEvent
+	(*SubscribeRequest)(nil),                   // 81: io.defang.v1.SubscribeRequest
+	(*SubscribeResponse)(nil),                  // 82: io.defang.v1.SubscribeResponse
+	(*GetServicesRequest)(nil),                 // 83: io.defang.v1.GetServicesRequest
+	(*DelegateSubdomainZoneRequest)(nil),       // 84: io.defang.v1.DelegateSubdomainZoneRequest
+	(*DelegateSubdomainZoneResponse)(nil),      // 85: io.defang.v1.DelegateSubdomainZoneResponse
+	(*DeleteSubdomainZoneRequest)(nil),         // 86: io.defang.v1.DeleteSubdomainZoneRequest
+	(*GetDelegateSubdomainZoneRequest)(nil),    // 87: io.defang.v1.GetDelegateSubdomainZoneRequest
+	(*SetOptionsRequest)(nil),                  // 88: io.defang.v1.SetOptionsRequest
+	(*WhoAmIResponse)(nil),                     // 89: io.defang.v1.WhoAmIResponse
+	(*EstimateRequest)(nil),                    // 90: io.defang.v1.EstimateRequest
+	(*EstimateLineItem)(nil),                   // 91: io.defang.v1.EstimateLineItem
+	(*EstimateResponse)(nil),                   // 92: io.defang.v1.EstimateResponse
+	(*PreviewRequest)(nil),                     // 93: io.defang.v1.PreviewRequest
+	(*PreviewResponse)(nil),                    // 94: io.defang.v1.PreviewResponse
+	(*GenerateComposeRequest)(nil),             // 95: io.defang.v1.GenerateComposeRequest
+	(*GenerateComposeResponse)(nil),            // 96: io.defang.v1.GenerateComposeResponse
+	nil,                                        // 97: io.defang.v1.TrackRequest.PropertiesEntry
+	nil,                                        // 98: io.defang.v1.Deployment.OriginMetadataEntry
+	(*timestamppb.Timestamp)(nil),              // 99: google.protobuf.Timestamp
+	(*_type.Money)(nil),                        // 100: google.type.Money
+	(*emptypb.Empty)(nil),                      // 101: google.protobuf.Empty
 }
 var file_io_defang_v1_fabric_proto_depIdxs = []int32{
 	0,   // 0: io.defang.v1.Stack.provider:type_name -> io.defang.v1.Provider
-	97,  // 1: io.defang.v1.Stack.last_deployed_at:type_name -> google.protobuf.Timestamp
+	99,  // 1: io.defang.v1.Stack.last_deployed_at:type_name -> google.protobuf.Timestamp
 	1,   // 2: io.defang.v1.Stack.mode:type_name -> io.defang.v1.DeploymentMode
 	13,  // 3: io.defang.v1.PutStackRequest.stack:type_name -> io.defang.v1.Stack
 	13,  // 4: io.defang.v1.GetStackResponse.stack:type_name -> io.defang.v1.Stack
 	13,  // 5: io.defang.v1.ListStacksResponse.stacks:type_name -> io.defang.v1.Stack
 	0,   // 6: io.defang.v1.GetSelectedProviderResponse.provider:type_name -> io.defang.v1.Provider
 	0,   // 7: io.defang.v1.SetSelectedProviderRequest.provider:type_name -> io.defang.v1.Provider
-	45,  // 8: io.defang.v1.DebugRequest.files:type_name -> io.defang.v1.File
-	97,  // 9: io.defang.v1.DebugRequest.since:type_name -> google.protobuf.Timestamp
-	97,  // 10: io.defang.v1.DebugRequest.until:type_name -> google.protobuf.Timestamp
-	35,  // 11: io.defang.v1.DebugResponse.issues:type_name -> io.defang.v1.Issue
-	36,  // 12: io.defang.v1.Issue.code_changes:type_name -> io.defang.v1.CodeChange
-	95,  // 13: io.defang.v1.TrackRequest.properties:type_name -> io.defang.v1.TrackRequest.PropertiesEntry
+	47,  // 8: io.defang.v1.DebugRequest.files:type_name -> io.defang.v1.File
+	99,  // 9: io.defang.v1.DebugRequest.since:type_name -> google.protobuf.Timestamp
+	99,  // 10: io.defang.v1.DebugRequest.until:type_name -> google.protobuf.Timestamp
+	37,  // 11: io.defang.v1.DebugResponse.issues:type_name -> io.defang.v1.Issue
+	38,  // 12: io.defang.v1.Issue.code_changes:type_name -> io.defang.v1.CodeChange
+	97,  // 13: io.defang.v1.TrackRequest.properties:type_name -> io.defang.v1.TrackRequest.PropertiesEntry
 	0,   // 14: io.defang.v1.CanIUseRequest.provider:type_name -> io.defang.v1.Provider
 	1,   // 15: io.defang.v1.DeployRequest.mode:type_name -> io.defang.v1.DeploymentMode
 	0,   // 16: io.defang.v1.DeployRequest.provider:type_name -> io.defang.v1.Provider
-	51,  // 17: io.defang.v1.DeployResponse.services:type_name -> io.defang.v1.ServiceInfo
-	45,  // 18: io.defang.v1.GenerateFilesResponse.files:type_name -> io.defang.v1.File
-	77,  // 19: io.defang.v1.ServiceInfo.service:type_name -> io.defang.v1.Service
-	97,  // 20: io.defang.v1.ServiceInfo.created_at:type_name -> google.protobuf.Timestamp
-	97,  // 21: io.defang.v1.ServiceInfo.updated_at:type_name -> google.protobuf.Timestamp
+	53,  // 17: io.defang.v1.DeployResponse.services:type_name -> io.defang.v1.ServiceInfo
+	47,  // 18: io.defang.v1.GenerateFilesResponse.files:type_name -> io.defang.v1.File
+	79,  // 19: io.defang.v1.ServiceInfo.service:type_name -> io.defang.v1.Service
+	99,  // 20: io.defang.v1.ServiceInfo.created_at:type_name -> google.protobuf.Timestamp
+	99,  // 21: io.defang.v1.ServiceInfo.updated_at:type_name -> google.protobuf.Timestamp
 	2,   // 22: io.defang.v1.ServiceInfo.state:type_name -> io.defang.v1.ServiceState
 	3,   // 23: io.defang.v1.ServiceInfo.type:type_name -> io.defang.v1.ResourceType
 	4,   // 24: io.defang.v1.Config.type:type_name -> io.defang.v1.ConfigType
 	4,   // 25: io.defang.v1.PutConfigRequest.type:type_name -> io.defang.v1.ConfigType
-	55,  // 26: io.defang.v1.GetConfigsRequest.configs:type_name -> io.defang.v1.ConfigKey
-	54,  // 27: io.defang.v1.GetConfigsResponse.configs:type_name -> io.defang.v1.Config
-	55,  // 28: io.defang.v1.DeleteConfigsRequest.configs:type_name -> io.defang.v1.ConfigKey
-	55,  // 29: io.defang.v1.ListConfigsResponse.configs:type_name -> io.defang.v1.ConfigKey
-	97,  // 30: io.defang.v1.Deployment.timestamp:type_name -> google.protobuf.Timestamp
+	57,  // 26: io.defang.v1.GetConfigsRequest.configs:type_name -> io.defang.v1.ConfigKey
+	56,  // 27: io.defang.v1.GetConfigsResponse.configs:type_name -> io.defang.v1.Config
+	57,  // 28: io.defang.v1.DeleteConfigsRequest.configs:type_name -> io.defang.v1.ConfigKey
+	57,  // 29: io.defang.v1.ListConfigsResponse.configs:type_name -> io.defang.v1.ConfigKey
+	99,  // 30: io.defang.v1.Deployment.timestamp:type_name -> google.protobuf.Timestamp
 	6,   // 31: io.defang.v1.Deployment.action:type_name -> io.defang.v1.DeploymentAction
 	0,   // 32: io.defang.v1.Deployment.provider:type_name -> io.defang.v1.Provider
 	1,   // 33: io.defang.v1.Deployment.mode:type_name -> io.defang.v1.DeploymentMode
-	97,  // 34: io.defang.v1.Deployment.completed:type_name -> google.protobuf.Timestamp
+	99,  // 34: io.defang.v1.Deployment.completed:type_name -> google.protobuf.Timestamp
 	9,   // 35: io.defang.v1.Deployment.status:type_name -> io.defang.v1.DeploymentStatus
 	7,   // 36: io.defang.v1.Deployment.origin:type_name -> io.defang.v1.DeploymentOrigin
-	96,  // 37: io.defang.v1.Deployment.origin_metadata:type_name -> io.defang.v1.Deployment.OriginMetadataEntry
-	51,  // 38: io.defang.v1.Deployment.services:type_name -> io.defang.v1.ServiceInfo
+	98,  // 37: io.defang.v1.Deployment.origin_metadata:type_name -> io.defang.v1.Deployment.OriginMetadataEntry
+	53,  // 38: io.defang.v1.Deployment.services:type_name -> io.defang.v1.ServiceInfo
 	8,   // 39: io.defang.v1.Deployment.cd_type:type_name -> io.defang.v1.CdType
-	63,  // 40: io.defang.v1.PutDeploymentRequest.deployment:type_name -> io.defang.v1.Deployment
+	65,  // 40: io.defang.v1.PutDeploymentRequest.deployment:type_name -> io.defang.v1.Deployment
 	5,   // 41: io.defang.v1.ListDeploymentsRequest.type:type_name -> io.defang.v1.DeploymentType
-	97,  // 42: io.defang.v1.ListDeploymentsRequest.until:type_name -> google.protobuf.Timestamp
-	63,  // 43: io.defang.v1.ListDeploymentsResponse.deployments:type_name -> io.defang.v1.Deployment
-	97,  // 44: io.defang.v1.TailRequest.since:type_name -> google.protobuf.Timestamp
-	97,  // 45: io.defang.v1.TailRequest.until:type_name -> google.protobuf.Timestamp
-	97,  // 46: io.defang.v1.LogEntry.timestamp:type_name -> google.protobuf.Timestamp
-	72,  // 47: io.defang.v1.TailResponse.entries:type_name -> io.defang.v1.LogEntry
-	51,  // 48: io.defang.v1.GetServicesResponse.services:type_name -> io.defang.v1.ServiceInfo
-	97,  // 49: io.defang.v1.GetServicesResponse.expires_at:type_name -> google.protobuf.Timestamp
-	51,  // 50: io.defang.v1.ProjectUpdate.services:type_name -> io.defang.v1.ServiceInfo
+	99,  // 42: io.defang.v1.ListDeploymentsRequest.until:type_name -> google.protobuf.Timestamp
+	65,  // 43: io.defang.v1.ListDeploymentsResponse.deployments:type_name -> io.defang.v1.Deployment
+	99,  // 44: io.defang.v1.TailRequest.since:type_name -> google.protobuf.Timestamp
+	99,  // 45: io.defang.v1.TailRequest.until:type_name -> google.protobuf.Timestamp
+	99,  // 46: io.defang.v1.LogEntry.timestamp:type_name -> google.protobuf.Timestamp
+	74,  // 47: io.defang.v1.TailResponse.entries:type_name -> io.defang.v1.LogEntry
+	53,  // 48: io.defang.v1.GetServicesResponse.services:type_name -> io.defang.v1.ServiceInfo
+	99,  // 49: io.defang.v1.GetServicesResponse.expires_at:type_name -> google.protobuf.Timestamp
+	53,  // 50: io.defang.v1.ProjectUpdate.services:type_name -> io.defang.v1.ServiceInfo
 	1,   // 51: io.defang.v1.ProjectUpdate.mode:type_name -> io.defang.v1.DeploymentMode
 	0,   // 52: io.defang.v1.ProjectUpdate.provider:type_name -> io.defang.v1.Provider
 	1,   // 53: io.defang.v1.DeployEvent.mode:type_name -> io.defang.v1.DeploymentMode
-	97,  // 54: io.defang.v1.DeployEvent.time:type_name -> google.protobuf.Timestamp
-	51,  // 55: io.defang.v1.SubscribeResponse.service:type_name -> io.defang.v1.ServiceInfo
+	99,  // 54: io.defang.v1.DeployEvent.time:type_name -> google.protobuf.Timestamp
+	53,  // 55: io.defang.v1.SubscribeResponse.service:type_name -> io.defang.v1.ServiceInfo
 	2,   // 56: io.defang.v1.SubscribeResponse.state:type_name -> io.defang.v1.ServiceState
 	10,  // 57: io.defang.v1.WhoAmIResponse.tier:type_name -> io.defang.v1.SubscriptionTier
-	97,  // 58: io.defang.v1.WhoAmIResponse.paid_until:type_name -> google.protobuf.Timestamp
-	97,  // 59: io.defang.v1.WhoAmIResponse.trial_until:type_name -> google.protobuf.Timestamp
+	99,  // 58: io.defang.v1.WhoAmIResponse.paid_until:type_name -> google.protobuf.Timestamp
+	99,  // 59: io.defang.v1.WhoAmIResponse.trial_until:type_name -> google.protobuf.Timestamp
 	0,   // 60: io.defang.v1.EstimateRequest.provider:type_name -> io.defang.v1.Provider
-	98,  // 61: io.defang.v1.EstimateLineItem.cost:type_name -> google.type.Money
+	100, // 61: io.defang.v1.EstimateLineItem.cost:type_name -> google.type.Money
 	0,   // 62: io.defang.v1.EstimateResponse.provider:type_name -> io.defang.v1.Provider
-	98,  // 63: io.defang.v1.EstimateResponse.subtotal:type_name -> google.type.Money
-	89,  // 64: io.defang.v1.EstimateResponse.line_items:type_name -> io.defang.v1.EstimateLineItem
+	100, // 63: io.defang.v1.EstimateResponse.subtotal:type_name -> google.type.Money
+	91,  // 64: io.defang.v1.EstimateResponse.line_items:type_name -> io.defang.v1.EstimateLineItem
 	0,   // 65: io.defang.v1.PreviewRequest.provider:type_name -> io.defang.v1.Provider
 	1,   // 66: io.defang.v1.PreviewRequest.mode:type_name -> io.defang.v1.DeploymentMode
 	11,  // 67: io.defang.v1.GenerateComposeRequest.platform:type_name -> io.defang.v1.SourcePlatform
-	99,  // 68: io.defang.v1.FabricController.GetStatus:input_type -> google.protobuf.Empty
-	99,  // 69: io.defang.v1.FabricController.GetVersion:input_type -> google.protobuf.Empty
-	67,  // 70: io.defang.v1.FabricController.Token:input_type -> io.defang.v1.TokenRequest
-	99,  // 71: io.defang.v1.FabricController.RevokeToken:input_type -> google.protobuf.Empty
-	71,  // 72: io.defang.v1.FabricController.Tail:input_type -> io.defang.v1.TailRequest
-	40,  // 73: io.defang.v1.FabricController.Deploy:input_type -> io.defang.v1.DeployRequest
-	76,  // 74: io.defang.v1.FabricController.Get:input_type -> io.defang.v1.GetRequest
-	99,  // 75: io.defang.v1.FabricController.GetPlaygroundProjectDomain:input_type -> google.protobuf.Empty
-	42,  // 76: io.defang.v1.FabricController.Delete:input_type -> io.defang.v1.DeleteRequest
-	31,  // 77: io.defang.v1.FabricController.Destroy:input_type -> io.defang.v1.DestroyRequest
-	79,  // 78: io.defang.v1.FabricController.Subscribe:input_type -> io.defang.v1.SubscribeRequest
-	81,  // 79: io.defang.v1.FabricController.GetServices:input_type -> io.defang.v1.GetServicesRequest
-	44,  // 80: io.defang.v1.FabricController.GenerateFiles:input_type -> io.defang.v1.GenerateFilesRequest
-	44,  // 81: io.defang.v1.FabricController.StartGenerate:input_type -> io.defang.v1.GenerateFilesRequest
-	48,  // 82: io.defang.v1.FabricController.GenerateStatus:input_type -> io.defang.v1.GenerateStatusRequest
-	33,  // 83: io.defang.v1.FabricController.Debug:input_type -> io.defang.v1.DebugRequest
-	99,  // 84: io.defang.v1.FabricController.SignEULA:input_type -> google.protobuf.Empty
-	99,  // 85: io.defang.v1.FabricController.CheckToS:input_type -> google.protobuf.Empty
-	56,  // 86: io.defang.v1.FabricController.PutSecret:input_type -> io.defang.v1.PutConfigRequest
-	52,  // 87: io.defang.v1.FabricController.DeleteSecrets:input_type -> io.defang.v1.Secrets
-	61,  // 88: io.defang.v1.FabricController.ListSecrets:input_type -> io.defang.v1.ListConfigsRequest
-	57,  // 89: io.defang.v1.FabricController.GetConfigs:input_type -> io.defang.v1.GetConfigsRequest
-	56,  // 90: io.defang.v1.FabricController.PutConfig:input_type -> io.defang.v1.PutConfigRequest
-	60,  // 91: io.defang.v1.FabricController.DeleteConfigs:input_type -> io.defang.v1.DeleteConfigsRequest
-	61,  // 92: io.defang.v1.FabricController.ListConfigs:input_type -> io.defang.v1.ListConfigsRequest
-	64,  // 93: io.defang.v1.FabricController.PutDeployment:input_type -> io.defang.v1.PutDeploymentRequest
-	65,  // 94: io.defang.v1.FabricController.ListDeployments:input_type -> io.defang.v1.ListDeploymentsRequest
-	49,  // 95: io.defang.v1.FabricController.CreateUploadURL:input_type -> io.defang.v1.UploadURLRequest
-	82,  // 96: io.defang.v1.FabricController.DelegateSubdomainZone:input_type -> io.defang.v1.DelegateSubdomainZoneRequest
-	84,  // 97: io.defang.v1.FabricController.DeleteSubdomainZone:input_type -> io.defang.v1.DeleteSubdomainZoneRequest
-	85,  // 98: io.defang.v1.FabricController.GetDelegateSubdomainZone:input_type -> io.defang.v1.GetDelegateSubdomainZoneRequest
-	86,  // 99: io.defang.v1.FabricController.SetOptions:input_type -> io.defang.v1.SetOptionsRequest
-	99,  // 100: io.defang.v1.FabricController.WhoAmI:input_type -> google.protobuf.Empty
-	37,  // 101: io.defang.v1.FabricController.Track:input_type -> io.defang.v1.TrackRequest
-	99,  // 102: io.defang.v1.FabricController.DeleteMe:input_type -> google.protobuf.Empty
+	101, // 68: io.defang.v1.FabricController.GetStatus:input_type -> google.protobuf.Empty
+	101, // 69: io.defang.v1.FabricController.GetVersion:input_type -> google.protobuf.Empty
+	69,  // 70: io.defang.v1.FabricController.Token:input_type -> io.defang.v1.TokenRequest
+	101, // 71: io.defang.v1.FabricController.RevokeToken:input_type -> google.protobuf.Empty
+	73,  // 72: io.defang.v1.FabricController.Tail:input_type -> io.defang.v1.TailRequest
+	42,  // 73: io.defang.v1.FabricController.Deploy:input_type -> io.defang.v1.DeployRequest
+	78,  // 74: io.defang.v1.FabricController.Get:input_type -> io.defang.v1.GetRequest
+	101, // 75: io.defang.v1.FabricController.GetPlaygroundProjectDomain:input_type -> google.protobuf.Empty
+	44,  // 76: io.defang.v1.FabricController.Delete:input_type -> io.defang.v1.DeleteRequest
+	33,  // 77: io.defang.v1.FabricController.Destroy:input_type -> io.defang.v1.DestroyRequest
+	81,  // 78: io.defang.v1.FabricController.Subscribe:input_type -> io.defang.v1.SubscribeRequest
+	83,  // 79: io.defang.v1.FabricController.GetServices:input_type -> io.defang.v1.GetServicesRequest
+	46,  // 80: io.defang.v1.FabricController.GenerateFiles:input_type -> io.defang.v1.GenerateFilesRequest
+	46,  // 81: io.defang.v1.FabricController.StartGenerate:input_type -> io.defang.v1.GenerateFilesRequest
+	50,  // 82: io.defang.v1.FabricController.GenerateStatus:input_type -> io.defang.v1.GenerateStatusRequest
+	35,  // 83: io.defang.v1.FabricController.Debug:input_type -> io.defang.v1.DebugRequest
+	101, // 84: io.defang.v1.FabricController.SignEULA:input_type -> google.protobuf.Empty
+	101, // 85: io.defang.v1.FabricController.CheckToS:input_type -> google.protobuf.Empty
+	58,  // 86: io.defang.v1.FabricController.PutSecret:input_type -> io.defang.v1.PutConfigRequest
+	54,  // 87: io.defang.v1.FabricController.DeleteSecrets:input_type -> io.defang.v1.Secrets
+	63,  // 88: io.defang.v1.FabricController.ListSecrets:input_type -> io.defang.v1.ListConfigsRequest
+	59,  // 89: io.defang.v1.FabricController.GetConfigs:input_type -> io.defang.v1.GetConfigsRequest
+	58,  // 90: io.defang.v1.FabricController.PutConfig:input_type -> io.defang.v1.PutConfigRequest
+	62,  // 91: io.defang.v1.FabricController.DeleteConfigs:input_type -> io.defang.v1.DeleteConfigsRequest
+	63,  // 92: io.defang.v1.FabricController.ListConfigs:input_type -> io.defang.v1.ListConfigsRequest
+	66,  // 93: io.defang.v1.FabricController.PutDeployment:input_type -> io.defang.v1.PutDeploymentRequest
+	67,  // 94: io.defang.v1.FabricController.ListDeployments:input_type -> io.defang.v1.ListDeploymentsRequest
+	51,  // 95: io.defang.v1.FabricController.CreateUploadURL:input_type -> io.defang.v1.UploadURLRequest
+	84,  // 96: io.defang.v1.FabricController.DelegateSubdomainZone:input_type -> io.defang.v1.DelegateSubdomainZoneRequest
+	86,  // 97: io.defang.v1.FabricController.DeleteSubdomainZone:input_type -> io.defang.v1.DeleteSubdomainZoneRequest
+	87,  // 98: io.defang.v1.FabricController.GetDelegateSubdomainZone:input_type -> io.defang.v1.GetDelegateSubdomainZoneRequest
+	88,  // 99: io.defang.v1.FabricController.SetOptions:input_type -> io.defang.v1.SetOptionsRequest
+	101, // 100: io.defang.v1.FabricController.WhoAmI:input_type -> google.protobuf.Empty
+	39,  // 101: io.defang.v1.FabricController.Track:input_type -> io.defang.v1.TrackRequest
+	101, // 102: io.defang.v1.FabricController.DeleteMe:input_type -> google.protobuf.Empty
 	24,  // 103: io.defang.v1.FabricController.VerifyDNSSetup:input_type -> io.defang.v1.VerifyDNSSetupRequest
 	25,  // 104: io.defang.v1.FabricController.ResolveIPAddr:input_type -> io.defang.v1.ResolveIPAddrRequest
 	27,  // 105: io.defang.v1.FabricController.ResolveCNAME:input_type -> io.defang.v1.ResolveCNAMERequest
 	29,  // 106: io.defang.v1.FabricController.ResolveNS:input_type -> io.defang.v1.ResolveNSRequest
-	21,  // 107: io.defang.v1.FabricController.GetSelectedProvider:input_type -> io.defang.v1.GetSelectedProviderRequest
-	23,  // 108: io.defang.v1.FabricController.SetSelectedProvider:input_type -> io.defang.v1.SetSelectedProviderRequest
-	38,  // 109: io.defang.v1.FabricController.CanIUse:input_type -> io.defang.v1.CanIUseRequest
-	88,  // 110: io.defang.v1.FabricController.Estimate:input_type -> io.defang.v1.EstimateRequest
-	91,  // 111: io.defang.v1.FabricController.Preview:input_type -> io.defang.v1.PreviewRequest
-	93,  // 112: io.defang.v1.FabricController.GenerateCompose:input_type -> io.defang.v1.GenerateComposeRequest
-	14,  // 113: io.defang.v1.FabricController.PutStack:input_type -> io.defang.v1.PutStackRequest
-	15,  // 114: io.defang.v1.FabricController.GetStack:input_type -> io.defang.v1.GetStackRequest
-	18,  // 115: io.defang.v1.FabricController.ListStacks:input_type -> io.defang.v1.ListStacksRequest
-	20,  // 116: io.defang.v1.FabricController.DeleteStack:input_type -> io.defang.v1.DeleteStackRequest
-	16,  // 117: io.defang.v1.FabricController.GetDefaultStack:input_type -> io.defang.v1.GetDefaultStackRequest
-	69,  // 118: io.defang.v1.FabricController.GetStatus:output_type -> io.defang.v1.Status
-	70,  // 119: io.defang.v1.FabricController.GetVersion:output_type -> io.defang.v1.Version
-	68,  // 120: io.defang.v1.FabricController.Token:output_type -> io.defang.v1.TokenResponse
-	99,  // 121: io.defang.v1.FabricController.RevokeToken:output_type -> google.protobuf.Empty
-	73,  // 122: io.defang.v1.FabricController.Tail:output_type -> io.defang.v1.TailResponse
-	41,  // 123: io.defang.v1.FabricController.Deploy:output_type -> io.defang.v1.DeployResponse
-	51,  // 124: io.defang.v1.FabricController.Get:output_type -> io.defang.v1.ServiceInfo
-	59,  // 125: io.defang.v1.FabricController.GetPlaygroundProjectDomain:output_type -> io.defang.v1.GetPlaygroundProjectDomainResponse
-	43,  // 126: io.defang.v1.FabricController.Delete:output_type -> io.defang.v1.DeleteResponse
-	32,  // 127: io.defang.v1.FabricController.Destroy:output_type -> io.defang.v1.DestroyResponse
-	80,  // 128: io.defang.v1.FabricController.Subscribe:output_type -> io.defang.v1.SubscribeResponse
-	74,  // 129: io.defang.v1.FabricController.GetServices:output_type -> io.defang.v1.GetServicesResponse
-	46,  // 130: io.defang.v1.FabricController.GenerateFiles:output_type -> io.defang.v1.GenerateFilesResponse
-	47,  // 131: io.defang.v1.FabricController.StartGenerate:output_type -> io.defang.v1.StartGenerateResponse
-	46,  // 132: io.defang.v1.FabricController.GenerateStatus:output_type -> io.defang.v1.GenerateFilesResponse
-	34,  // 133: io.defang.v1.FabricController.Debug:output_type -> io.defang.v1.DebugResponse
-	99,  // 134: io.defang.v1.FabricController.SignEULA:output_type -> google.protobuf.Empty
-	99,  // 135: io.defang.v1.FabricController.CheckToS:output_type -> google.protobuf.Empty
-	99,  // 136: io.defang.v1.FabricController.PutSecret:output_type -> google.protobuf.Empty
-	99,  // 137: io.defang.v1.FabricController.DeleteSecrets:output_type -> google.protobuf.Empty
-	52,  // 138: io.defang.v1.FabricController.ListSecrets:output_type -> io.defang.v1.Secrets
-	58,  // 139: io.defang.v1.FabricController.GetConfigs:output_type -> io.defang.v1.GetConfigsResponse
-	99,  // 140: io.defang.v1.FabricController.PutConfig:output_type -> google.protobuf.Empty
-	99,  // 141: io.defang.v1.FabricController.DeleteConfigs:output_type -> google.protobuf.Empty
-	62,  // 142: io.defang.v1.FabricController.ListConfigs:output_type -> io.defang.v1.ListConfigsResponse
-	99,  // 143: io.defang.v1.FabricController.PutDeployment:output_type -> google.protobuf.Empty
-	66,  // 144: io.defang.v1.FabricController.ListDeployments:output_type -> io.defang.v1.ListDeploymentsResponse
-	50,  // 145: io.defang.v1.FabricController.CreateUploadURL:output_type -> io.defang.v1.UploadURLResponse
-	83,  // 146: io.defang.v1.FabricController.DelegateSubdomainZone:output_type -> io.defang.v1.DelegateSubdomainZoneResponse
-	99,  // 147: io.defang.v1.FabricController.DeleteSubdomainZone:output_type -> google.protobuf.Empty
-	83,  // 148: io.defang.v1.FabricController.GetDelegateSubdomainZone:output_type -> io.defang.v1.DelegateSubdomainZoneResponse
-	99,  // 149: io.defang.v1.FabricController.SetOptions:output_type -> google.protobuf.Empty
-	87,  // 150: io.defang.v1.FabricController.WhoAmI:output_type -> io.defang.v1.WhoAmIResponse
-	99,  // 151: io.defang.v1.FabricController.Track:output_type -> google.protobuf.Empty
-	99,  // 152: io.defang.v1.FabricController.DeleteMe:output_type -> google.protobuf.Empty
-	99,  // 153: io.defang.v1.FabricController.VerifyDNSSetup:output_type -> google.protobuf.Empty
-	26,  // 154: io.defang.v1.FabricController.ResolveIPAddr:output_type -> io.defang.v1.ResolveIPAddrResponse
-	28,  // 155: io.defang.v1.FabricController.ResolveCNAME:output_type -> io.defang.v1.ResolveCNAMEResponse
-	30,  // 156: io.defang.v1.FabricController.ResolveNS:output_type -> io.defang.v1.ResolveNSResponse
-	22,  // 157: io.defang.v1.FabricController.GetSelectedProvider:output_type -> io.defang.v1.GetSelectedProviderResponse
-	99,  // 158: io.defang.v1.FabricController.SetSelectedProvider:output_type -> google.protobuf.Empty
-	39,  // 159: io.defang.v1.FabricController.CanIUse:output_type -> io.defang.v1.CanIUseResponse
-	90,  // 160: io.defang.v1.FabricController.Estimate:output_type -> io.defang.v1.EstimateResponse
-	92,  // 161: io.defang.v1.FabricController.Preview:output_type -> io.defang.v1.PreviewResponse
-	94,  // 162: io.defang.v1.FabricController.GenerateCompose:output_type -> io.defang.v1.GenerateComposeResponse
-	99,  // 163: io.defang.v1.FabricController.PutStack:output_type -> google.protobuf.Empty
-	17,  // 164: io.defang.v1.FabricController.GetStack:output_type -> io.defang.v1.GetStackResponse
-	19,  // 165: io.defang.v1.FabricController.ListStacks:output_type -> io.defang.v1.ListStacksResponse
-	99,  // 166: io.defang.v1.FabricController.DeleteStack:output_type -> google.protobuf.Empty
-	17,  // 167: io.defang.v1.FabricController.GetDefaultStack:output_type -> io.defang.v1.GetStackResponse
-	118, // [118:168] is the sub-list for method output_type
-	68,  // [68:118] is the sub-list for method input_type
+	31,  // 107: io.defang.v1.FabricController.ResolveTXT:input_type -> io.defang.v1.ResolveTXTRequest
+	21,  // 108: io.defang.v1.FabricController.GetSelectedProvider:input_type -> io.defang.v1.GetSelectedProviderRequest
+	23,  // 109: io.defang.v1.FabricController.SetSelectedProvider:input_type -> io.defang.v1.SetSelectedProviderRequest
+	40,  // 110: io.defang.v1.FabricController.CanIUse:input_type -> io.defang.v1.CanIUseRequest
+	90,  // 111: io.defang.v1.FabricController.Estimate:input_type -> io.defang.v1.EstimateRequest
+	93,  // 112: io.defang.v1.FabricController.Preview:input_type -> io.defang.v1.PreviewRequest
+	95,  // 113: io.defang.v1.FabricController.GenerateCompose:input_type -> io.defang.v1.GenerateComposeRequest
+	14,  // 114: io.defang.v1.FabricController.PutStack:input_type -> io.defang.v1.PutStackRequest
+	15,  // 115: io.defang.v1.FabricController.GetStack:input_type -> io.defang.v1.GetStackRequest
+	18,  // 116: io.defang.v1.FabricController.ListStacks:input_type -> io.defang.v1.ListStacksRequest
+	20,  // 117: io.defang.v1.FabricController.DeleteStack:input_type -> io.defang.v1.DeleteStackRequest
+	16,  // 118: io.defang.v1.FabricController.GetDefaultStack:input_type -> io.defang.v1.GetDefaultStackRequest
+	71,  // 119: io.defang.v1.FabricController.GetStatus:output_type -> io.defang.v1.Status
+	72,  // 120: io.defang.v1.FabricController.GetVersion:output_type -> io.defang.v1.Version
+	70,  // 121: io.defang.v1.FabricController.Token:output_type -> io.defang.v1.TokenResponse
+	101, // 122: io.defang.v1.FabricController.RevokeToken:output_type -> google.protobuf.Empty
+	75,  // 123: io.defang.v1.FabricController.Tail:output_type -> io.defang.v1.TailResponse
+	43,  // 124: io.defang.v1.FabricController.Deploy:output_type -> io.defang.v1.DeployResponse
+	53,  // 125: io.defang.v1.FabricController.Get:output_type -> io.defang.v1.ServiceInfo
+	61,  // 126: io.defang.v1.FabricController.GetPlaygroundProjectDomain:output_type -> io.defang.v1.GetPlaygroundProjectDomainResponse
+	45,  // 127: io.defang.v1.FabricController.Delete:output_type -> io.defang.v1.DeleteResponse
+	34,  // 128: io.defang.v1.FabricController.Destroy:output_type -> io.defang.v1.DestroyResponse
+	82,  // 129: io.defang.v1.FabricController.Subscribe:output_type -> io.defang.v1.SubscribeResponse
+	76,  // 130: io.defang.v1.FabricController.GetServices:output_type -> io.defang.v1.GetServicesResponse
+	48,  // 131: io.defang.v1.FabricController.GenerateFiles:output_type -> io.defang.v1.GenerateFilesResponse
+	49,  // 132: io.defang.v1.FabricController.StartGenerate:output_type -> io.defang.v1.StartGenerateResponse
+	48,  // 133: io.defang.v1.FabricController.GenerateStatus:output_type -> io.defang.v1.GenerateFilesResponse
+	36,  // 134: io.defang.v1.FabricController.Debug:output_type -> io.defang.v1.DebugResponse
+	101, // 135: io.defang.v1.FabricController.SignEULA:output_type -> google.protobuf.Empty
+	101, // 136: io.defang.v1.FabricController.CheckToS:output_type -> google.protobuf.Empty
+	101, // 137: io.defang.v1.FabricController.PutSecret:output_type -> google.protobuf.Empty
+	101, // 138: io.defang.v1.FabricController.DeleteSecrets:output_type -> google.protobuf.Empty
+	54,  // 139: io.defang.v1.FabricController.ListSecrets:output_type -> io.defang.v1.Secrets
+	60,  // 140: io.defang.v1.FabricController.GetConfigs:output_type -> io.defang.v1.GetConfigsResponse
+	101, // 141: io.defang.v1.FabricController.PutConfig:output_type -> google.protobuf.Empty
+	101, // 142: io.defang.v1.FabricController.DeleteConfigs:output_type -> google.protobuf.Empty
+	64,  // 143: io.defang.v1.FabricController.ListConfigs:output_type -> io.defang.v1.ListConfigsResponse
+	101, // 144: io.defang.v1.FabricController.PutDeployment:output_type -> google.protobuf.Empty
+	68,  // 145: io.defang.v1.FabricController.ListDeployments:output_type -> io.defang.v1.ListDeploymentsResponse
+	52,  // 146: io.defang.v1.FabricController.CreateUploadURL:output_type -> io.defang.v1.UploadURLResponse
+	85,  // 147: io.defang.v1.FabricController.DelegateSubdomainZone:output_type -> io.defang.v1.DelegateSubdomainZoneResponse
+	101, // 148: io.defang.v1.FabricController.DeleteSubdomainZone:output_type -> google.protobuf.Empty
+	85,  // 149: io.defang.v1.FabricController.GetDelegateSubdomainZone:output_type -> io.defang.v1.DelegateSubdomainZoneResponse
+	101, // 150: io.defang.v1.FabricController.SetOptions:output_type -> google.protobuf.Empty
+	89,  // 151: io.defang.v1.FabricController.WhoAmI:output_type -> io.defang.v1.WhoAmIResponse
+	101, // 152: io.defang.v1.FabricController.Track:output_type -> google.protobuf.Empty
+	101, // 153: io.defang.v1.FabricController.DeleteMe:output_type -> google.protobuf.Empty
+	101, // 154: io.defang.v1.FabricController.VerifyDNSSetup:output_type -> google.protobuf.Empty
+	26,  // 155: io.defang.v1.FabricController.ResolveIPAddr:output_type -> io.defang.v1.ResolveIPAddrResponse
+	28,  // 156: io.defang.v1.FabricController.ResolveCNAME:output_type -> io.defang.v1.ResolveCNAMEResponse
+	30,  // 157: io.defang.v1.FabricController.ResolveNS:output_type -> io.defang.v1.ResolveNSResponse
+	32,  // 158: io.defang.v1.FabricController.ResolveTXT:output_type -> io.defang.v1.ResolveTXTResponse
+	22,  // 159: io.defang.v1.FabricController.GetSelectedProvider:output_type -> io.defang.v1.GetSelectedProviderResponse
+	101, // 160: io.defang.v1.FabricController.SetSelectedProvider:output_type -> google.protobuf.Empty
+	41,  // 161: io.defang.v1.FabricController.CanIUse:output_type -> io.defang.v1.CanIUseResponse
+	92,  // 162: io.defang.v1.FabricController.Estimate:output_type -> io.defang.v1.EstimateResponse
+	94,  // 163: io.defang.v1.FabricController.Preview:output_type -> io.defang.v1.PreviewResponse
+	96,  // 164: io.defang.v1.FabricController.GenerateCompose:output_type -> io.defang.v1.GenerateComposeResponse
+	101, // 165: io.defang.v1.FabricController.PutStack:output_type -> google.protobuf.Empty
+	17,  // 166: io.defang.v1.FabricController.GetStack:output_type -> io.defang.v1.GetStackResponse
+	19,  // 167: io.defang.v1.FabricController.ListStacks:output_type -> io.defang.v1.ListStacksResponse
+	101, // 168: io.defang.v1.FabricController.DeleteStack:output_type -> google.protobuf.Empty
+	17,  // 169: io.defang.v1.FabricController.GetDefaultStack:output_type -> io.defang.v1.GetStackResponse
+	119, // [119:170] is the sub-list for method output_type
+	68,  // [68:119] is the sub-list for method input_type
 	68,  // [68:68] is the sub-list for extension type_name
 	68,  // [68:68] is the sub-list for extension extendee
 	0,   // [0:68] is the sub-list for field type_name
@@ -6901,7 +7008,7 @@ func file_io_defang_v1_fabric_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_io_defang_v1_fabric_proto_rawDesc), len(file_io_defang_v1_fabric_proto_rawDesc)),
 			NumEnums:      13,
-			NumMessages:   84,
+			NumMessages:   86,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/src/protos/io/defang/v1/fabric.proto
+++ b/src/protos/io/defang/v1/fabric.proto
@@ -123,6 +123,9 @@ service FabricController {
   rpc ResolveNS(ResolveNSRequest) returns (ResolveNSResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
   }
+  rpc ResolveTXT(ResolveTXTRequest) returns (ResolveTXTResponse) {
+    option idempotency_level = NO_SIDE_EFFECTS;
+  }
 
   rpc GetSelectedProvider(GetSelectedProviderRequest) returns (GetSelectedProviderResponse) {
     option deprecated = true; // deprecated in favor of stacks; kept for old CLI clients
@@ -261,6 +264,15 @@ message ResolveNSRequest {
 
 message ResolveNSResponse {
   repeated string hosts = 1;
+}
+
+message ResolveTXTRequest {
+  string domain = 1;
+  string ns_server = 2; // optional; if empty, resolve from root
+}
+
+message ResolveTXTResponse {
+  repeated string txts = 1;
 }
 
 message DestroyRequest {


### PR DESCRIPTION
## Description

Adds the `ResolveTXT` RPC to `FabricController`, mirroring the existing
`ResolveIPAddr` / `ResolveCNAME` / `ResolveNS` shape:

- request: `domain` (required) + `ns_server` (optional; empty = recursive from root)
- response: `repeated string txts`
- `idempotency_level = NO_SIDE_EFFECTS`

This unblocks two follow-ups:

1. **Server-side handler in `defang-mvp`** — same place that handles the existing three Resolve* RPCs (added in defang-mvp#2914). Will land separately once defang-mvp picks up the regenerated bindings via its dependency on this repo.
2. **CLI client wiring in #2069** — that PR introduces `FabricResolverClient` and `FabricResolver`; once this proto change is merged, #2069 picks up `ResolveTXT` and adds:
   - `FabricClient.ResolveTXT` (interface)
   - `GrpcClient.ResolveTXT` (impl)
   - `MockFabricClient.ResolveTXT` (test stub)
   - `FabricResolverClient.ResolveTXT` (subset interface)
   - `FabricResolver.LookupTXT` (impl)

The `pkg/dns.Resolver` interface already gained `LookupTXT` (used by Azure cert validation in `pkg/cli/client/byoc/azure/cert.go`); the fabric resolver impl is the only Resolver still missing it once #2069 lands.

## Linked issues

Prereq for #2069 and the eventual server-side change in defang-mvp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added DNS TXT record resolution capability to the Fabric Controller service, enabling queries for domain TXT records with optional nameserver specification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->