### PR TITLE
fix: show containerapp endpoints in deployment summary

### DIFF
--- a/src/cmd/cli/command/compose.go
+++ b/src/cmd/cli/command/compose.go
@@ -182,11 +182,22 @@ func makeComposeUpCmd() *cobra.Command {
 				return deploymentErr
 			}
 
-			for _, service := range deploy.Services {
+			// Fetch updated service infos from the provider — for Azure, defang.app
+			// DNS delegation is not yet implemented, so the CD task writes the actual
+			// azurecontainerapps.io endpoints into project.pb after Pulumi finishes.
+			// Reading back here ensures we display the real URLs instead of the
+			// pre-deploy defang.app placeholders. Remove this once Azure delegate
+			// domains are supported.
+			updatedServices := deploy.Services
+			if resp, err := session.Provider.GetServices(ctx, &defangv1.GetServicesRequest{Project: project.Name}); err == nil && len(resp.Services) > 0 {
+				updatedServices = resp.Services
+			}
+
+			for _, service := range updatedServices {
 				service.State = serviceStates[service.Service.Name]
 			}
 
-			services, err := cli.NewServiceFromServiceInfo(deploy.Services)
+			services, err := cli.NewServiceFromServiceInfo(updatedServices)
 			if err != nil {
 				return err
 			}

--- a/src/cmd/cli/command/compose.go
+++ b/src/cmd/cli/command/compose.go
@@ -189,7 +189,10 @@ func makeComposeUpCmd() *cobra.Command {
 			// pre-deploy defang.app placeholders. Remove this once Azure delegate
 			// domains are supported.
 			updatedServices := deploy.Services
-			if resp, err := session.Provider.GetServices(ctx, &defangv1.GetServicesRequest{Project: project.Name}); err == nil && len(resp.Services) > 0 {
+			resp, err := session.Provider.GetServices(ctx, &defangv1.GetServicesRequest{Project: project.Name})
+			if err != nil || resp == nil || len(resp.Services) == 0 {
+				term.Debugf("GetServices failed after deployment: %v", err)
+			} else {
 				updatedServices = resp.Services
 			}
 


### PR DESCRIPTION
## Description

After the CD task finishes, re-fetch service infos from the provider so the deployment summary displays the actual azurecontainerapps.io URLs written by the CD task rather than the pre-deploy defang.app placeholders. Azure delegate domain support is not yet implemented, so this is a stopgap until it is.

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * After `compose up` finishes, service info is now refreshed from the deployment target so printed service states and endpoint URLs reflect actual deployed values (Azure endpoints now show real URLs instead of placeholders).
  * If the refresh fails or returns no data, the command gracefully keeps and displays the original service information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefangLabs/defang/pull/2130?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->