### PR TITLE
Lio/compose deployment

### DIFF
--- a/src/pkg/cli/common.go
+++ b/src/pkg/cli/common.go
@@ -52,6 +52,7 @@ type putDeploymentParams struct {
 	ServiceInfos []*defangv1.ServiceInfo
 	CdType       defangv1.CdType
 	CdId         string
+	Compose      []byte
 }
 
 func putDeploymentAndStack(ctx context.Context, provider client.Provider, fabric client.FabricClient, stack *stacks.Parameters, req putDeploymentParams) error {
@@ -119,6 +120,7 @@ func putDeploymentAndStack(ctx context.Context, provider client.Provider, fabric
 			Services:          req.ServiceInfos,
 			CdId:              req.CdId,
 			CdType:            req.CdType,
+			Compose:           req.Compose,
 		},
 	})
 }

--- a/src/pkg/cli/composeUp.go
+++ b/src/pkg/cli/composeUp.go
@@ -104,13 +104,13 @@ func ComposeUp(ctx context.Context, fabric client.FabricClient, provider client.
 		return nil, project, &ComposeError{err}
 	}
 
-	bytes, err := compose.MarshalYAML(fixedProject)
+	composeYaml, err := compose.MarshalYAML(fixedProject)
 	if err != nil {
 		return nil, project, err
 	}
 
 	if upload == compose.UploadModeIgnore {
-		term.Println(string(bytes))
+		term.Println(string(composeYaml))
 		return nil, project, dryrun.ErrDryRun
 	}
 
@@ -142,7 +142,7 @@ func ComposeUp(ctx context.Context, fabric client.FabricClient, provider client.
 		DeployRequest: defangv1.DeployRequest{
 			Mode:           mode.Value(),
 			Project:        project.Name,
-			Compose:        bytes,
+			Compose:        composeYaml,
 			DelegateDomain: delegateDomain.Zone,
 		},
 	}
@@ -206,6 +206,7 @@ func ComposeUp(ctx context.Context, fabric client.FabricClient, provider client.
 		ServiceInfos: resp.Services,
 		CdType:       resp.CdType,
 		CdId:         resp.CdId,
+		Compose:      composeYaml,
 	})
 	if err != nil {
 		term.Debug("Failed to record deployment:", err)

--- a/src/protos/io/defang/v1/fabric.pb.go
+++ b/src/protos/io/defang/v1/fabric.pb.go
@@ -3888,6 +3888,7 @@ type Deployment struct {
 	Services          []*ServiceInfo         `protobuf:"bytes,18,rep,name=services,proto3" json:"services,omitempty"`
 	CdType            CdType                 `protobuf:"varint,19,opt,name=cd_type,json=cdType,proto3,enum=io.defang.v1.CdType" json:"cd_type,omitempty"`
 	CdId              string                 `protobuf:"bytes,20,opt,name=cd_id,json=cdId,proto3" json:"cd_id,omitempty"`
+	Compose           []byte                 `protobuf:"bytes,21,opt,name=compose,proto3" json:"compose,omitempty"` // yaml
 	unknownFields     protoimpl.UnknownFields
 	sizeCache         protoimpl.SizeCache
 }
@@ -4061,6 +4062,13 @@ func (x *Deployment) GetCdId() string {
 		return x.CdId
 	}
 	return ""
+}
+
+func (x *Deployment) GetCompose() []byte {
+	if x != nil {
+		return x.Compose
+	}
+	return nil
 }
 
 type PutDeploymentRequest struct {
@@ -6350,7 +6358,7 @@ const file_io_defang_v1_fabric_proto_rawDesc = "" +
 	"\x12ListConfigsRequest\x12\x18\n" +
 	"\aproject\x18\x01 \x01(\tR\aproject\"H\n" +
 	"\x13ListConfigsResponse\x121\n" +
-	"\aconfigs\x18\x01 \x03(\v2\x17.io.defang.v1.ConfigKeyR\aconfigs\"\xbb\a\n" +
+	"\aconfigs\x18\x01 \x03(\v2\x17.io.defang.v1.ConfigKeyR\aconfigs\"\xd5\a\n" +
 	"\n" +
 	"Deployment\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x18\n" +
@@ -6375,7 +6383,8 @@ const file_io_defang_v1_fabric_proto_rawDesc = "" +
 	"\x0forigin_metadata\x18\x11 \x03(\v2,.io.defang.v1.Deployment.OriginMetadataEntryR\x0eoriginMetadata\x125\n" +
 	"\bservices\x18\x12 \x03(\v2\x19.io.defang.v1.ServiceInfoR\bservices\x12-\n" +
 	"\acd_type\x18\x13 \x01(\x0e2\x14.io.defang.v1.CdTypeR\x06cdType\x12\x13\n" +
-	"\x05cd_id\x18\x14 \x01(\tR\x04cdId\x1aA\n" +
+	"\x05cd_id\x18\x14 \x01(\tR\x04cdId\x12\x18\n" +
+	"\acompose\x18\x15 \x01(\fR\acompose\x1aA\n" +
 	"\x13OriginMetadataEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"P\n" +

--- a/src/protos/io/defang/v1/fabric.proto
+++ b/src/protos/io/defang/v1/fabric.proto
@@ -5,8 +5,8 @@ package io.defang.v1;
 
 import "google/protobuf/empty.proto";
 import "google/protobuf/timestamp.proto";
-
 import "google/type/money.proto";
+
 option go_package = "github.com/DefangLabs/defang/src/protos/io/defang/v1;defangv1";
 
 service FabricController {
@@ -594,6 +594,7 @@ message Deployment {
   repeated ServiceInfo services = 18;
   CdType cd_type = 19;
   string cd_id = 20;
+  bytes compose = 21; // yaml
 }
 
 enum CdType {


### PR DESCRIPTION
## Description

Passing Compose YAML to `PutDeployment` requests. This is for the Portal Compose visualizer.

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Deployment system now captures and stores complete compose configuration data alongside deployment records, enabling improved visibility into deployment specifications and better tracking of infrastructure changes across all deployment types.
  * Internal deployment communication protocol updated to transmit compose configuration with deployment payloads, ensuring deployment specifications are preserved throughout the deployment lifecycle.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefangLabs/defang/pull/2111)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->