### PR TITLE
avoid loading stacks from fabric when invoking cd commands

### DIFF
--- a/src/cmd/cli/command/cd.go
+++ b/src/cmd/cli/command/cd.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"errors"
+	"strings"
 
 	"github.com/DefangLabs/defang/src/pkg/cli"
 	"github.com/DefangLabs/defang/src/pkg/cli/client"
@@ -23,26 +24,27 @@ func cdCommand(cmd *cobra.Command, command client.CdCommand, args []string, fabr
 	ctx := cmd.Context()
 	allowUpgrade, _ := cmd.Flags().GetBool("allow-upgrade")
 
-	session, err := newCommandSession(cmd)
-	if err != nil {
-		return err
-	}
-
-	if len(args) == 0 {
-		projectName, err := client.LoadProjectNameWithFallback(ctx, session.Loader, session.Provider)
-		if err != nil {
-			return err
-		}
-		args = []string{projectName}
+	providerID := global.Stack.Provider
+	if providerID == client.ProviderDefang || providerID == client.ProviderAuto {
+		return errors.New("cannot run CD commands with the Defang Playground provider; please specify a different provider with --provider")
 	}
 
 	var errs []error
-	for _, projectName := range args {
-		err := canIUseProvider(ctx, session.Provider, projectName, 0, allowUpgrade)
+	for _, arg := range args {
+		// split arg by "/" to get project and stack name
+		parts := strings.Split(arg, "/")
+		if len(parts) != 2 {
+			errs = append(errs, errors.New("invalid argument: "+arg+", expected format: <project>/<stack>"))
+			continue
+		}
+		projectName := parts[0]
+		stackName := parts[1]
+		provider := cli.NewProvider(ctx, providerID, fabric, stackName)
+		err := canIUseProvider(ctx, provider, projectName, 0, allowUpgrade)
 		if err != nil {
 			return err
 		}
-		errs = append(errs, cli.CdCommandAndTail(ctx, session.Provider, projectName, global.Verbose, command, fabric))
+		errs = append(errs, cli.CdCommandAndTail(ctx, provider, projectName, global.Verbose, command, fabric))
 	}
 	return errors.Join(errs...)
 }
@@ -51,6 +53,7 @@ var cdDestroyCmd = &cobra.Command{
 	Use:         "destroy [PROJECT...]",
 	Annotations: authNeededAlways, // need subscription
 	Short:       "Destroy the service stack",
+	Args:        cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return cdCommand(cmd, client.CdCommandDestroy, args, global.Client)
 	},
@@ -60,6 +63,7 @@ var cdDownCmd = &cobra.Command{
 	Use:         "down [PROJECT...]",
 	Annotations: authNeededAlways, // need subscription
 	Short:       "Refresh and then destroy the service stack",
+	Args:        cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return cdCommand(cmd, client.CdCommandDown, args, global.Client)
 	},
@@ -78,6 +82,7 @@ var cdCancelCmd = &cobra.Command{
 	Use:         "cancel [PROJECT...]",
 	Annotations: authNeededAlways, // need subscription
 	Short:       "Cancel the current CD operation",
+	Args:        cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return cdCommand(cmd, client.CdCommandCancel, args, global.Client)
 	},
@@ -87,6 +92,7 @@ var cdOutputsCmd = &cobra.Command{
 	Use:         "outputs [PROJECT...]",
 	Annotations: authNeededAlways, // need subscription
 	Short:       "Get the outputs of the service stack",
+	Args:        cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return cdCommand(cmd, client.CdCommandOutputs, args, global.Client)
 	},
@@ -123,25 +129,26 @@ var cdListCmd = &cobra.Command{
 		remote, _ := cmd.Flags().GetBool("remote")
 		all, _ := cmd.Flags().GetBool("all")
 
-		session, err := newCommandSession(cmd)
-		if err != nil {
-			return err
+		providerID := global.Stack.Provider
+		if providerID == client.ProviderDefang || providerID == client.ProviderAuto {
+			return errors.New("cannot list projects with the Defang Playground provider; please specify a different provider with --provider")
 		}
+		provider := cli.NewProvider(ctx, providerID, global.Client, "") // stack name is not needed for listing projects
 
 		if remote {
 			if all {
 				return errors.New("--all cannot be used with --remote")
 			}
 
-			err = canIUseProvider(ctx, session.Provider, "", 0, true) // safe to use latest CD image
+			err := canIUseProvider(ctx, provider, "", 0, true) // safe to use latest CD image
 			if err != nil {
 				return err
 			}
 
 			// FIXME: this needs auth because it spawns the CD task
-			return cli.CdCommandAndTail(ctx, session.Provider, "", global.Verbose, client.CdCommandList, global.Client)
+			return cli.CdCommandAndTail(ctx, provider, "", global.Verbose, client.CdCommandList, global.Client)
 		} else {
-			return cli.CdListFromStorage(ctx, session.Provider, all || global.Verbose)
+			return cli.CdListFromStorage(ctx, provider, all || global.Verbose)
 		}
 	},
 }

--- a/src/cmd/cli/command/cd.go
+++ b/src/cmd/cli/command/cd.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/DefangLabs/defang/src/pkg/cli"
@@ -42,7 +43,8 @@ func cdCommand(cmd *cobra.Command, command client.CdCommand, args []string, fabr
 		provider := cli.NewProvider(ctx, providerID, fabric, stackName)
 		err := canIUseProvider(ctx, provider, projectName, 0, allowUpgrade)
 		if err != nil {
-			return err
+			errs = append(errs, fmt.Errorf("validating provider for %q: %w", arg, err))
+			continue
 		}
 		errs = append(errs, cli.CdCommandAndTail(ctx, provider, projectName, global.Verbose, command, fabric))
 	}

--- a/src/cmd/cli/command/cd.go
+++ b/src/cmd/cli/command/cd.go
@@ -40,6 +40,10 @@ func cdCommand(cmd *cobra.Command, command client.CdCommand, args []string, fabr
 		}
 		projectName := parts[0]
 		stackName := parts[1]
+		if projectName == "" || stackName == "" {
+			errs = append(errs, errors.New("invalid argument: "+arg+", project and stack name cannot be empty"))
+			continue
+		}
 		provider := cli.NewProvider(ctx, providerID, fabric, stackName)
 		err := canIUseProvider(ctx, provider, projectName, 0, allowUpgrade)
 		if err != nil {

--- a/src/cmd/cli/command/cd.go
+++ b/src/cmd/cli/command/cd.go
@@ -56,7 +56,7 @@ func cdCommand(cmd *cobra.Command, command client.CdCommand, args []string, fabr
 }
 
 var cdDestroyCmd = &cobra.Command{
-	Use:         "destroy [PROJECT...]",
+	Use:         "destroy [PROJECT/STACK...]",
 	Annotations: authNeededAlways, // need subscription
 	Short:       "Destroy the service stack",
 	Args:        cobra.MinimumNArgs(1),
@@ -66,7 +66,7 @@ var cdDestroyCmd = &cobra.Command{
 }
 
 var cdDownCmd = &cobra.Command{
-	Use:         "down [PROJECT...]",
+	Use:         "down [PROJECT/STACK...]",
 	Annotations: authNeededAlways, // need subscription
 	Short:       "Refresh and then destroy the service stack",
 	Args:        cobra.MinimumNArgs(1),
@@ -76,7 +76,7 @@ var cdDownCmd = &cobra.Command{
 }
 
 var cdRefreshCmd = &cobra.Command{
-	Use:         "refresh [PROJECT...]",
+	Use:         "refresh [PROJECT/STACK...]",
 	Annotations: authNeededAlways, // need subscription
 	Short:       "Refresh the service stack",
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -85,7 +85,7 @@ var cdRefreshCmd = &cobra.Command{
 }
 
 var cdCancelCmd = &cobra.Command{
-	Use:         "cancel [PROJECT...]",
+	Use:         "cancel [PROJECT/STACK...]",
 	Annotations: authNeededAlways, // need subscription
 	Short:       "Cancel the current CD operation",
 	Args:        cobra.MinimumNArgs(1),
@@ -95,7 +95,7 @@ var cdCancelCmd = &cobra.Command{
 }
 
 var cdOutputsCmd = &cobra.Command{
-	Use:         "outputs [PROJECT...]",
+	Use:         "outputs [PROJECT/STACK...]",
 	Annotations: authNeededAlways, // need subscription
 	Short:       "Get the outputs of the service stack",
 	Args:        cobra.MinimumNArgs(1),


### PR DESCRIPTION
## Description

The `defang cd` commands were always intended to invoke `cd` commands directly with minimal dependencies on fabric. When we introduced stacks, we thought it would make sense to also use stack files when invoking `cd` commands, but as stacks have evolved, fabric has played a more significant role in resolving stack properties, so `cd` commands ended up with a dependency on fabric. This change removes that dependency by requiring that all necessary properties be provided by command line flag, argument, or environment variable.

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced PROJECT/STACK format for each `cd` argument with clearer per-argument errors
  * Blocked `cd` operations when the provider is in restricted modes (Defang/Auto)

* **Refactor**
  * `cd` subcommands now require at least one argument and show updated usage
  * Unified provider handling for `cd ls` and related commands, routing remote and local listings through the same provider mechanism

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefangLabs/defang/pull/2109)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->