### PR TITLE
Use defang cli client id for azure login

### DIFF
--- a/src/pkg/clouds/azure/login.go
+++ b/src/pkg/clouds/azure/login.go
@@ -24,10 +24,10 @@ import (
 const (
 	// managementScope is the OAuth2 scope for ARM (management plane) calls.
 	managementScope = "https://management.azure.com/.default"
-	// azureCLIClientID is Microsoft's public client ID for Azure CLI. Using
+	// defangCLIClientID is Microsoft's public client ID for Azure CLI. Using
 	// it means the user sees the same consent prompt they would from
 	// `az login --use-device-code`, and we don't need to register our own app.
-	azureCLIClientID = "04b07795-8ddb-461a-bbee-02f9e1bf7b46"
+	defangCLIClientID = "e6b89a2c-82c7-4072-85e5-9ee7e838d5cf"
 	// defaultTenant routes through Microsoft's "organizations" tenant so any
 	// work/school account can authenticate when we can't discover the
 	// subscription's specific tenant.
@@ -158,7 +158,7 @@ func (a *Azure) Authenticate(ctx context.Context, interactive bool) error {
 		}
 	}
 
-	client, err := public.New(azureCLIClientID,
+	client, err := public.New(defangCLIClientID,
 		public.WithAuthority("https://login.microsoftonline.com/"+tenant),
 		public.WithCache(&defangMSALCache{store: a.TokenStore, key: msalCacheKey}),
 	)

--- a/src/pkg/clouds/azure/login.go
+++ b/src/pkg/clouds/azure/login.go
@@ -24,9 +24,7 @@ import (
 const (
 	// managementScope is the OAuth2 scope for ARM (management plane) calls.
 	managementScope = "https://management.azure.com/.default"
-	// defangCLIClientID is Microsoft's public client ID for Azure CLI. Using
-	// it means the user sees the same consent prompt they would from
-	// `az login --use-device-code`, and we don't need to register our own app.
+	// defangCLIClientID is defang's public client ID for Azure CLI.
 	defangCLIClientID = "e6b89a2c-82c7-4072-85e5-9ee7e838d5cf"
 	// defaultTenant routes through Microsoft's "organizations" tenant so any
 	// work/school account can authenticate when we can't discover the


### PR DESCRIPTION
## Description
Use defang cli client id for azure login

## Linked Issues
Fixes https://github.com/DefangLabs/defang/issues/2065

## Checklist

- [X] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated Azure authentication to use correct client credentials for improved authentication reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->