### PR TITLE
fix(ci): compare coverage against merge-base commit, not latest main

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,6 +15,7 @@ on:
 permissions:
   contents: read
   id-token: write # for GitHub id-token auth
+  actions: read # to query workflow runs for coverage baseline
 
 jobs:
   go-test:
@@ -53,15 +54,31 @@ jobs:
           path: src/coverage.txt
           overwrite: true
 
-      - name: Download main branch coverage
+      - name: Find merge-base run ID
         if: github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/v')
+        id: merge-base-run
+        continue-on-error: true # no baseline yet on first run
+        run: |
+          git fetch origin main --depth=50
+          MERGE_BASE=$(git merge-base HEAD origin/main)
+          echo "Merge base: $MERGE_BASE"
+          RUN_ID=$(gh api "repos/$GITHUB_REPOSITORY/actions/workflows/go.yml/runs" \
+            -X GET -f branch=main -f per_page=100 \
+            --jq ".workflow_runs[] | select(.head_sha == \"$MERGE_BASE\" and .conclusion == \"success\") | .id" \
+            | head -1)
+          echo "run_id=${RUN_ID}" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download merge-base coverage
+        if: github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/v') && steps.merge-base-run.outputs.run_id != ''
         uses: dawidd6/action-download-artifact@8305c0f1062bb0d184d09ef4493ecb9288447732 # v20
         with:
           workflow: go.yml
-          branch: main
+          run_id: ${{ steps.merge-base-run.outputs.run_id }}
           name: coverage-main
           path: coverage-main
-        continue-on-error: true # no baseline yet on first run
+        continue-on-error: true # artifact may have expired
 
       - name: Verify Go modules
         working-directory: src


### PR DESCRIPTION
## Summary

- Dependabot PRs (and any branch that diverges from main) were failing the coverage regression check because the baseline was always the **most recent main artifact**. If new tested code landed on main after the branch was created, main's coverage would rise while the branch stayed flat — a false regression.
- Now the check finds the GitHub Actions run whose `head_sha` matches the git merge-base of the PR branch and main, and downloads the coverage artifact from that specific run.
- Falls back gracefully (`continue-on-error`) when no matching run exists (first run, expired artifact, API error) — identical behavior to before in those cases.

## Test plan

- [ ] Verify this PR's own CI run passes the coverage check
- [ ] Confirm a Dependabot dep-only PR (e.g. #2082) passes after rebasing or re-running with this workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced the continuous integration workflow's coverage baseline retrieval mechanism with improved reliability and error handling for more accurate coverage comparisons.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefangLabs/defang/pull/2117)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->