### PR TITLE
Use multiple shorter timeout requests to check for ssl cert

### DIFF
--- a/src/pkg/cert/check.go
+++ b/src/pkg/cert/check.go
@@ -2,6 +2,7 @@ package cert
 
 import (
 	"context"
+	"io"
 	"net"
 	"net/http"
 	"time"
@@ -9,26 +10,46 @@ import (
 	"github.com/DefangLabs/defang/src/pkg/dns"
 )
 
+// perAttemptTimeout caps a single HTTPS probe against one IP so a server that
+// completes TCP but stalls during TLS or the HTTP reply can't pin the caller
+// for the full polling budget. waitForTLS retries on a 3s ticker, so this is
+// the inner cap, not the total wait. Var rather than const so tests can
+// shorten it.
+var perAttemptTimeout = 10 * time.Second
+
 func CheckTLSCert(ctx context.Context, domain string, resolver dns.Resolver) error {
 	ips, err := resolver.LookupIPAddr(ctx, domain)
 	if err != nil {
 		return err
 	}
 	for _, ip := range ips {
-		url := "https://" + domain
-		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
-		if err != nil {
+		if err := checkOne(ctx, domain, ip.String()); err != nil {
 			return err
 		}
-		httpClient := &http.Client{
-			Transport: getFixedIPTransport(ip.String()),
-		}
-		resp, err := httpClient.Do(req)
-		if err != nil {
-			return err
-		}
-		defer resp.Body.Close()
 	}
+	return nil
+}
+
+func checkOne(ctx context.Context, domain, ip string) error {
+	attemptCtx, cancel := context.WithTimeout(ctx, perAttemptTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(attemptCtx, http.MethodGet, "https://"+domain, nil)
+	if err != nil {
+		return err
+	}
+	httpClient := &http.Client{
+		Transport: getFixedIPTransport(ip),
+		Timeout:   perAttemptTimeout,
+	}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	// Drain so the connection can be reused; cap the read so a chatty server
+	// can't extend the attempt past its deadline.
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 1<<14))
 	return nil
 }
 
@@ -48,6 +69,7 @@ func getFixedIPTransport(ip string) *http.Transport {
 		MaxIdleConns:          100,
 		IdleConnTimeout:       90 * time.Second,
 		TLSHandshakeTimeout:   10 * time.Second,
+		ResponseHeaderTimeout: 5 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,
 	}
 }

--- a/src/pkg/cert/check.go
+++ b/src/pkg/cert/check.go
@@ -2,6 +2,7 @@ package cert
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net"
 	"net/http"
