### PR TITLE
Display the interpolated domain for DNS setup from service info

### DIFF
--- a/src/pkg/cli/cert.go
+++ b/src/pkg/cli/cert.go
@@ -110,10 +110,14 @@ func GenerateLetsEncryptCert(ctx context.Context, project *compose.Project, clie
 		}
 		if service, ok := project.Services[serviceInfo.Service.Name]; ok {
 			if service.DomainName != serviceInfo.Domainname {
-				term.Warnf("service %q: domainname %q in compose file does not match deployed value %q", service.Name, service.DomainName, serviceInfo.Domainname)
+				term.Warnf("service %q: domainname %q in compose file does not match deployed value %q, will use the deployed value", service.Name, service.DomainName, serviceInfo.Domainname)
 			}
 			cnt++
-			domains := []string{service.DomainName}
+			if serviceInfo.Domainname == "" {
+				term.Warnf("service %q: `domainname` is deployed without a domainname, skipping cert generation", service.Name)
+				continue
+			}
+			domains := []string{serviceInfo.Domainname}
 			if defaultNetwork := service.Networks["default"]; defaultNetwork != nil {
 				domains = append(domains, defaultNetwork.Aliases...)
 			}


### PR DESCRIPTION
## Description
Right now the DNS instruction displays the raw value of domainname from compose file, which main contain uninterpreted variables, making the instruction invalid, we should display the actual domain name returned from serviceinfo. 

## Checklist

- [X] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed certificate generation to prioritize the deployed service's domain name when it differs from the configuration file's domain name.
  * Certificate generation now gracefully skips services without a deployed domain name and logs a warning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->