### PR TITLE
fix(track): skip telemetry under testing.Testing() to avoid term race

### DIFF
--- a/src/pkg/track/track.go
+++ b/src/pkg/track/track.go
@@ -3,6 +3,7 @@ package track
 import (
 	"strings"
 	"sync"
+	"testing"
 
 	"github.com/DefangLabs/defang/src/pkg"
 	"github.com/DefangLabs/defang/src/pkg/cli/client"
@@ -35,6 +36,14 @@ var trackWG = sync.WaitGroup{}
 //	client := "vscode"
 //	track.Evt("MCP Setup Client:", track.P("client", client))
 func Evt(name string, props ...Property) {
+	// Tests shouldn't send real telemetry, and the goroutine spawned below
+	// outlives the calling test — its background term.Debug reads then race
+	// the next test's term.SetupTestTerm swap of DefaultTerm. testing.Testing()
+	// (Go 1.21+) is the standard idiom for safely detecting test context from
+	// non-test code.
+	if testing.Testing() {
+		return
+	}
 	if disableAnalytics {
 		return
 	}


### PR DESCRIPTION
## What

Adds a `testing.Testing()` short-circuit at the top of `track.Evt` so telemetry is never fired during tests. Stops a data race between `track.Evt`'s background goroutine and `term.SetupTestTerm`'s mutation of `term.DefaultTerm`.

## The race

\`\`\`
WARNING: DATA RACE
Read at 0x... by goroutine 288:
  pkg/term.Debug() ← grpcLogger.logRequest ← Track ← track.Evt.func1
Previous write at 0x... by goroutine 295:
  pkg/term.SetupTestTerm() ← TestWorkspaceListVerboseTable
\`\`\`

`track.Evt` spawns a goroutine that calls `tracker.Track` through the gRPC interceptor, which calls `term.Debug` — reading `term.DefaultTerm`. The goroutine isn't bound to the calling test's lifetime; it routinely outlives one test by the duration of an HTTP roundtrip.

`term.SetupTestTerm` writes `term.DefaultTerm` at the start of every test that uses it. When test N's tracking goroutine is still alive when test N+1 starts, the SetupTestTerm write races the orphan's `term.Debug` read.

## Fix

\`\`\`go
func Evt(name string, props ...Property) {
    if testing.Testing() {
        return
    }
    // ...
}
\`\`\`

- **Stops the race at the source** — no goroutine spawned in tests means nothing to race with.
- **`testing.Testing()` is the idiomatic Go-1.21+ way to detect test context from non-test code.** Project is on Go 1.25.
- **Zero production risk** — returns `false` outside `go test` binaries.

## Why not the alternatives

| Option | Problem |
|---|---|
| `FlushAllTracking` in `SetupTestTerm` cleanup | Import cycle: `track` already imports `term`. |
| Per-test `t.Cleanup(track.FlushAllTracking)` | Manual; easy to forget on new tests. |
| Race-safe `term.DefaultTerm` | Treats symptom not cause; future readers from orphan goroutines stay risky. |
| `DEFANG_DISABLE_ANALYTICS=true` in TestMain | Per-package; doesn't help across packages. |

## Verification

\`\`\`
$ cd src && go test -race -short -count=3 ./cmd/cli/command/
ok  github.com/DefangLabs/defang/src/cmd/cli/command  12.675s
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Tests now execute without background tracking activity, improving test environment isolation and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->