### PR TITLE
fix: use GetStack rpc for remote stack params

### DIFF
--- a/src/pkg/stacks/manager.go
+++ b/src/pkg/stacks/manager.go
@@ -20,8 +20,9 @@ import (
 )
 
 type Lister interface {
-	ListStacks(ctx context.Context, req *defangv1.ListStacksRequest) (*defangv1.ListStacksResponse, error)
 	GetDefaultStack(ctx context.Context, req *defangv1.GetDefaultStackRequest) (*defangv1.GetStackResponse, error)
+	GetStack(ctx context.Context, req *defangv1.GetStackRequest) (*defangv1.GetStackResponse, error)
+	ListStacks(ctx context.Context, req *defangv1.ListStacksRequest) (*defangv1.ListStacksResponse, error)
 }
 
 type manager struct {
@@ -101,34 +102,26 @@ func (sm *manager) ListRemote(ctx context.Context) ([]ListItem, error) {
 	}
 	stackParams := make([]ListItem, 0, len(resp.GetStacks()))
 	for _, stack := range resp.GetStacks() {
-		name := stack.GetName()
-		if name == "" {
-			name = DefaultBeta
-		}
-		bytes := stack.GetStackFile()
-		params, err := NewParametersFromContent(name, bytes)
+		params, err := newParametersFromPB(stack)
 		if err != nil {
-			term.Warnf("Skipping invalid remote stack %s: %v\n", name, err)
+			term.Warnf("Skipping invalid remote stack %s: %v\n", stack.GetName(), err)
 			continue
-		}
-		// fill in missing fields from remote stack info
-		if params.Mode == modes.ModeUnspecified {
-			params.Mode = modes.Mode(stack.GetMode())
-		}
-		if params.Region == "" {
-			params.Region = stack.GetRegion()
-		}
-		if params.Provider == "" {
-			params.Provider.SetValue(stack.GetProvider())
 		}
 		account := params.Account()
 		if account == "" {
 			account = stack.GetProviderAccountId()
 		}
+		deployedAt := timeutils.AsTime(stack.GetLastDeployedAt(), time.Time{})
+		if !deployedAt.IsZero() {
+			deployedAt = deployedAt.Local()
+		}
 		stackParams = append(stackParams, ListItem{
-			Parameters: *params,
+			Name:       params.Name,
+			Provider:   params.Provider,
+			Mode:       params.Mode,
+			Region:     params.Region,
 			Account:    account,
-			DeployedAt: timeutils.AsTime(stack.GetLastDeployedAt(), time.Time{}).Local(),
+			DeployedAt: deployedAt,
 			Default:    stack.GetIsDefault(),
 		})
 	}
@@ -138,6 +131,29 @@ func (sm *manager) ListRemote(ctx context.Context) ([]ListItem, error) {
 		return b.DeployedAt.Compare(a.DeployedAt)
 	})
 	return stackParams, nil
