### PR TITLE
dns: add LookupTXT to Resolver interface

### DIFF
--- a/src/pkg/cli/cert_test.go
+++ b/src/pkg/cli/cert_test.go
@@ -191,6 +191,10 @@ func (mr *MockResolver) LookupNS(ctx context.Context, domain string) ([]*net.NS,
 	mr.calls++
 	return []*net.NS{{Host: ""}}, nil
 }
+func (mr *MockResolver) LookupTXT(ctx context.Context, domain string) ([]string, error) {
+	mr.calls++
+	return nil, nil
+}
 
 func TestHttpClient(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/src/pkg/cli/client/byoc/aws/domain_test.go
+++ b/src/pkg/cli/client/byoc/aws/domain_test.go
@@ -248,6 +248,12 @@ func (r *CallbackMockResolver) LookupCNAME(ctx context.Context, domain string) (
 	}
 	return r.MockResolver.LookupCNAME(ctx, domain)
 }
+func (r *CallbackMockResolver) LookupTXT(ctx context.Context, domain string) ([]string, error) {
+	if r.Callback != nil {
+		r.Callback(domain)
+	}
+	return r.MockResolver.LookupTXT(ctx, domain)
+}
 
 func TestPrepareDomainDelegation(t *testing.T) {
 	ctx := t.Context()

--- a/src/pkg/dns/mock.go
+++ b/src/pkg/dns/mock.go
@@ -56,3 +56,6 @@ func (r MockResolver) LookupNS(ctx context.Context, domain string) ([]*net.NS, e
 	ns, err := r.records(DNSRequest{Type: "NS", Domain: domain})
 	return convert(ns, func(n string) *net.NS { return &net.NS{Host: n} }), err
 }
+func (r MockResolver) LookupTXT(ctx context.Context, domain string) ([]string, error) {
+	return r.records(DNSRequest{Type: "TXT", Domain: domain})
+}

--- a/src/pkg/dns/resolver.go
+++ b/src/pkg/dns/resolver.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"slices"
 	"sort"
+	"strings"
 
 	"github.com/DefangLabs/defang/src/pkg"
 	"github.com/miekg/dns"
@@ -16,6 +17,7 @@ type Resolver interface {
 	LookupIPAddr(ctx context.Context, domain string) ([]net.IPAddr, error)
 	LookupCNAME(ctx context.Context, domain string) (string, error)
 	LookupNS(ctx context.Context, domain string) ([]*net.NS, error)
+	LookupTXT(ctx context.Context, domain string) ([]string, error)
 }
 
 type RootResolver struct{}
@@ -59,6 +61,10 @@ func (r RootResolver) LookupCNAME(ctx context.Context, domain string) (string, e
 
 func (r RootResolver) LookupNS(ctx context.Context, domain string) ([]*net.NS, error) {
 	return r.getResolver(ctx, domain).LookupNS(ctx, domain)
+}
+
+func (r RootResolver) LookupTXT(ctx context.Context, domain string) ([]string, error) {
+	return r.getResolver(ctx, domain).LookupTXT(ctx, domain)
 }
 
 func (r RootResolver) getResolver(ctx context.Context, domain string) Resolver {
@@ -174,6 +180,28 @@ func (r DirectResolver) LookupCNAME(ctx context.Context, domain string) (string,
 		}
 	}
 	return "", ErrNoSuchHost
+}
+
+func (r DirectResolver) LookupTXT(ctx context.Context, domain string) ([]string, error) {
+	res, err := r.query(ctx, domain, dns.TypeTXT)
+	if err != nil {
+		return nil, err
+	}
+
+	var result []string
+	// A single TXT response can be split into multiple "strings" on the wire
+	// (each ≤255 bytes); the convention is to concatenate them. miekg/dns
+	// already returns each record's strings as a []string in TXT.Txt, so we
+	// just join those and emit one entry per RR.
+	for _, rr := range res.Answer {
+		if t, ok := rr.(*dns.TXT); ok {
+			result = append(result, strings.Join(t.Txt, ""))
+		}
+	}
+	if len(result) == 0 {
+		return nil, ErrNoSuchHost
+	}
+	return result, nil
 }
 
 func (r DirectResolver) LookupNS(ctx context.Context, domain string) ([]*net.NS, error) {

--- a/src/pkg/dns/resolver.go
+++ b/src/pkg/dns/resolver.go
@@ -64,7 +64,18 @@ func (r RootResolver) LookupNS(ctx context.Context, domain string) ([]*net.NS, e
 }
 
 func (r RootResolver) LookupTXT(ctx context.Context, domain string) ([]string, error) {
-	return r.getResolver(ctx, domain).LookupTXT(ctx, domain)
+	for range 10 {
+		txts, err := r.getResolver(ctx, domain).LookupTXT(ctx, domain)
+		if err != nil {
+			if cnameErr, ok := err.(ErrCNAMEFound); ok {
+				domain = cnameErr.CNAME()
+				continue
+			}
+			return nil, err
+		}
+		return txts, nil
+	}
+	return nil, errors.New("too many CNAME lookups")
 }
 
 func (r RootResolver) getResolver(ctx context.Context, domain string) Resolver {
@@ -189,6 +200,7 @@ func (r DirectResolver) LookupTXT(ctx context.Context, domain string) ([]string,
 	}
 
 	var result []string
+	var cname string
 	// A single TXT response can be split into multiple "strings" on the wire
 	// (each ≤255 bytes); the convention is to concatenate them. miekg/dns
 	// already returns each record's strings as a []string in TXT.Txt, so we
@@ -196,9 +208,16 @@ func (r DirectResolver) LookupTXT(ctx context.Context, domain string) ([]string,
 	for _, rr := range res.Answer {
 		if t, ok := rr.(*dns.TXT); ok {
 			result = append(result, strings.Join(t.Txt, ""))
+		} else if cn, ok := rr.(*dns.CNAME); ok {
+			cname = cn.Target
 		}
 	}
 	if len(result) == 0 {
+		// No TXT record but a CNAME — surface it so RootResolver can
+		// follow the alias, matching LookupIPAddr's behavior.
+		if cname != "" {
+			return nil, ErrCNAMEFound(cname)
+		}
 		return nil, ErrNoSuchHost
 	}
 	return result, nil


### PR DESCRIPTION
## Description

Adds `LookupTXT(ctx, domain) ([]string, error)` to `dns.Resolver` and implementations:

- **DirectResolver** — issues a `TypeTXT` query, joins each record's wire-split strings into one entry per RR
- **RootResolver** — delegates to its per-domain DirectResolver
- **MockResolver** — reads from `Records[{Type: \"TXT\"}]`
- Test stubs (`cli.MockResolver`, `aws.CallbackMockResolver`) gain matching `LookupTXT` methods to keep satisfying the interface

## Why

Prereq for two follow-ups:

1. **defang-mvp `ResolveTXT` server handler** — calls `resolver.LookupTXT(ctx, req.Domain)`, mirroring the existing `ResolveCNAME` / `ResolveNS` server impls.
2. **#2069 (fabric resolver)** — adds a fabric-backed `Resolver` impl; once this lands, that PR's `FabricResolver` gains a matching `LookupTXT` that calls the new `ResolveTXT` RPC (added in #2100).

The cert-validation flow on `edw/azure-cert-gen` already consumes these primitives (Azure managed-cert TXT polling), but its `cert.go` integration is intentionally not part of this PR — kept narrow so server-side and client-side teams can land in any order.

## Linked issues

Builds on #2100 (proto: add ResolveTXT RPC).

## Checklist

- [x] Self-review
- [x] Tests pass (`go test -short ./pkg/dns/ ./pkg/cli/ ./pkg/cli/client/byoc/aws/`)
- [ ] No new tests — interface addition; behavior is exercised by integration tests on the consumers' branches

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * DNS resolver now supports TXT record lookups across resolver implementations, including CNAME-following behavior and proper TXT record assembly.

* **Tests**
  * Test scaffolding and mock resolvers updated to support TXT record resolution, improving coverage for DNS- and certificate-related flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->