### PR TITLE
add --detach flag to cd commands

### DIFF
--- a/src/cmd/cli/command/cd.go
+++ b/src/cmd/cli/command/cd.go
@@ -24,6 +24,7 @@ var cdCmd = &cobra.Command{
 func cdCommand(cmd *cobra.Command, command client.CdCommand, args []string, fabric client.FabricClient) error {
 	ctx := cmd.Context()
 	allowUpgrade, _ := cmd.Flags().GetBool("allow-upgrade")
+	detach, _ := cmd.Flags().GetBool("detach")
 
 	providerID := global.Stack.Provider
 	if providerID == client.ProviderDefang || providerID == client.ProviderAuto {
@@ -50,7 +51,12 @@ func cdCommand(cmd *cobra.Command, command client.CdCommand, args []string, fabr
 			errs = append(errs, fmt.Errorf("validating provider for %q: %w", arg, err))
 			continue
 		}
-		errs = append(errs, cli.CdCommandAndTail(ctx, provider, projectName, global.Verbose, command, fabric))
+		if detach {
+			_, err = cli.CdCommand(ctx, projectName, provider, fabric, command)
+			errs = append(errs, err)
+		} else {
+			errs = append(errs, cli.CdCommandAndTail(ctx, provider, projectName, global.Verbose, command, fabric))
+		}
 	}
 	return errors.Join(errs...)
 }

--- a/src/cmd/cli/command/commands.go
+++ b/src/cmd/cli/command/commands.go
@@ -175,6 +175,7 @@ func SetupCommands(version string) {
 	RootCmd.AddCommand(cdCmd)
 	cdCmd.PersistentFlags().StringVar(&byoc.DefangPulumiBackend, "pulumi-backend", "", `specify an alternate Pulumi backend URL or "pulumi-cloud"`)
 	cdCmd.PersistentFlags().Bool("allow-upgrade", pkg.GetenvBool("DEFANG_ALLOW_UPGRADE"), "allow upgrading the CD image and Pulumi version to the latest available")
+	cdCmd.PersistentFlags().BoolP("detach", "d", false, "run in detached mode")
 	cdCmd.AddCommand(cdDestroyCmd)
 	cdCmd.AddCommand(cdDownCmd)
 	cdCmd.AddCommand(cdRefreshCmd)


### PR DESCRIPTION
## Description

`defang compose down` supports `--detach`, but `defang cd down` did not. This PR adds support.

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--detach` (`-d`) flag to the `cd` command. When enabled, the command executes in detached mode without streaming output. Without the flag, the command maintains its default behavior of tailing and displaying live output.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefangLabs/defang/pull/2110)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->