+}
+
+func newParametersFromPB(stack *defangv1.Stack) (*Parameters, error) {
+	name := stack.GetName()
+	if name == "" {
+		name = DefaultBeta
+	}
+	bytes := stack.GetStackFile()
+	params, err := NewParametersFromContent(name, bytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse remote stack content: %w", err)
+	}
+	// fill in missing fields from remote stack info
+	if params.Mode == modes.ModeUnspecified {
+		params.Mode = modes.Mode(stack.GetMode())
+	}
+	if params.Region == "" {
+		params.Region = stack.GetRegion()
+	}
+	if params.Provider == "" {
+		params.Provider.SetValue(stack.GetProvider())
+	}
+	return params, nil
 }
 
 type ErrOutside struct {
@@ -171,22 +187,24 @@ func (sm *manager) LoadLocal(name string) (*Parameters, error) {
 }
 
 func (sm *manager) GetRemote(ctx context.Context, name string) (*Parameters, error) {
-	remoteStacks, err := sm.ListRemote(ctx)
+	if sm.projectName == "" {
+		return nil, errors.New("project name is required to gett remote stack")
+	}
+	if name == "" {
+		return nil, errors.New("stack name is required to get remote stack")
+	}
+	remoteStack, err := sm.fabric.GetStack(ctx, &defangv1.GetStackRequest{
+		Project: sm.projectName,
+		Stack:   name,
+	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to list remote stacks: %w", err)
-	}
-	var remoteStack *ListItem
-	for i := range remoteStacks {
-		if remoteStacks[i].Name == name {
-			remoteStack = &remoteStacks[i]
-			break
+		if connect.CodeOf(err) == connect.CodeNotFound {
+			return nil, &ErrNotExist{ProjectName: sm.projectName, StackName: name}
 		}
-	}
-	if remoteStack == nil {
-		return nil, &ErrNotExist{ProjectName: sm.projectName, StackName: name}
+		return nil, fmt.Errorf("failed to get remote stack: %w", err)
 	}
 
-	return &remoteStack.Parameters, nil
+	return newParametersFromPB(remoteStack.GetStack())
 }
 
 func (sm *manager) Create(params Parameters) (string, error) {
@@ -319,7 +337,7 @@ func (sm *manager) getDefaultStack(ctx context.Context) (*Parameters, string, er
 	}
 
 	whence := "default stack from server"
-	params, err := NewParametersFromContent(res.Stack.Name, res.Stack.StackFile)
+	params, err := newParametersFromPB(res.Stack)
 	if err != nil {
 		return nil, whence, err
 	}

--- a/src/pkg/stacks/manager_test.go
+++ b/src/pkg/stacks/manager_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"connectrpc.com/connect"
 	"github.com/DefangLabs/defang/src/pkg/cli/client"
 	"github.com/DefangLabs/defang/src/pkg/modes"
 	defangv1 "github.com/DefangLabs/defang/src/protos/io/defang/v1"
@@ -22,6 +23,17 @@ type mockFabricClient struct {
 	defaultStack *defangv1.Stack
 	stacks       []*defangv1.Stack
 	listErr      error
+}
+
+func (m *mockFabricClient) GetStack(ctx context.Context, req *defangv1.GetStackRequest) (*defangv1.GetStackResponse, error) {
+	for _, stack := range m.stacks {
+		if stack.GetName() == req.GetStack() {
+			return &defangv1.GetStackResponse{
+				Stack: stack,
+			}, nil
+		}
+	}
+	return nil, connect.NewError(connect.CodeNotFound, errors.New("not found"))
 }
 
 func (m *mockFabricClient) ListStacks(ctx context.Context, req *defangv1.ListStacksRequest) (*defangv1.ListStacksResponse, error) {
@@ -419,7 +431,7 @@ GOOGLE_REGION=us-central1
 	assert.Equal(t, "us-east-1", sharedStack.Region, "Expected shared stack to use remote region us-east-1")
 	assert.Equal(t, client.ProviderAWS, sharedStack.Provider, "Expected shared stack to use provider aws")
 	assert.Equal(t, modes.ModeUnspecified, sharedStack.Mode, "Expected shared stack to use mode UNSPECIFIED")
-	assert.Equal(t, "", sharedStack.Variables["AWS_PROFILE"], "Expected shared stack to have empty AWS_PROFILE variable")
+	assert.Equal(t, "", sharedStack.Account, "Expected shared stack to have empty AWS_PROFILE variable")
 	assert.Equal(t, deployedAt.Local().Format(time.RFC3339), sharedStack.DeployedAt.Local().Format(time.RFC3339), "Expected shared stack to have deployment time from remote")
 
 	// Check remote-only stack exists

--- a/src/pkg/stacks/selector.go
+++ b/src/pkg/stacks/selector.go
@@ -15,6 +15,7 @@ const CreateNewStack = "Create new stack"
 
 type Manager interface {
 	List(ctx context.Context) ([]ListItem, error)
+	Load(ctx context.Context, name string) (*Parameters, error)
 	Create(params Parameters) (string, error)
 }
 
@@ -88,13 +89,11 @@ func (ss *stackSelector) SelectStack(ctx context.Context, opts SelectStackOption
 	}
 
 	// find the stack with the selected name in the list of stacks
-	for _, stack := range stackList {
-		if stack.Name == selectedName {
-			return &stack.Parameters, nil
-		}
+	stack, err := ss.sm.Load(ctx, selectedName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load stack %q: %w", selectedName, err)
 	}
-
-	return nil, fmt.Errorf("selected stack %q not found", selectedName)
+	return stack, nil
 }
 
 func (ss *stackSelector) createStack(ctx context.Context) (*Parameters, error) {

--- a/src/pkg/stacks/selector_test.go
+++ b/src/pkg/stacks/selector_test.go
@@ -41,6 +41,18 @@ type MockStacksManager struct {
 	mock.Mock
 }
 
+func (m *MockStacksManager) Load(ctx context.Context, name string) (*Parameters, error) {
+	args := m.Called(ctx, name)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	result, ok := args.Get(0).(*Parameters)
+	if !ok {
+		return nil, args.Error(1)
+	}
+	return result, args.Error(1)
+}
+
 func (m *MockStacksManager) List(ctx context.Context) ([]ListItem, error) {
 	args := m.Called(ctx)
 	if args.Get(0) == nil {
@@ -83,21 +95,22 @@ func TestStackSelector_SelectStack_ExistingStack(t *testing.T) {
 	// Mock existing stacks list
 	existingStacks := []ListItem{
 		{
-			Parameters: Parameters{
-				Name:     "production",
-				Provider: "aws",
-				Region:   "us-west-2",
-			},
+			Name:     "production",
+			Provider: "aws",
+			Region:   "us-west-2",
 		},
 		{
-			Parameters: Parameters{
-				Name:     "development",
-				Provider: "aws",
-				Region:   "us-east-1",
-			},
+			Name:     "development",
+			Provider: "aws",
+			Region:   "us-east-1",
 		},
 	}
 	mockSM.On("List", ctx).Return(existingStacks, nil)
+	mockSM.On("Load", ctx, "production").Return(&Parameters{
+		Name:     "production",
+		Provider: "aws",
+		Region:   "us-west-2",
+	}, nil)
 
 	// Mock user selecting existing stack
 	expectedOptions := []string{"production [us-west-2]", "development [us-east-1]"}
@@ -133,10 +146,15 @@ func TestStackSelector_SelectOrCreateStack_ExistingStack(t *testing.T) {
 
 	// Mock existing stacks list
 	existingStacks := []ListItem{
-		{Parameters: Parameters{Name: "production", Provider: "aws", Region: "us-west-2"}},
-		{Parameters: Parameters{Name: "development", Provider: "aws", Region: "us-east-1"}},
+		{Name: "production", Provider: "aws", Region: "us-west-2"},
+		{Name: "development", Provider: "aws", Region: "us-east-1"},
 	}
 	mockSM.On("List", ctx).Return(existingStacks, nil)
+	mockSM.On("Load", ctx, "production").Return(&Parameters{
+		Name:     "production",
+		Provider: "aws",
+		Region:   "us-west-2",
+	}, nil)
 
 	// Mock user selecting existing stack
 	expectedOptions := []string{"production [us-west-2]", "development [us-east-1]", CreateNewStack}
@@ -174,7 +192,7 @@ func TestStackSelector_SelectStack_CreateNewStack(t *testing.T) {
 
 	// Mock existing stacks list
 	existingStacks := []ListItem{
-		{Parameters: Parameters{Name: "production", Provider: "aws", Region: "us-west-2"}},
+		{Name: "production", Provider: "aws", Region: "us-west-2"},
 	}
 	mockSM.On("List", ctx).Return(existingStacks, nil)
 
@@ -378,7 +396,7 @@ func TestStackSelector_SelectStack_ElicitationError(t *testing.T) {
 
 	// Mock existing stacks list
 	existingStacks := []ListItem{
-		{Parameters: Parameters{Name: "production", Provider: "aws", Region: "us-west-2"}},
+		{Name: "production", Provider: "aws", Region: "us-west-2"},
 	}
 	mockSM.On("List", ctx).Return(existingStacks, nil)
 
@@ -409,7 +427,7 @@ func TestStackSelector_SelectStack_WizardError(t *testing.T) {
 
 	// Mock existing stacks list
 	existingStacks := []ListItem{
-		{Parameters: Parameters{Name: "production", Provider: "aws", Region: "us-west-2"}},
+		{Name: "production", Provider: "aws", Region: "us-west-2"},
 	}
 	mockSM.On("List", ctx).Return(existingStacks, nil)
 
@@ -446,7 +464,7 @@ func TestStackSelector_SelectStack_CreateStackError(t *testing.T) {
 
 	// Mock existing stacks list
 	existingStacks := []ListItem{
-		{Parameters: Parameters{Name: "production", Provider: "aws", Region: "us-west-2"}},
+		{Name: "production", Provider: "aws", Region: "us-west-2"},
 	}
 	mockSM.On("List", ctx).Return(existingStacks, nil)
 
@@ -528,10 +546,15 @@ func TestStackSelector_SelectStack_ShowsAccountInLabel(t *testing.T) {
 	mockEC.On("IsSupported").Return(true)
 
 	existingStacks := []ListItem{
-		{Parameters: Parameters{Name: "prod", Provider: "aws", Region: "us-west-2"}, Account: "prod-account"},
-		{Parameters: Parameters{Name: "dev", Provider: "aws", Region: "us-west-2"}, Account: "dev-account"},
+		{Name: "prod", Provider: "aws", Region: "us-west-2", Account: "prod-account"},
+		{Name: "dev", Provider: "aws", Region: "us-west-2", Account: "dev-account"},
 	}
 	mockSM.On("List", ctx).Return(existingStacks, nil)
+	mockSM.On("Load", ctx, "prod").Return(&Parameters{
+		Name:     "prod",
+		Provider: "aws",
+		Region:   "us-west-2",
+	}, nil)
 
 	// provider and region are redundant; only account differs
 	expectedOptions := []string{"prod [prod-account]", "dev [dev-account]"}
@@ -567,22 +590,22 @@ func TestMakeStackSelectorLabels(t *testing.T) {
 		{
 			name: "one stack - present all fields",
 			stacks: []ListItem{
-				{Parameters: Parameters{Name: "production", Provider: "aws", Region: "us-west-2"}},
+				{Name: "production", Provider: "aws", Region: "us-west-2"},
 			},
 			wantLabels: []string{"production [aws us-west-2]"},
 		},
 		{
 			name: "one stack with AWS profile",
 			stacks: []ListItem{
-				{Parameters: Parameters{Name: "production", Provider: "aws", Region: "us-west-2"}, Account: "my-profile"},
+				{Name: "production", Provider: "aws", Region: "us-west-2", Account: "my-profile"},
 			},
 			wantLabels: []string{"production [aws my-profile us-west-2]"},
 		},
 		{
 			name: "hide redundant provider",
 			stacks: []ListItem{
-				{Parameters: Parameters{Name: "production", Provider: "aws", Region: "us-west-2"}},
-				{Parameters: Parameters{Name: "development", Provider: "aws", Region: "us-east-1"}},
+				{Name: "production", Provider: "aws", Region: "us-west-2"},
+				{Name: "development", Provider: "aws", Region: "us-east-1"},
 			},
 			wantLabels: []string{
 				"production [us-west-2]",
@@ -592,8 +615,8 @@ func TestMakeStackSelectorLabels(t *testing.T) {
 		{
 			name: "hide redundant provider and region",
 			stacks: []ListItem{
-				{Parameters: Parameters{Name: "prod-us-west-2", Provider: "aws", Region: "us-west-2"}},
-				{Parameters: Parameters{Name: "dev-us-west-2", Provider: "aws", Region: "us-west-2"}},
+				{Name: "prod-us-west-2", Provider: "aws", Region: "us-west-2"},
+				{Name: "dev-us-west-2", Provider: "aws", Region: "us-west-2"},
 			},
 			wantLabels: []string{
 				"prod-us-west-2",
@@ -603,9 +626,9 @@ func TestMakeStackSelectorLabels(t *testing.T) {
 		{
 			name: "mixed redundancy",
 			stacks: []ListItem{
-				{Parameters: Parameters{Name: "prod-us-west-2", Provider: "aws", Region: "us-west-2"}},
-				{Parameters: Parameters{Name: "dev-us-east-1", Provider: "aws", Region: "us-east-1"}},
-				{Parameters: Parameters{Name: "gcp-stack", Provider: "gcp", Region: "us-central1"}},
+				{Name: "prod-us-west-2", Provider: "aws", Region: "us-west-2"},
+				{Name: "dev-us-east-1", Provider: "aws", Region: "us-east-1"},
+				{Name: "gcp-stack", Provider: "gcp", Region: "us-central1"},
 			},
 			wantLabels: []string{
 				"prod-us-west-2 [aws us-west-2]",
@@ -616,8 +639,8 @@ func TestMakeStackSelectorLabels(t *testing.T) {
 		{
 			name: "show different AWS profiles",
 			stacks: []ListItem{
-				{Parameters: Parameters{Name: "prod", Provider: "aws", Region: "us-west-2"}, Account: "prod-account"},
-				{Parameters: Parameters{Name: "dev", Provider: "aws", Region: "us-west-2"}, Account: "dev-account"},
+				{Name: "prod", Provider: "aws", Region: "us-west-2", Account: "prod-account"},
+				{Name: "dev", Provider: "aws", Region: "us-west-2", Account: "dev-account"},
 			},
 			wantLabels: []string{
 				"prod [prod-account]",
@@ -627,8 +650,8 @@ func TestMakeStackSelectorLabels(t *testing.T) {
 		{
 			name: "hide redundant AWS profile",
 			stacks: []ListItem{
-				{Parameters: Parameters{Name: "prod", Provider: "aws", Region: "us-west-2"}, Account: "shared"},
-				{Parameters: Parameters{Name: "dev", Provider: "aws", Region: "us-east-1"}, Account: "shared"},
+				{Name: "prod", Provider: "aws", Region: "us-west-2", Account: "shared"},
+				{Name: "dev", Provider: "aws", Region: "us-east-1", Account: "shared"},
 			},
 			wantLabels: []string{
 				"prod [us-west-2]",
@@ -638,8 +661,8 @@ func TestMakeStackSelectorLabels(t *testing.T) {
 		{
 			name: "show different GCP project IDs",
 			stacks: []ListItem{
-				{Parameters: Parameters{Name: "prod", Provider: "gcp", Region: "us-central1"}, Account: "my-prod-project"},
-				{Parameters: Parameters{Name: "dev", Provider: "gcp", Region: "us-central1"}, Account: "my-dev-project"},
+				{Name: "prod", Provider: "gcp", Region: "us-central1", Account: "my-prod-project"},
+				{Name: "dev", Provider: "gcp", Region: "us-central1", Account: "my-dev-project"},
 			},
 			wantLabels: []string{
 				"prod [my-prod-project]",

--- a/src/pkg/stacks/stacks.go
+++ b/src/pkg/stacks/stacks.go
@@ -157,7 +157,10 @@ func (p *Parameters) Account() string {
 
 // for shell printing for converting to string format of StackParameters
 type ListItem struct {
-	Parameters
+	Name       string
+	Provider   client.ProviderID
+	Mode       modes.Mode
+	Region     string
 	Account    string
 	Default    bool
 	DeployedAt time.Time
@@ -192,8 +195,11 @@ func ListInDirectory(workingDirectory string) ([]ListItem, error) {
 			continue
 		}
 		stacks = append(stacks, ListItem{
-			Parameters: *params,
-			Account:    params.Account(),
+			Name:     params.Name,
+			Provider: params.Provider,
+			Mode:     params.Mode,
+			Region:   params.Region,
+			Account:  params.Account(),
 		})
 	}
 


### PR DESCRIPTION
## Description

Since "Encrypt tenant data" https://github.com/DefangLabs/defang-mvp/pull/2979, the `ListStacks` rpc no longer returns the remote contents of a stack. To get those (plaintext), a call to `GetStack` is needed. This was a breaking change, since the CLI only ever invoked the `ListStacks` rpc so for a while, remote stacks did not return any content. Local stacks, as well as remote *default* stacks were not broken.

This PR changes the internal `ListItem` structure to no longer the stack file contents and only the metadata. The StackSelector and StackManager now explicitly call `Load` and `GetStack`, resp.

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Remote stack access now fetches stacks individually and centralizes parameter parsing for more consistent stack details.
  * Stack listing and selection logic updated to load stack details on demand.
  * Internal stack item representation refined for clearer provider/region/mode/account display.

* **Bug Fix**
  * More accurate handling of missing or not-found remote stacks, reducing incorrect or stale metadata shown.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefangLabs/defang/pull/2121?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->