@@ -20,7 +21,13 @@ var perAttemptTimeout = 10 * time.Second
 func CheckTLSCert(ctx context.Context, domain string, resolver dns.Resolver) error {
 	ips, err := resolver.LookupIPAddr(ctx, domain)
 	if err != nil {
-		return err
+		return fmt.Errorf("lookup A records for %q: %w", domain, err)
+	}
+	// An empty A-record set is not "TLS ready" — every caller treats nil as
+	// success and would short-circuit their polling loop. Surface it as an
+	// error so the caller keeps waiting for DNS to populate.
+	if len(ips) == 0 {
+		return fmt.Errorf("no A records found for %q", domain)
 	}
 	for _, ip := range ips {
 		if err := checkOne(ctx, domain, ip.String()); err != nil {
@@ -36,7 +43,7 @@ func checkOne(ctx context.Context, domain, ip string) error {
 
 	req, err := http.NewRequestWithContext(attemptCtx, http.MethodGet, "https://"+domain, nil)
 	if err != nil {
-		return err
+		return fmt.Errorf("build TLS probe request for %q via %s: %w", domain, ip, err)
 	}
 	httpClient := &http.Client{
 		Transport: getFixedIPTransport(ip),
@@ -44,7 +51,7 @@ func checkOne(ctx context.Context, domain, ip string) error {
 	}
 	resp, err := httpClient.Do(req)
 	if err != nil {
-		return err
+		return fmt.Errorf("TLS probe failed for %q via %s: %w", domain, ip, err)
 	}
 	defer resp.Body.Close()
 	// Drain so the connection can be reused; cap the read so a chatty server

--- a/src/pkg/cert/check_test.go
+++ b/src/pkg/cert/check_test.go
@@ -1,0 +1,192 @@
+package cert
+
+import (
+	"context"
+	"net"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/DefangLabs/defang/src/pkg/dns"
+)
+
+// stallingListener accepts TCP connections and holds them open without
+// speaking TLS or writing any bytes. This is how we exercise the per-attempt
+// timeout: from the client's view, TCP succeeds but the TLS handshake never
+// progresses.
+func stallingListener(t *testing.T) (host string, port string) {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	wg.Go(func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			// Hold the connection until the test signals shutdown. Wrapping in
+			// a goroutine so the accept loop is free to handle the (typical)
+			// case of one connect attempt; the caller's per-attempt timeout
+			// is what makes the test return.
+			go func(c net.Conn) {
+				<-stop
+				c.Close()
+			}(conn)
+		}
+	})
+
+	t.Cleanup(func() {
+		close(stop)
+		ln.Close()
+		wg.Wait()
+	})
+
+	host, port, err = net.SplitHostPort(ln.Addr().String())
+	if err != nil {
+		t.Fatalf("split addr: %v", err)
+	}
+	return host, port
+}
+
+// withTestPerAttemptTimeout temporarily shortens the per-attempt cap so the
+// test doesn't sit on the 10s production default.
+func withTestPerAttemptTimeout(t *testing.T, d time.Duration) {
+	t.Helper()
+	prev := perAttemptTimeout
+	perAttemptTimeout = d
+	t.Cleanup(func() { perAttemptTimeout = prev })
+}
+
+func TestCheckTLSCert_PerAttemptTimeoutFiresOnStalledServer(t *testing.T) {
+	withTestPerAttemptTimeout(t, 200*time.Millisecond)
+	ip, port := stallingListener(t)
+
+	// Build a domain that embeds the listener port so the URL becomes
+	// https://<host>:<port>; getFixedIPTransport will dial <ip>:<port>.
+	domain := "localhost:" + port
+	resolver := dns.MockResolver{Records: map[dns.DNSRequest]dns.DNSResponse{
+		{Type: "A", Domain: domain}: {Records: []string{ip}},
+	}}
+
+	// Outer deadline is far larger than the per-attempt cap. If the cap
+	// works the call returns in ~perAttemptTimeout; if it doesn't, this
+	// test fails by context deadline.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	start := time.Now()
+	err := CheckTLSCert(ctx, domain, resolver)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected error from stalled TLS handshake, got nil")
+	}
+	// 4x the cap is generous CI slack; the point is it's nowhere near the
+	// outer 5s ctx deadline.
+	if elapsed > 4*perAttemptTimeout {
+		t.Fatalf("CheckTLSCert took %v, expected <= %v (per-attempt cap was %v)",
+			elapsed, 4*perAttemptTimeout, perAttemptTimeout)
+	}
+	if ctx.Err() != nil {
+		t.Fatalf("outer ctx expired (%v); per-attempt timeout did not fire first", ctx.Err())
+	}
+}
+
+func TestCheckTLSCert_ResolverErrorPropagates(t *testing.T) {
+	wantErr := &net.DNSError{Err: "no such host", Name: "missing.example"}
+	resolver := dns.MockResolver{Records: map[dns.DNSRequest]dns.DNSResponse{
+		{Type: "A", Domain: "missing.example"}: {Error: wantErr},
+	}}
+
+	err := CheckTLSCert(context.Background(), "missing.example", resolver)
+	if err == nil {
+		t.Fatal("expected resolver error, got nil")
+	}
+}
+
+func TestCheckTLSCert_NoIPsReturnsNil(t *testing.T) {
+	// Defensive: if the resolver returns no A records we should not loop,
+	// not error, and not panic. The cert command will retry on its 3s
+	// ticker and pick up the records once they propagate.
+	resolver := dns.MockResolver{Records: map[dns.DNSRequest]dns.DNSResponse{
+		{Type: "A", Domain: "empty.example"}: {Records: nil},
+	}}
+	if err := CheckTLSCert(context.Background(), "empty.example", resolver); err != nil {
+		t.Fatalf("expected nil for empty IP list, got %v", err)
+	}
+}
+
+func TestGetFixedIPTransport_HasResponseHeaderTimeout(t *testing.T) {
+	// Regression guard: the response-header timeout is the second half of
+	// the fix (the first being http.Client.Timeout in checkOne). If someone
+	// later trims it back to zero, this fails so the fix isn't silently
+	// undone.
+	tr := getFixedIPTransport("127.0.0.1")
+	if tr.ResponseHeaderTimeout <= 0 {
+		t.Fatalf("ResponseHeaderTimeout = %v, want > 0", tr.ResponseHeaderTimeout)
+	}
+	if tr.TLSHandshakeTimeout <= 0 {
+		t.Fatalf("TLSHandshakeTimeout = %v, want > 0", tr.TLSHandshakeTimeout)
+	}
+}
+
+// Ensure we wired the transport's DialContext to the fixed IP rather than
+// honoring the URL host. Belt-and-suspenders test: if a refactor accidentally
+// drops the IP pinning, this fails.
+func TestGetFixedIPTransport_DialsFixedIP(t *testing.T) {
+	tr := getFixedIPTransport("127.0.0.1")
+	// We can't easily intercept the dial without rewriting the transport,
+	// so just confirm the public knobs are present and DialContext is set.
+	if tr.DialContext == nil {
+		t.Fatal("DialContext is nil")
+	}
+	// A bogus host:port is fine — we only care that the dial target is
+	// derived from the fixed IP, not the URL host. We assert by attempting
+	// a dial against a closed port on 127.0.0.1 and expecting a connection
+	// refused error rather than a name resolution error.
+	_, err := tr.DialContext(context.Background(), "tcp", "doesnotexist.invalid:1")
+	if err == nil {
+		t.Fatal("expected dial error against closed port, got nil")
+	}
+	// On a fixed-IP transport the dial should never have done a DNS lookup
+	// for "doesnotexist.invalid"; net.OpError wraps a "connection refused"
+	// or similar. We don't pin to an exact string but check it's not a DNS
+	// error message.
+	if strings.Contains(err.Error(), "no such host") {
+		t.Fatalf("dial appears to have resolved the URL host instead of using the fixed IP: %v", err)
+	}
+}
+
+// Sanity check that http.Client is what we think — guards against a future
+// refactor that drops Client.Timeout without realizing it's the user-visible
+// cap that keeps waitForTLS's 3s ticker reachable.
+func TestCheckOne_ClientHasTimeout(t *testing.T) {
+	withTestPerAttemptTimeout(t, 50*time.Millisecond)
+	ip, port := stallingListener(t)
+	domain := "localhost:" + port
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	start := time.Now()
+	err := checkOne(ctx, domain, ip)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected error from stalled connection, got nil")
+	}
+	if elapsed > 500*time.Millisecond {
+		t.Fatalf("checkOne took %v with %v cap; client timeout not honored",
+			elapsed, perAttemptTimeout)
+	}
+	// Don't assert the error type — it can be either a context.DeadlineExceeded
+	// (from attemptCtx) or url.Error wrapping it (from http.Client.Timeout),
+	// depending on which fires first. Both are correct behavior.
+}

--- a/src/pkg/cert/check_test.go
+++ b/src/pkg/cert/check_test.go
@@ -2,6 +2,7 @@ package cert
 
 import (
 	"context"
+	"errors"
 	"net"
 	"strings"
 	"sync"
@@ -109,17 +110,32 @@ func TestCheckTLSCert_ResolverErrorPropagates(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected resolver error, got nil")
 	}
+	// CheckTLSCert wraps the resolver error with domain context so callers
+	// (whose debug log might not otherwise mention the lookup stage) can tell
+	// what failed.
+	if !errors.Is(err, wantErr) {
+		t.Errorf("wrapped error should still unwrap to the resolver error; got %v", err)
+	}
+	if !strings.Contains(err.Error(), "missing.example") {
+		t.Errorf("error %q should name the domain", err)
+	}
 }
 
-func TestCheckTLSCert_NoIPsReturnsNil(t *testing.T) {
-	// Defensive: if the resolver returns no A records we should not loop,
-	// not error, and not panic. The cert command will retry on its 3s
-	// ticker and pick up the records once they propagate.
+func TestCheckTLSCert_NoIPsReturnsError(t *testing.T) {
+	// An empty A-record set is not TLS-ready. Every CheckTLSCert caller
+	// (waitForTLS in pkg/cli/cert.go, and the Azure cert flow) treats nil
+	// as "cert is online" and exits its polling loop — so returning nil
+	// for zero probes would prematurely declare success. Surface an error
+	// so callers keep waiting for DNS to populate.
 	resolver := dns.MockResolver{Records: map[dns.DNSRequest]dns.DNSResponse{
 		{Type: "A", Domain: "empty.example"}: {Records: nil},
 	}}
-	if err := CheckTLSCert(context.Background(), "empty.example", resolver); err != nil {
-		t.Fatalf("expected nil for empty IP list, got %v", err)
+	err := CheckTLSCert(context.Background(), "empty.example", resolver)
+	if err == nil {
+		t.Fatal("expected error for empty IP list, got nil")
+	}
+	if !strings.Contains(err.Error(), "empty.example") {
+		t.Errorf("error %q should name the domain", err)
 	}
 }
 


### PR DESCRIPTION
To prevent cert verification timeout

## Checklist

- [X] I have performed a self-review of my code
- [X] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Per-IP certificate checks now enforce a per-attempt timeout and better reuse connections to avoid hangs.
  * DNS resolution failures and empty-IP results are now reported as errors instead of silently proceeding.
  * Transport timeouts tightened (including response-header/TLS handshake) to fail faster on stalled peers.

* **Tests**
  * Expanded tests covering timeouts, DNS error propagation, empty-resolution handling, and fixed-IP transport behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->