### PR TITLE
Do not try to delete delegate subdomain for azure

### DIFF
--- a/src/pkg/cli/cd.go
+++ b/src/pkg/cli/cd.go
@@ -46,10 +46,12 @@ func CdCommand(ctx context.Context, projectName string, provider client.Provider
 	action := defangv1.DeploymentAction_DEPLOYMENT_ACTION_REFRESH
 	switch command {
 	case client.CdCommandDown, client.CdCommandDestroy:
-		err := deleteSubdomain(ctx, projectName, provider, fabric)
-		if err != nil {
-			term.Warn("Unable to update deployment history; deployment will proceed anyway.")
-			break
+		// Skip subdomain cleanup for providers that did not delegate one on the way up.
+		if provider.HasDelegatedSubdomain() {
+			if err := deleteSubdomain(ctx, projectName, provider, fabric); err != nil {
+				term.Warn("Failed to delete delegated subdomain; the destroy will proceed anyway.")
+				break
+			}
 		}
 		// Update deployment table to mark deployment as destroyed only after successful deletion of the subdomain
 		action = defangv1.DeploymentAction_DEPLOYMENT_ACTION_DOWN
@@ -66,7 +68,12 @@ func CdCommand(ctx context.Context, projectName string, provider client.Provider
 		})
 		if err != nil {
 			term.Debug("Failed to record deployment:", err)
-			term.Warn("Unable to update deployment history; deployment will proceed anyway.")
+			switch command {
+			case client.CdCommandDown, client.CdCommandDestroy:
+				term.Warn("Unable to update deployment history; the destroy will proceed anyway.")
+			default:
+				term.Warn("Unable to update deployment history; the refresh will proceed anyway.")
+			}
 		}
 	}
 	return cd.ETag, nil

--- a/src/pkg/cli/cd.go
+++ b/src/pkg/cli/cd.go
@@ -68,12 +68,7 @@ func CdCommand(ctx context.Context, projectName string, provider client.Provider
 		})
 		if err != nil {
 			term.Debug("Failed to record deployment:", err)
-			switch command {
-			case client.CdCommandDown, client.CdCommandDestroy:
-				term.Warn("Unable to update deployment history; the destroy will proceed anyway.")
-			default:
-				term.Warn("Unable to update deployment history; the refresh will proceed anyway.")
-			}
+			term.Warnf("Unable to update deployment history; %s will proceed anyway.", command)
 		}
 	}
 	return cd.ETag, nil

--- a/src/pkg/cli/client/byoc/azure/byoc.go
+++ b/src/pkg/cli/client/byoc/azure/byoc.go
@@ -704,6 +704,14 @@ func (b *ByocAzure) PrepareDomainDelegation(context.Context, client.PrepareDomai
 	return nil, nil // TODO: implement domain delegation for Azure
 }
 
+// HasDelegatedSubdomain implements client.Provider. Azure does not yet
+// implement domain delegation, so there is no subdomain zone to delete on
+// destroy. Flip to true (or remove the override) once PrepareDomainDelegation
+// is wired up.
+func (*ByocAzure) HasDelegatedSubdomain() bool {
+	return false
+}
+
 // Preview implements client.Provider.
 func (b *ByocAzure) Preview(ctx context.Context, req *client.DeployRequest) (*client.DeployResponse, error) {
 	defer term.Timing()()

--- a/src/pkg/cli/client/byoc/baseclient.go
+++ b/src/pkg/cli/client/byoc/baseclient.go
@@ -73,6 +73,12 @@ func (b *ByocBaseClient) GetStackName() string {
 	return b.PulumiStack
 }
 
+// HasDelegatedSubdomain returns true by default; providers that do not yet
+// implement domain delegation (Azure, DO) override this to return false.
+func (b *ByocBaseClient) HasDelegatedSubdomain() bool {
+	return true
+}
+
 func (b *ByocBaseClient) SetCanIUseConfig(quotas *defangv1.CanIUseResponse) {
 	b.CanIUseConfig.AllowGPU = quotas.Gpu
 	b.CanIUseConfig.AllowScaling = quotas.AllowScaling

--- a/src/pkg/cli/client/byoc/do/byoc.go
+++ b/src/pkg/cli/client/byoc/do/byoc.go
@@ -592,6 +592,13 @@ func (b *ByocDo) PrepareDomainDelegation(ctx context.Context, req client.Prepare
 	return nil, nil // TODO: implement domain delegation for DO
 }
 
+// HasDelegatedSubdomain implements client.Provider. DO does not yet implement
+// domain delegation, so there is no subdomain zone to delete on destroy. Flip
+// to true (or remove the override) once PrepareDomainDelegation is wired up.
+func (*ByocDo) HasDelegatedSubdomain() bool {
+	return false
+}
+
 type cdCommand struct {
 	command        []string
 	etag           types.ETag

--- a/src/pkg/cli/client/mock.go
+++ b/src/pkg/cli/client/mock.go
@@ -75,6 +75,10 @@ func (MockProvider) GetStackName() string {
 	return "test"
 }
 
+func (MockProvider) HasDelegatedSubdomain() bool {
+	return true
+}
+
 func (MockProvider) GetStackNameForDomain() string {
 	return ""
 }

--- a/src/pkg/cli/client/playground.go
+++ b/src/pkg/cli/client/playground.go
@@ -55,6 +55,10 @@ func (*PlaygroundProvider) Driver() string {
 	return "playground"
 }
 
+func (*PlaygroundProvider) HasDelegatedSubdomain() bool {
+	return true
+}
+
 func (g *PlaygroundProvider) Preview(ctx context.Context, req *DeployRequest) (*DeployResponse, error) {
 	req.Preview = true
 	return g.Deploy(ctx, req)

--- a/src/pkg/cli/client/provider.go
+++ b/src/pkg/cli/client/provider.go
@@ -92,6 +92,11 @@ type Provider interface {
 	GetServices(context.Context, *defangv1.GetServicesRequest) (*defangv1.GetServicesResponse, error)
 	GetStackName() string
 	GetStackNameForDomain() string
+	// HasDelegatedSubdomain reports whether the provider creates a delegated
+	// subdomain zone via PrepareDomainDelegation + CreateDelegateSubdomainZone
+	// during deploy. Providers that return false (currently Azure and DO) skip
+	// the matching DeleteSubdomainZone call on destroy.
+	HasDelegatedSubdomain() bool
 	ListConfig(context.Context, *defangv1.ListConfigsRequest) (*defangv1.Secrets, error)
 	PrepareDomainDelegation(context.Context, PrepareDomainDelegationRequest) (*PrepareDomainDelegationResponse, error)
 	Preview(context.Context, *DeployRequest) (*DeployResponse, error)


### PR DESCRIPTION
## Description
And print correct warning message about saving deployment history for down and refresh

## Linked Issues
Fixes: #2095

## Checklist

- [X] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Providers can now advertise whether they manage delegated subdomains.

* **Improvements**
  * Destroy/refresh flows now skip delegated-subdomain removal when not applicable.
  * Warning messages are clearer and operation-specific; deployment history updates are withheld on certain cleanup failures.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefangLabs/defang/pull/2106)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->