### PR TITLE
Fix azure accountinfo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ pre-commit:
 	@if git diff --cached --name-only | grep -q '^src/'; then $(MAKE) -C src lint; fi
 
 .PHONY: pre-push
-pre-push: pkgs/npm/README.md src/README.md test test-nix
+pre-push: pkgs/npm/README.md src/README.md test
 
 .PHONY: test
 test:

--- a/src/cmd/cli/command/compose.go
+++ b/src/cmd/cli/command/compose.go
@@ -255,7 +255,7 @@ func confirmDeployment(targetDirectory string, existingDeployments []*defangv1.D
 }
 
 func printExistingDeployments(existingDeployments []*defangv1.Deployment) {
-	term.Info("This project was previously deployed to the following locations:")
+	term.Warn("This project was previously deployed to the following locations:")
 	deploymentStrings := make([]string, 0, len(existingDeployments))
 	for _, dep := range existingDeployments {
 		var providerId client.ProviderID
@@ -265,7 +265,9 @@ func printExistingDeployments(existingDeployments []*defangv1.Deployment) {
 	// sort and remove duplicates
 	slices.Sort(deploymentStrings)
 	deploymentStrings = slices.Compact(deploymentStrings)
-	term.Println(strings.Join(deploymentStrings, "\n"))
+	for _, depStr := range deploymentStrings {
+		term.Println(depStr)
+	}
 }
 
 func confirmDeploymentToNewLocation() (bool, error) {

--- a/src/pkg/cli/client/byoc/azure/byoc.go
+++ b/src/pkg/cli/client/byoc/azure/byoc.go
@@ -169,7 +169,7 @@ func (b *ByocAzure) CdList(ctx context.Context, _ bool) (iter.Seq[state.Info], e
 // AccountInfo implements client.Provider.
 func (b *ByocAzure) AccountInfo(context.Context) (*client.AccountInfo, error) {
 	if err := b.setUpLocation(); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("AccountInfo: %w", err)
 	}
 	return &client.AccountInfo{
 		AccountID: b.driver.SubscriptionID,

--- a/src/pkg/cli/client/byoc/azure/byoc.go
+++ b/src/pkg/cli/client/byoc/azure/byoc.go
@@ -168,6 +168,9 @@ func (b *ByocAzure) CdList(ctx context.Context, _ bool) (iter.Seq[state.Info], e
 
 // AccountInfo implements client.Provider.
 func (b *ByocAzure) AccountInfo(context.Context) (*client.AccountInfo, error) {
+	if err := b.setUpLocation(); err != nil {
+		return nil, err
+	}
 	return &client.AccountInfo{
 		AccountID: b.driver.SubscriptionID,
 		Provider:  client.ProviderAzure,

--- a/src/pkg/cli/tailAndMonitor_test.go
+++ b/src/pkg/cli/tailAndMonitor_test.go
@@ -61,6 +61,9 @@ func (m *mockTailAndMonitorProvider) DelayBeforeRetry(ctx context.Context) error
 }
 
 func TestTailAndMonitor(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping: relies on 6s post-monitor sleep")
+	}
 	mockProvider := &mockTailAndMonitorProvider{
 		getDeploymentStatusErr: io.EOF, //client.ErrDeploymentFailed{}, // done
 		subs: map[types.ETag]*mockSubscribeData{

--- a/src/pkg/cli/waitForCdTaskExit_test.go
+++ b/src/pkg/cli/waitForCdTaskExit_test.go
@@ -27,6 +27,9 @@ func (m *mockCdWaiter) GetDeploymentStatus(ctx context.Context) (bool, error) {
 }
 
 func TestWaitForCdTaskExit(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping: relies on pollDuration ticker (~10s)")
+	}
 	t.Run("CodeBuild failure", func(t *testing.T) {
 		waiter := &mockCdWaiter{
 			getDeploymentStatusErr: awscodebuild.BuildFailure{},


### PR DESCRIPTION
## Description

Azure `AccountInfo` did not have region set, resulting in the "already deployed elsewhere" prompt.

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed BYOC Azure account setup to correctly resolve location and subscription values.

* **Improvements**
  * Deployment notifications now show clearer, line-by-line listings of existing deployments.

* **Tests**
  * Long-running tests now skip under short test mode to speed up test runs.

* **Chores**
  * Simplified pre-push check prerequisites to reduce unnecessary triggers.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefangLabs/defang/pull/2108)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->