### PR TITLE
fix(agent): update GetClientWithRetry to use fabricAddr and enhance e…

### DIFF
--- a/src/pkg/agent/tools/auth.go
+++ b/src/pkg/agent/tools/auth.go
@@ -7,16 +7,16 @@ import (
 	"github.com/DefangLabs/defang/src/pkg/cli/client"
 )
 
-func GetClientWithRetry(ctx context.Context, cli CLIInterface, config StackConfig) (*client.GrpcClient, error) {
-	client, err := cli.Connect(ctx, config.FabricAddr)
+func GetClientWithRetry(ctx context.Context, cli CLIInterface, fabricAddr string) (*client.GrpcClient, error) {
+	client, err := cli.Connect(ctx, fabricAddr)
 	if err != nil {
-		err = cli.InteractiveLoginMCP(ctx, config.FabricAddr, common.MCPDevelopmentClient)
+		err = cli.InteractiveLoginMCP(ctx, fabricAddr, common.MCPDevelopmentClient)
 		if err != nil {
 			return nil, err
 		}
 
 		// Reconnect with the new token
-		client, err = cli.Connect(ctx, config.FabricAddr)
+		client, err = cli.Connect(ctx, fabricAddr)
 		if err != nil {
 			return nil, err
 		}

--- a/src/pkg/agent/tools/deploy.go
+++ b/src/pkg/agent/tools/deploy.go
@@ -31,7 +31,7 @@ func HandleDeployTool(ctx context.Context, loader client.Loader, params DeployPa
 	}
 
 	term.Debug("Function invoked: cli.Connect")
-	client, err := GetClientWithRetry(ctx, cli, sc)
+	client, err := GetClientWithRetry(ctx, cli, sc.FabricAddr)
 	if err != nil {
 		var noBrowserErr auth.ErrNoBrowser
 		if errors.As(err, &noBrowserErr) {

--- a/src/pkg/agent/tools/deploy_test.go
+++ b/src/pkg/agent/tools/deploy_test.go
@@ -51,9 +51,9 @@ func (m *MockDeployCLI) Connect(ctx context.Context, fabricAddr string) (*client
 	return &client.GrpcClient{}, nil
 }
 
-func (m *MockDeployCLI) NewProvider(ctx context.Context, providerId client.ProviderID, client client.FabricClient, stack string) client.Provider {
+func (m *MockDeployCLI) NewProvider(ctx context.Context, providerId client.ProviderID, fabric client.FabricClient, stack string) client.Provider {
 	m.CallLog = append(m.CallLog, fmt.Sprintf("NewProvider(%s)", providerId))
-	return nil
+	return client.MockProvider{}
 }
 
 func (m *MockDeployCLI) InteractiveLoginMCP(ctx context.Context, fabricAddr string, mcpClient string) error {

--- a/src/pkg/agent/tools/destroy.go
+++ b/src/pkg/agent/tools/destroy.go
@@ -20,7 +20,7 @@ type DestroyParams struct {
 
 func HandleDestroyTool(ctx context.Context, loader client.Loader, params DestroyParams, cli CLIInterface, ec elicitations.Controller, sc StackConfig) (string, error) {
 	term.Debug("Function invoked: cli.Connect")
-	client, err := GetClientWithRetry(ctx, cli, sc)
+	client, err := GetClientWithRetry(ctx, cli, sc.FabricAddr)
 	if err != nil {
 		var noBrowserErr auth.ErrNoBrowser
 		if errors.As(err, &noBrowserErr) {

--- a/src/pkg/agent/tools/destroy_test.go
+++ b/src/pkg/agent/tools/destroy_test.go
@@ -39,7 +39,7 @@ func (m *MockDestroyCLI) Connect(ctx context.Context, fabricAddr string) (*clien
 
 func (m *MockDestroyCLI) NewProvider(ctx context.Context, providerId client.ProviderID, grpcClient client.FabricClient, stack string) client.Provider {
 	m.CallLog = append(m.CallLog, fmt.Sprintf("NewProvider(%s)", providerId))
-	return nil
+	return client.MockProvider{}
 }
 
 func (m *MockDestroyCLI) ComposeDown(ctx context.Context, projectName string, grpcClient *client.GrpcClient, provider client.Provider) (string, error) {

--- a/src/pkg/agent/tools/estimate.go
+++ b/src/pkg/agent/tools/estimate.go
@@ -28,7 +28,7 @@ func HandleEstimateTool(ctx context.Context, loader client.Loader, params Estima
 	}
 
 	term.Debug("Function invoked: cli.Connect")
-	fabric, err := GetClientWithRetry(ctx, cli, sc)
+	fabric, err := GetClientWithRetry(ctx, cli, sc.FabricAddr)
 	if err != nil {
 		var noBrowserErr auth.ErrNoBrowser
 		if errors.As(err, &noBrowserErr) {

--- a/src/pkg/agent/tools/listConfig.go
+++ b/src/pkg/agent/tools/listConfig.go
@@ -21,7 +21,7 @@ type ListConfigParams struct {
 // HandleListConfigTool handles the list config tool logic
 func HandleListConfigTool(ctx context.Context, loader client.Loader, params ListConfigParams, cli CLIInterface, ec elicitations.Controller, sc StackConfig) (string, error) {
 	term.Debug("Function invoked: cli.Connect")
-	client, err := GetClientWithRetry(ctx, cli, sc)
+	client, err := GetClientWithRetry(ctx, cli, sc.FabricAddr)
 	if err != nil {
 		var noBrowserErr auth.ErrNoBrowser
 		if errors.As(err, &noBrowserErr) {
@@ -56,11 +56,11 @@ func HandleListConfigTool(ctx context.Context, loader client.Loader, params List
 
 	numConfigs := len(config.Names)
 	if numConfigs == 0 {
-		return fmt.Sprintf("No config variables found for the project %q.", projectName), nil
+		return fmt.Sprintf("No config variables found for the project %q in stack %q.", projectName, sc.Stack.Name), nil
 	}
 
 	configNames := make([]string, numConfigs)
 	copy(configNames, config.Names)
 
-	return fmt.Sprintf("Here is the list of config variables for the project %q: %v", projectName, strings.Join(configNames, ", ")), nil
+	return fmt.Sprintf("Here is the list of config variables for the project %q in stack %q: %v", projectName, sc.Stack.Name, strings.Join(configNames, ", ")), nil
 }

--- a/src/pkg/agent/tools/listConfig_test.go
+++ b/src/pkg/agent/tools/listConfig_test.go
@@ -36,9 +36,9 @@ func (m *MockListConfigCLI) Connect(ctx context.Context, fabricAddr string) (*cl
 	return &client.GrpcClient{}, nil
 }
 
-func (m *MockListConfigCLI) NewProvider(ctx context.Context, providerId client.ProviderID, client client.FabricClient, stack string) client.Provider {
+func (m *MockListConfigCLI) NewProvider(ctx context.Context, providerId client.ProviderID, fabric client.FabricClient, stack string) client.Provider {
 	m.CallLog = append(m.CallLog, fmt.Sprintf("NewProvider(%s)", providerId))
-	return nil // Mock provider
+	return client.MockProvider{}
 }
 
 func (m *MockListConfigCLI) LoadProjectNameWithFallback(ctx context.Context, loader client.Loader, provider client.Provider) (string, error) {
@@ -119,7 +119,7 @@ func TestHandleListConfigTool(t *testing.T) {
 					Names: []string{"DATABASE_URL"},
 				}
 			},
-			expectedTextContains: "Here is the list of config variables for the project \"test-project\": DATABASE_URL",
+			expectedTextContains: "Here is the list of config variables for the project \"test-project\" in stack \"test-stack\": DATABASE_URL",
 		},
 	}
 

--- a/src/pkg/agent/tools/logs.go
+++ b/src/pkg/agent/tools/logs.go
@@ -42,7 +42,7 @@ func HandleLogsTool(ctx context.Context, loader client.Loader, params LogsParams
 	}
 
 	term.Debug("Function invoked: cli.Connect")
-	client, err := GetClientWithRetry(ctx, cli, sc)
+	client, err := GetClientWithRetry(ctx, cli, sc.FabricAddr)
 	if err != nil {
 		var noBrowserErr auth.ErrNoBrowser
 		if errors.As(err, &noBrowserErr) {

--- a/src/pkg/agent/tools/project_name.go
+++ b/src/pkg/agent/tools/project_name.go
@@ -1,0 +1,21 @@
+package tools
+
+import (
+	"context"
+
+	"github.com/DefangLabs/defang/src/pkg/agent/common"
+	"github.com/DefangLabs/defang/src/pkg/cli/client"
+)
+
+type ProjectNameParams struct {
+	common.LoaderParams
+}
+
+// HandleProjectNameTool handles the project name tool logic
+func HandleProjectNameTool(ctx context.Context, loader client.Loader) (string, error) {
+	pn, _, err := loader.LoadProjectName(ctx)
+	if err != nil {
+		return "", err
+	}
+	return pn, nil
+}

--- a/src/pkg/agent/tools/provider.go
+++ b/src/pkg/agent/tools/provider.go
@@ -50,6 +50,9 @@ func (pp *providerPreparer) SetupProvider(ctx context.Context, stack *stacks.Par
 
 	term.Debug("Function invoked: cli.NewProvider")
 	provider := pp.pc.NewProvider(ctx, stack.Provider, pp.fc, stack.Name)
+	if err := provider.Authenticate(ctx, pp.ec.IsSupported()); err != nil {
+		return nil, nil, fmt.Errorf("failed to authenticate with provider %q: %w", stack.Provider, err)
+	}
 	providerID := stack.Provider
 	return &providerID, provider, nil
 }

--- a/src/pkg/agent/tools/removeConfig.go
+++ b/src/pkg/agent/tools/removeConfig.go
@@ -22,7 +22,7 @@ type RemoveConfigParams struct {
 // HandleRemoveConfigTool handles the remove config tool logic
 func HandleRemoveConfigTool(ctx context.Context, loader client.Loader, params RemoveConfigParams, cli CLIInterface, ec elicitations.Controller, sc StackConfig) (string, error) {
 	term.Debug("Function invoked: cli.Connect")
-	client, err := GetClientWithRetry(ctx, cli, sc)
+	client, err := GetClientWithRetry(ctx, cli, sc.FabricAddr)
 	if err != nil {
 		var noBrowserErr auth.ErrNoBrowser
 		if errors.As(err, &noBrowserErr) {
@@ -49,10 +49,10 @@ func HandleRemoveConfigTool(ctx context.Context, loader client.Loader, params Re
 	if err := cli.ConfigDelete(ctx, projectName, provider, params.Name); err != nil {
 		// Show a warning (not an error) if the config was not found
 		if connect.CodeOf(err) == connect.CodeNotFound {
-			return fmt.Sprintf("Config variable %q not found in project %q", params.Name, projectName), nil
+			return fmt.Sprintf("Config variable %q not found in project %q in stack %q", params.Name, projectName, sc.Stack.Name), nil
 		}
-		return "", fmt.Errorf("failed to remove config variable %q from project %q: %w", params.Name, projectName, err)
+		return "", fmt.Errorf("failed to remove config variable %q from project %q in stack %q: %w", params.Name, projectName, sc.Stack.Name, err)
 	}
 
-	return fmt.Sprintf("Successfully removed the config variable %q from project %q", params.Name, projectName), nil
+	return fmt.Sprintf("Successfully removed the config variable %q from project %q in stack %q", params.Name, projectName, sc.Stack.Name), nil
 }

--- a/src/pkg/agent/tools/removeConfig_test.go
+++ b/src/pkg/agent/tools/removeConfig_test.go
@@ -36,9 +36,9 @@ func (m *MockRemoveConfigCLI) Connect(ctx context.Context, fabricAddr string) (*
 	return &client.GrpcClient{}, nil
 }
 
-func (m *MockRemoveConfigCLI) NewProvider(ctx context.Context, providerId client.ProviderID, client client.FabricClient, stack string) client.Provider {
+func (m *MockRemoveConfigCLI) NewProvider(ctx context.Context, providerId client.ProviderID, fabric client.FabricClient, stack string) client.Provider {
 	m.CallLog = append(m.CallLog, fmt.Sprintf("NewProvider(%s)", providerId))
-	return nil // Mock provider
+	return client.MockProvider{}
 }
 
 func (m *MockRemoveConfigCLI) LoadProjectNameWithFallback(ctx context.Context, loader client.Loader, provider client.Provider) (string, error) {
@@ -113,7 +113,7 @@ func TestHandleRemoveConfigTool(t *testing.T) {
 				m.ConfigDeleteError = errors.New("failed to delete config")
 			},
 			expectError:   true,
-			expectedError: "failed to remove config variable \"DATABASE_URL\" from project \"test-project\": failed to delete config",
+			expectedError: "failed to remove config variable \"DATABASE_URL\" from project \"test-project\" in stack \"test-stack\": failed to delete config",
 		},
 		{
 			name:       "successful_config_removal",
@@ -123,7 +123,7 @@ func TestHandleRemoveConfigTool(t *testing.T) {
 				// No errors, successful removal
 			},
 			expectError:          false,
-			expectedTextContains: "Successfully removed the config variable \"DATABASE_URL\" from project \"test-project\"",
+			expectedTextContains: "Successfully removed the config variable \"DATABASE_URL\" from project \"test-project\" in stack \"test-stack\"",
 		},
 	}
 

--- a/src/pkg/agent/tools/services.go
+++ b/src/pkg/agent/tools/services.go
@@ -23,7 +23,7 @@ type ServicesParams struct {
 
 func HandleServicesTool(ctx context.Context, loader client.Loader, params ServicesParams, cli CLIInterface, ec elicitations.Controller, sc StackConfig) (string, error) {
 	term.Debug("Function invoked: cli.Connect")
-	client, err := GetClientWithRetry(ctx, cli, sc)
+	client, err := GetClientWithRetry(ctx, cli, sc.FabricAddr)
 	if err != nil {
 		var noBrowserErr auth.ErrNoBrowser
 		if errors.As(err, &noBrowserErr) {

--- a/src/pkg/agent/tools/setConfig.go
+++ b/src/pkg/agent/tools/setConfig.go
@@ -24,7 +24,7 @@ type SetConfigParams struct {
 
 func HandleSetConfig(ctx context.Context, loader client.Loader, params SetConfigParams, cliInterface CLIInterface, ec elicitations.Controller, sc StackConfig) (string, error) {
 	term.Debug("Function invoked: cli.Connect")
-	client, err := GetClientWithRetry(ctx, cliInterface, sc)
+	client, err := GetClientWithRetry(ctx, cliInterface, sc.FabricAddr)
 	if err != nil {
 		var noBrowserErr auth.ErrNoBrowser
 		if errors.As(err, &noBrowserErr) {
@@ -71,5 +71,5 @@ func HandleSetConfig(ctx context.Context, loader client.Loader, params SetConfig
 		return "", fmt.Errorf("failed to set config: %w", err)
 	}
 
-	return fmt.Sprintf("Successfully set the config variable %q for project %q", params.Name, params.ProjectName), nil
+	return fmt.Sprintf("Successfully set the config variable %q for project %q in stack %q", params.Name, params.ProjectName, sc.Stack.Name), nil
 }

--- a/src/pkg/agent/tools/setConfig_test.go
+++ b/src/pkg/agent/tools/setConfig_test.go
@@ -64,6 +64,10 @@ func (p *MockProvider) AccountInfo(context.Context) (*client.AccountInfo, error)
 	return &client.AccountInfo{}, nil
 }
 
+func (p *MockProvider) Authenticate(context.Context, bool) error {
+	return nil
+}
+
 func (m *MockSetConfigCLI) LoadProjectNameWithFallback(ctx context.Context, loader client.Loader, provider client.Provider) (string, error) {
 	m.LoadProjectNameCalled = true
 	if m.LoadProjectNameError != nil {

--- a/src/pkg/agent/tools/tools.go
+++ b/src/pkg/agent/tools/tools.go
@@ -10,7 +10,7 @@ func CollectDefangTools(ec elicitations.Controller, sc StackConfig) []ai.Tool {
 	return []ai.Tool{
 		ai.NewTool(
 			"services",
-			"List deployed services for the project in the current working directory",
+			"List deployed services for the selected project stack in the current working directory",
 			func(ctx *ai.ToolContext, params ServicesParams) (string, error) {
 				loader, err := common.ConfigureAgentLoader(params.LoaderParams)
 				if err != nil {
@@ -21,7 +21,7 @@ func CollectDefangTools(ec elicitations.Controller, sc StackConfig) []ai.Tool {
 			},
 		),
 		ai.NewTool("deploy",
-			"Initiate deployment of the application defined in the docker-compose files in the current working directory",
+			"Initiate deployment of the application stack defined in the docker-compose files in the current working directory",
 			func(ctx *ai.ToolContext, params DeployParams) (string, error) {
 				loader, err := common.ConfigureAgentLoader(params.LoaderParams)
 				if err != nil {
@@ -32,7 +32,7 @@ func CollectDefangTools(ec elicitations.Controller, sc StackConfig) []ai.Tool {
 			},
 		),
 		ai.NewTool("destroy",
-			"Destroy the deployed application defined in the docker-compose files in the current working directory",
+			"Destroy the deployed application in the selected stack, defined in the docker-compose files in the current working directory",
 			func(ctx *ai.ToolContext, params DestroyParams) (string, error) {
 				loader, err := common.ConfigureAgentLoader(params.LoaderParams)
 				if err != nil {
@@ -43,7 +43,7 @@ func CollectDefangTools(ec elicitations.Controller, sc StackConfig) []ai.Tool {
 			},
 		),
 		ai.NewTool("logs",
-			"Fetch logs for the application in pages of up to 100 lines. You can use the 'since' and 'until' parameters to page through logs by time.",
+			"Fetch logs for the application in the selected stack, in pages of up to 100 lines. You can use the 'since' and 'until' parameters to page through logs by time.",
 			func(ctx *ai.ToolContext, params LogsParams) (string, error) {
 				loader, err := common.ConfigureAgentLoader(params.LoaderParams)
 				if err != nil {
@@ -65,7 +65,7 @@ func CollectDefangTools(ec elicitations.Controller, sc StackConfig) []ai.Tool {
 			},
 		),
 		ai.NewTool("set_config",
-			"Set a config variable for the defang project",
+			"Set a config variable for the currently selected stack in the Defang project",
 			func(ctx *ai.ToolContext, params SetConfigParams) (string, error) {
 				loader, err := common.ConfigureAgentLoader(params.LoaderParams)
 				if err != nil {
@@ -76,7 +76,7 @@ func CollectDefangTools(ec elicitations.Controller, sc StackConfig) []ai.Tool {
 			},
 		),
 		ai.NewTool("select_stack",
-			"Select the deployment stack for the defang project",
+			"Select the deployment stack for the Defang project",
 			func(ctx *ai.ToolContext, params SelectStackParams) (string, error) {
 				return HandleSelectStackTool(ctx.Context, params, sc)
 			},
@@ -112,7 +112,7 @@ func CollectDefangTools(ec elicitations.Controller, sc StackConfig) []ai.Tool {
 			},
 		),
 		ai.NewTool("remove_config",
-			"Remove a config variable from the defang project",
+			"Remove a config variable from the currently selected stack in the Defang project",
 			func(ctx *ai.ToolContext, params RemoveConfigParams) (string, error) {
 				loader, err := common.ConfigureAgentLoader(params.LoaderParams)
 				if err != nil {
@@ -123,7 +123,7 @@ func CollectDefangTools(ec elicitations.Controller, sc StackConfig) []ai.Tool {
 			},
 		),
 		ai.NewTool("list_configs",
-			"List config variables for the defang project",
+			"List config variables for the currently selected stack in the Defang project",
 			func(ctx *ai.ToolContext, params ListConfigParams) (string, error) {
 				loader, err := common.ConfigureAgentLoader(params.LoaderParams)
 				if err != nil {
@@ -131,6 +131,16 @@ func CollectDefangTools(ec elicitations.Controller, sc StackConfig) []ai.Tool {
 				}
 				cli := &DefaultToolCLI{}
 				return HandleListConfigTool(ctx.Context, loader, params, cli, ec, sc)
+			},
+		),
+		ai.NewTool("project_name",
+			"Get the current project name",
+			func(ctx *ai.ToolContext, params ProjectNameParams) (string, error) {
+				loader, err := common.ConfigureAgentLoader(params.LoaderParams)
+				if err != nil {
+					return "Failed to configure loader", err
+				}
+				return HandleProjectNameTool(ctx, loader)
 			},
 		),
 	}

--- a/src/pkg/cli/client/mock.go
+++ b/src/pkg/cli/client/mock.go
@@ -67,6 +67,10 @@ func (MockProvider) AccountInfo(context.Context) (*AccountInfo, error) {
 	return &AccountInfo{}, nil
 }
 
+func (MockProvider) Authenticate(context.Context, bool) error {
+	return nil
+}
+
 func (MockProvider) GetStackName() string {
 	return "test"
 }


### PR DESCRIPTION
…rror messages for stack context

Agent must call Authenticate to auth to the cloud

## Description

<!-- Concise description of what this PR is tackling. -->

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `project_name` tool to retrieve the current project name.
  * Tools now properly authenticate with providers upon connection.

* **Improvements**
  * Configuration operation messages now include stack context for improved clarity.
  * Tool descriptions clarified to specify they operate on the currently selected stack rather than the entire project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->