### PR TITLE
Parallel the cert gen process

### DIFF
--- a/src/pkg/cli/cert.go
+++ b/src/pkg/cli/cert.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"connectrpc.com/connect"
@@ -17,9 +18,9 @@ import (
 	"github.com/DefangLabs/defang/src/pkg/cli/client"
 	"github.com/DefangLabs/defang/src/pkg/cli/compose"
 	"github.com/DefangLabs/defang/src/pkg/dns"
-	"github.com/DefangLabs/defang/src/pkg/spinner"
 	"github.com/DefangLabs/defang/src/pkg/term"
 	defangv1 "github.com/DefangLabs/defang/src/protos/io/defang/v1"
+	"golang.org/x/sync/errgroup"
 )
 
 type HTTPClient interface {
@@ -37,6 +38,11 @@ var (
 
 	httpRetryDelayBase = 5 * time.Second
 )
+
+// maxCertWorkers caps concurrent per-domain cert workers. Per-domain work is
+// mostly idle wait (DNS propagation, ACME issuance), so the cap exists to keep
+// the log stream readable rather than for throughput.
+const maxCertWorkers = 8
 
 func newCertHTTPClient(r dns.Resolver) HTTPClient {
 	return &http.Client{
@@ -88,66 +94,76 @@ type CertIssuer interface {
 	IssueCert(ctx context.Context, projectName, serviceName, hostname string, resolverAt func(string) dns.Resolver) error
 }
 
-func GenerateLetsEncryptCert(ctx context.Context, project *compose.Project, client client.FabricClient, provider client.Provider) error {
+// domainJob is one (service, domain, targets) tuple processed by a worker.
+// targets are pre-normalized at collection time so workers can read them
+// concurrently without each performing their own in-place normalization.
+type domainJob struct {
+	serviceName string
+	domain      string
+	targets     []string
+}
+
+func GenerateLetsEncryptCert(ctx context.Context, project *compose.Project, fab client.FabricClient, provider client.Provider) error {
 	term.Debugf("Generating TLS cert for project %q", project.Name)
 
 	services, err := provider.GetServices(ctx, &defangv1.GetServicesRequest{Project: project.Name})
 	if err != nil {
 		return err
 	}
-
 	if len(services.Services) == 0 {
 		return fmt.Errorf("no services found for project %q; deployment may not be finished yet", project.Name)
 	}
 
 	issuer, _ := provider.(CertIssuer)
+	jobs := collectDomainJobs(project, services.Services)
+	if len(jobs) == 0 {
+		term.Infof("No `domainname` found in compose file; no HTTPS cert generation needed")
+		return nil
+	}
 
-	var issueErrs []error
-	cnt := 0
-	for _, serviceInfo := range services.Services {
-		if !serviceInfo.UseAcmeCert {
+	if issuer != nil {
+		return runIssuerJobs(ctx, project.Name, jobs, fab, issuer)
+	}
+	return runACMEJobs(ctx, jobs, fab)
+}
+
+// collectDomainJobs flattens services into per-domain work items. Validation
+// warnings (domain mismatch, missing domainname) are emitted here so they
+// appear once, up-front, before any parallel worker output.
+func collectDomainJobs(project *compose.Project, services []*defangv1.ServiceInfo) []domainJob {
+	var jobs []domainJob
+	for _, si := range services {
+		if !si.UseAcmeCert {
 			continue
 		}
-		if service, ok := project.Services[serviceInfo.Service.Name]; ok {
-			if service.DomainName != serviceInfo.Domainname {
-				term.Warnf("service %q: domainname %q in compose file does not match deployed value %q, will use the deployed value", service.Name, service.DomainName, serviceInfo.Domainname)
-			}
-			cnt++
-			if serviceInfo.Domainname == "" {
-				term.Warnf("service %q: `domainname` is deployed without a domainname, skipping cert generation", service.Name)
-				continue
-			}
-			domains := []string{serviceInfo.Domainname}
-			if defaultNetwork := service.Networks["default"]; defaultNetwork != nil {
-				domains = append(domains, defaultNetwork.Aliases...)
-			}
+		svc, ok := project.Services[si.Service.Name]
+		if !ok {
+			continue
+		}
+		if svc.DomainName != si.Domainname {
+			term.Warnf("service %q: domainname %q in compose file does not match deployed value %q, will use the deployed value", svc.Name, svc.DomainName, si.Domainname)
+		}
+		if si.Domainname == "" {
+			term.Warnf("service %q: `domainname` is deployed without a domainname, skipping cert generation", svc.Name)
+			continue
+		}
+		// Pre-normalize once so the worker's wait loop can read the slice
+		// without racing other workers on shared backing storage.
+		rawTargets := getDomainTargets(si, svc)
+		targets := make([]string, len(rawTargets))
+		for i, t := range rawTargets {
+			targets[i] = dns.Normalize(t)
+		}
 
-			if issuer != nil {
-				term.Debugf("Issuing certs for service %v with domains %v via provider", service.Name, domains)
-				for _, domain := range domains {
-					if err := issuer.IssueCert(ctx, project.Name, service.Name, domain, dns.NewFabricResolverAt(client)); err != nil {
-						term.Errorf("Cert issuance for %v failed: %v", domain, err)
-						issueErrs = append(issueErrs, fmt.Errorf("%v: %w", domain, err))
-					}
-				}
-				continue
-			}
-
-			targets := getDomainTargets(serviceInfo, service)
-			term.Debugf("Found service %v with domains %v and targets %v", service.Name, domains, targets)
-			for _, domain := range domains {
-				generateCert(ctx, domain, targets, client, dns.FabricResolver{Client: client})
-			}
+		domains := []string{si.Domainname}
+		if defaultNetwork := svc.Networks["default"]; defaultNetwork != nil {
+			domains = append(domains, defaultNetwork.Aliases...)
+		}
+		for _, d := range domains {
+			jobs = append(jobs, domainJob{serviceName: svc.Name, domain: d, targets: targets})
 		}
 	}
-	if cnt == 0 {
-		term.Infof("No `domainname` found in compose file; no HTTPS cert generation needed")
-	}
-
-	if len(issueErrs) > 0 {
-		return fmt.Errorf("certificate issuance failed for one or more domains; verify DNS records and retry `defang cert generate`: %w", errors.Join(issueErrs...))
-	}
-	return nil
+	return jobs
 }
 
 func getDomainTargets(serviceInfo *defangv1.ServiceInfo, service compose.ServiceConfig) []string {
@@ -165,78 +181,241 @@ func getDomainTargets(serviceInfo *defangv1.ServiceInfo, service compose.Service
 	}
 }
 
-func generateCert(ctx context.Context, domain string, targets []string, client client.FabricClient, r dns.Resolver) {
-	term.Infof("Checking DNS setup for %v", domain)
-	if err := waitForCNAME(ctx, domain, targets, client); err != nil {
-		term.Errorf("Error waiting for CNAME: %v", err)
-		return
+// runIssuerJobs runs the provider-driven cert issuance in parallel. Per-domain
+// state transitions are emitted via a per-domain prefixed logger so the log
+// stream remains readable across concurrent workers.
+func runIssuerJobs(ctx context.Context, projectName string, jobs []domainJob, fab client.FabricClient, issuer CertIssuer) error {
+	pad := maxDomainLen(jobs)
+	eg, gctx := errgroup.WithContext(ctx)
+	eg.SetLimit(maxCertWorkers)
+	var (
+		errMu sync.Mutex
+		errs  []error
+	)
+	for _, j := range jobs {
+		job := j
+		log := newDomainLogger(job.domain, pad)
+		eg.Go(func() error {
+			start := time.Now()
+			log("issuing cert…")
+			if err := issuer.IssueCert(gctx, projectName, job.serviceName, job.domain, dns.NewFabricResolverAt(fab)); err != nil {
+				log("failed: %v", err)
+				errMu.Lock()
+				errs = append(errs, fmt.Errorf("%v: %w", job.domain, err))
+				errMu.Unlock()
+				return nil // don't abort sibling workers
+			}
+			log("cert issued ✓ (%s)", time.Since(start).Round(time.Second))
+			return nil
+		})
 	}
-
-	term.Infof("%v DNS is properly configured!", domain)
-	if err := cert.CheckTLSCert(ctx, domain, r); err == nil {
-		term.Infof("TLS cert for %v is already ready", domain)
-		return
+	_ = eg.Wait() // goroutines never return errors; collected via errs
+	if len(errs) > 0 {
+		return fmt.Errorf("certificate issuance failed for one or more domains; verify DNS records and retry `defang cert generate`: %w", errors.Join(errs...))
 	}
-	if err := pkg.SleepWithContext(ctx, 5*time.Second); err != nil { // slight delay to ensure DNS to propagate
-		term.Errorf("Error waiting for DNS propagation: %v", err)
-		return
-	}
-	term.Infof("Triggering cert generation for %v", domain)
-	if err := triggerCertGeneration(ctx, domain, r); err != nil {
-		term.Errorf("Error triggering cert generation, please try again")
-		return
-	}
-
-	term.Infof("Waiting for TLS cert to be online for %v, this could take a few minutes", domain)
-	if err := waitForTLS(ctx, domain, r); err != nil {
-		term.Errorf("Error waiting for TLS to be online: %v", err)
-		// FIXME: Add more info on how to debug, possibly provided by the server side to avoid client type detection here
-		return
-	}
-
-	term.Infof("TLS cert for %v is ready\n", domain)
+	return nil
 }
 
-func triggerCertGeneration(ctx context.Context, domain string, r dns.Resolver) error {
-	doSpinner := term.StdoutCanColor() && term.IsTerminal()
-	if doSpinner {
-		term.HideCursor()
-		defer term.ShowCursor()
+// runACMEJobs runs the fabric/ACME redirect-dance flow in two phases:
+// Phase 1 — sequential pre-flight VerifyDNSSetup across all domains, then a
+// single grouped CNAME/ALIAS instruction block for the ones not yet ready,
+// so the user can configure every record in one DNS-console sitting.
+// Phase 2 — parallel per-domain workers (DNS wait, cert trigger, TLS wait)
+// emitting one prefixed status line per state transition.
+func runACMEJobs(ctx context.Context, jobs []domainJob, fab client.FabricClient) error {
+	pad := maxDomainLen(jobs)
 
-		spin := spinner.New()
-		cancelSpinner := spin.Start(ctx)
-		defer cancelSpinner()
+	// Phase 1: pre-flight.
+	verified := preflightDNS(ctx, jobs, fab)
+	var needsSetup []domainJob
+	for _, j := range jobs {
+		if verified[j.domain] {
+			newDomainLogger(j.domain, pad)("DNS already configured")
+		} else {
+			needsSetup = append(needsSetup, j)
+		}
 	}
-	// Our own retry logic uses the root resolver to prevent cached DNS and retry on all non-200 errors
-	if err := getWithRetries(ctx, fmt.Sprintf("http://%v", domain), 5, newCertHTTPClient(r)); err != nil { // Retry incase of DNS error
-		// Ignore possible tls error as cert attachment may take time
-		term.Debugf("Error triggering cert generation: %v", err)
+	if len(needsSetup) > 0 {
+		printGroupedCNAMEs(needsSetup, pad)
+		term.Infof("Awaiting DNS record setup and propagation for %d domain(s)…", len(needsSetup))
+	}
+
+	// Phase 2: parallel workers.
+	eg, gctx := errgroup.WithContext(ctx)
+	eg.SetLimit(maxCertWorkers)
+	var (
+		errMu sync.Mutex
+		errs  []error
+	)
+	for _, j := range jobs {
+		job := j
+		alreadyVerified := verified[job.domain]
+		log := newDomainLogger(job.domain, pad)
+		eg.Go(func() error {
+			if err := runACMEForDomain(gctx, job, fab, log, alreadyVerified); err != nil {
+				log("failed: %v", err)
+				errMu.Lock()
+				errs = append(errs, fmt.Errorf("%v: %w", job.domain, err))
+				errMu.Unlock()
+			}
+			return nil
+		})
+	}
+	_ = eg.Wait()
+	if len(errs) > 0 {
+		return fmt.Errorf("certificate issuance failed for one or more domains; verify DNS records and retry `defang cert generate`: %w", errors.Join(errs...))
+	}
+	return nil
+}
+
+// preflightDNS asks the server to verify each domain's CNAME/ALIAS setup once,
+// returning the set of domains the server is happy with. Negative results
+// (CodeFailedPrecondition) and RPC failures are both treated as "not yet
+// verified" — the per-domain worker will keep retrying and supplement with
+// local DNS checks.
+func preflightDNS(ctx context.Context, jobs []domainJob, fab client.FabricClient) map[string]bool {
+	verified := make(map[string]bool, len(jobs))
+	for _, j := range jobs {
+		if err := fab.VerifyDNSSetup(ctx, &defangv1.VerifyDNSSetupRequest{Domain: j.domain, Targets: j.targets}); err == nil {
+			verified[j.domain] = true
+		} else {
+			term.Debugf("Pre-flight DNS verification for %v not yet ready: %v", j.domain, err)
+		}
+	}
+	return verified
+}
+
+// printGroupedCNAMEs prints every pending domain's record on its own line, in
+// a single block. Padding aligns the arrow column so multi-domain projects
+// read like a small table.
+func printGroupedCNAMEs(jobs []domainJob, pad int) {
+	term.Infof("Configure the following DNS record(s) (CNAME or ALIAS; any listed target per row works):")
+	for _, j := range jobs {
+		term.Printf("  %-*s  ->  %s\n", pad, j.domain, strings.Join(j.targets, " or "))
+	}
+}
+
+// runACMEForDomain runs the per-domain ACME flow: wait for DNS, probe for an
+// existing cert, trigger generation, wait for the cert to come online. All
+// inline progress goes through log so concurrent workers don't fight for the
+// TTY. If alreadyVerified, the DNS wait step is skipped — Phase 1 just saw it.
+func runACMEForDomain(ctx context.Context, job domainJob, fab client.FabricClient, log func(string, ...any), alreadyVerified bool) error {
+	r := dns.FabricResolver{Client: fab}
+	start := time.Now()
+
+	if !alreadyVerified {
+		if err := waitForDNSVerified(ctx, job.domain, job.targets, fab, log); err != nil {
+			return fmt.Errorf("waiting for DNS verification: %w", err)
+		}
+		log("DNS verified")
+	}
+
+	if err := cert.CheckTLSCert(ctx, job.domain, r); err == nil {
+		log("TLS cert already ready (%s)", time.Since(start).Round(time.Second))
+		return nil
+	}
+	if err := pkg.SleepWithContext(ctx, 5*time.Second); err != nil {
+		return fmt.Errorf("waiting for DNS propagation: %w", err)
+	}
+
+	log("triggering cert generation…")
+	if err := triggerCertGen(ctx, job.domain, r); err != nil {
+		return fmt.Errorf("triggering cert generation: %w", err)
+	}
+
+	log("waiting for TLS cert to come online…")
+	if err := waitForTLSReady(ctx, job.domain, r); err != nil {
+		return fmt.Errorf("waiting for TLS to come online: %w", err)
+	}
+	log("TLS online ✓ (%s)", time.Since(start).Round(time.Second))
+	return nil
+}
+
+// waitForDNSVerified blocks until the server-side or local DNS check confirms
+// the record is in place, or ctx expires. Quiet by design — the caller logs
+// state transitions; this function only logs the propagation caveat because
+// it materially changes user expectations (the server is happy but the local
+// DNS may still be stale).
+func waitForDNSVerified(ctx context.Context, domain string, targets []string, fab client.FabricClient, log func(string, ...any)) error {
+	serverSideVerified := false
+	serverVerifyRpcFailure := 0
+	propagationNoted := false
+
+	verify := func() bool {
+		if !serverSideVerified && serverVerifyRpcFailure < 3 {
+			err := fab.VerifyDNSSetup(ctx, &defangv1.VerifyDNSSetupRequest{Domain: domain, Targets: targets})
+			switch {
+			case err == nil:
+				serverSideVerified = true
+			case isNegativeVerify(err):
+				// Server says "not yet" — don't count against the RPC budget.
+				term.Debugf("Server side DNS verification for %v negative: %v", domain, err)
+			default:
+				serverVerifyRpcFailure++
+				term.Debugf("Server side DNS verification request for %v failed (%d/3): %v", domain, serverVerifyRpcFailure, err)
+			}
+		}
+		if serverSideVerified || serverVerifyRpcFailure >= 3 {
+			locallyVerified := dns.CheckDomainDNSReady(ctx, domain, targets, dns.NewFabricResolverAt(fab))
+			if serverSideVerified && !locallyVerified {
+				if !propagationNoted {
+					log("DNS verified server-side; local caches still propagating (may take a few minutes)")
+					propagationNoted = true
+				}
+				return true // server-side trust wins; cert work can proceed
+			}
+			return locallyVerified
+		}
+		return false
+	}
+
+	if verify() {
+		return nil
+	}
+	ticker := time.NewTicker(5 * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			if verify() {
+				return nil
+			}
+		}
+	}
+}
+
+func isNegativeVerify(err error) bool {
+	cerr := new(connect.Error)
+	return errors.As(err, &cerr) && cerr.Code() == connect.CodeFailedPrecondition
+}
+
+// triggerCertGen sends the HTTP GET that nudges the fabric into running the
+// ACME challenge for this domain. No spinner: callers running concurrently
+// would clobber the TTY; the worker's prefixed log line is the progress signal.
+func triggerCertGen(ctx context.Context, domain string, r dns.Resolver) error {
+	if err := getWithRetries(ctx, fmt.Sprintf("http://%v", domain), 5, newCertHTTPClient(r)); err != nil {
+		term.Debugf("Error triggering cert generation for %v: %v", domain, err)
 		return err
 	}
 	return nil
 }
 
-func waitForTLS(ctx context.Context, domain string, r dns.Resolver) error {
+// waitForTLSReady polls https://domain on a 3s ticker until the TLS handshake
+// succeeds or the 10-minute budget is exhausted. The outer ctx still bounds
+// the total wait.
+func waitForTLSReady(ctx context.Context, domain string, r dns.Resolver) error {
 	ticker := time.NewTicker(3 * time.Second)
 	defer ticker.Stop()
-	timeout, cancel := context.WithTimeout(ctx, 10*time.Minute)
+	deadline, cancel := context.WithTimeout(ctx, 10*time.Minute)
 	defer cancel()
-
-	doSpinner := term.StdoutCanColor() && term.IsTerminal()
-	if doSpinner {
-		term.HideCursor()
-		defer term.ShowCursor()
-
-		spin := spinner.New()
-		cancelSpinner := spin.Start(ctx)
-		defer cancelSpinner()
-	}
 	for {
 		select {
-		case <-timeout.Done():
-			return timeout.Err()
+		case <-deadline.Done():
+			return deadline.Err()
 		case <-ticker.C:
-			if err := cert.CheckTLSCert(timeout, domain, r); err == nil {
+			if err := cert.CheckTLSCert(deadline, domain, r); err == nil {
 				return nil
 			} else {
 				term.Debugf("Error checking TLS cert for %v: %v", domain, err)
@@ -245,72 +424,27 @@ func waitForTLS(ctx context.Context, domain string, r dns.Resolver) error {
 	}
 }
 
-func waitForCNAME(ctx context.Context, domain string, targets []string, client client.FabricClient) error {
-	for i, target := range targets {
-		targets[i] = dns.Normalize(target)
-	}
-
-	ticker := time.NewTicker(5 * time.Second)
-	defer ticker.Stop()
-
-	serverSideVerified := false
-	serverVerifyRpcFailure := 0
-	doSpinner := term.StdoutCanColor() && term.IsTerminal()
-	if doSpinner {
-		term.HideCursor()
-		defer term.ShowCursor()
-
-		spin := spinner.New()
-		cancelSpinner := spin.Start(ctx)
-		defer cancelSpinner()
-	}
-
-	verifyDNS := func() error {
-		if !serverSideVerified && serverVerifyRpcFailure < 3 {
-			if err := client.VerifyDNSSetup(ctx, &defangv1.VerifyDNSSetupRequest{Domain: domain, Targets: targets}); err == nil {
-				term.Debugf("Server side DNS verification for %v successful", domain)
-				serverSideVerified = true
-			} else {
-				if cerr := new(connect.Error); errors.As(err, &cerr) && cerr.Code() == connect.CodeFailedPrecondition {
-					term.Debugf("Server side DNS verification negative result: %v", cerr.Message())
-				} else {
-					term.Debugf("Server side DNS verification request for %v failed: %v", domain, err)
-					serverVerifyRpcFailure++
-				}
-			}
-			if serverVerifyRpcFailure >= 3 {
-				term.Warnf("Server side DNS verification for %v failed multiple times, skipping server side DNS verification.", domain)
-			}
+// maxDomainLen returns the longest domain across jobs, used to right-pad
+// per-domain log prefixes so columns line up. Returns 0 when there are no
+// jobs (callers handle that earlier, but be defensive).
+func maxDomainLen(jobs []domainJob) int {
+	n := 0
+	for _, j := range jobs {
+		if len(j.domain) > n {
+			n = len(j.domain)
 		}
-		if serverSideVerified || serverVerifyRpcFailure >= 3 {
-			locallyVerified := dns.CheckDomainDNSReady(ctx, domain, targets, dns.NewFabricResolverAt(client))
-			if serverSideVerified && !locallyVerified {
-				term.Warnf("DNS settings for %v are verified, but changes may take a few minutes to propagate due to caching.", domain)
-				return nil
-			}
-			if locallyVerified {
-				return nil
-			}
-		}
-		return errors.New("not verified")
 	}
+	return n
+}
 
-	if err := verifyDNS(); err == nil {
-		return nil
-	}
-	term.Infof("Configure a CNAME or ALIAS record for the domain name: %v", domain)
-	term.Printf("  %v  -> %v\n", domain, strings.Join(targets, " or "))
-	term.Infof("Awaiting DNS record setup and propagation... This may take a while.")
-
-	for {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-ticker.C:
-			if err := verifyDNS(); err == nil {
-				return nil
-			}
-		}
+// newDomainLogger returns a closure that prefixes every line with [domain]
+// padded to a fixed width so concurrent workers' output reads as a clean
+// stream of per-domain events. term.Infof writes one Fprintf per call, which
+// is goroutine-safe for our single-line events.
+func newDomainLogger(domain string, pad int) func(format string, args ...any) {
+	prefix := "[" + domain + "]" + strings.Repeat(" ", pad-len(domain)+1)
+	return func(format string, args ...any) {
+		term.Infof(prefix+format, args...)
 	}
 }
 

--- a/src/pkg/cli/cert.go
+++ b/src/pkg/cli/cert.go
@@ -33,6 +33,10 @@ type DNSResult struct {
 }
 
 var (
+	// dnsCacheMu guards dnsCache. Workers now run in parallel (see
+	// runACMEJobs), so newCertHTTPClient's DialContext closure — captured by
+	// every worker's HTTP client — can race on this map without it.
+	dnsCacheMu       sync.RWMutex
 	dnsCache         = make(map[string]DNSResult)
 	dnsCacheDuration = 1 * time.Minute
 
@@ -54,7 +58,9 @@ func newCertHTTPClient(r dns.Resolver) HTTPClient {
 				if err != nil {
 					return nil, err
 				}
+				dnsCacheMu.RLock()
 				cached, ok := dnsCache[host]
+				dnsCacheMu.RUnlock()
 				var ips []net.IPAddr
 				if ok && cached.Expiry.After(time.Now()) {
 					ips = cached.IPs
@@ -63,9 +69,13 @@ func newCertHTTPClient(r dns.Resolver) HTTPClient {
 					if err != nil {
 						return nil, err
 					}
-					// Keep 1min of dns cache to avoid spamming root dns servers
+					// Keep 1min of dns cache to avoid spamming root dns servers.
+					// A racing concurrent lookup may overwrite this entry with
+					// fresh data — that's fine; both writes are valid.
 					expiry := time.Now().Add(dnsCacheDuration)
+					dnsCacheMu.Lock()
 					dnsCache[host] = DNSResult{ips, expiry}
+					dnsCacheMu.Unlock()
 				}
 
 				dialer := &net.Dialer{}

--- a/src/pkg/cli/cert.go
+++ b/src/pkg/cli/cert.go
@@ -219,7 +219,9 @@ func runIssuerJobs(ctx context.Context, projectName string, jobs []domainJob, fa
 			return nil
 		})
 	}
-	_ = eg.Wait() // goroutines never return errors; collected via errs
+	if err := eg.Wait(); err != nil {
+		return err
+	}
 	if len(errs) > 0 {
 		return fmt.Errorf("certificate issuance failed for one or more domains; verify DNS records and retry `defang cert generate`: %w", errors.Join(errs...))
 	}
@@ -271,7 +273,9 @@ func runACMEJobs(ctx context.Context, jobs []domainJob, fab client.FabricClient)
 			return nil
 		})
 	}
-	_ = eg.Wait()
+	if err := eg.Wait(); err != nil {
+		return err
+	}
 	if len(errs) > 0 {
 		return fmt.Errorf("certificate issuance failed for one or more domains; verify DNS records and retry `defang cert generate`: %w", errors.Join(errs...))
 	}
@@ -285,12 +289,24 @@ func runACMEJobs(ctx context.Context, jobs []domainJob, fab client.FabricClient)
 // local DNS checks.
 func preflightDNS(ctx context.Context, jobs []domainJob, fab client.FabricClient) map[string]bool {
 	verified := make(map[string]bool, len(jobs))
+	var mu sync.Mutex
+	eg, gctx := errgroup.WithContext(ctx)
+	eg.SetLimit(maxCertWorkers)
 	for _, j := range jobs {
-		if err := fab.VerifyDNSSetup(ctx, &defangv1.VerifyDNSSetupRequest{Domain: j.domain, Targets: j.targets}); err == nil {
-			verified[j.domain] = true
-		} else {
-			term.Debugf("Pre-flight DNS verification for %v not yet ready: %v", j.domain, err)
-		}
+		job := j
+		eg.Go(func() error {
+			if err := fab.VerifyDNSSetup(gctx, &defangv1.VerifyDNSSetupRequest{Domain: job.domain, Targets: job.targets}); err == nil {
+				mu.Lock()
+				verified[job.domain] = true
+				mu.Unlock()
+			} else {
+				term.Debugf("Pre-flight DNS verification for %v not yet ready: %v", job.domain, err)
+			}
+			return nil
+		})
+	}
+	if err := eg.Wait(); err != nil {
+		return nil // ignore errors, this should never happen
 	}
 	return verified
 }
@@ -352,17 +368,21 @@ func waitForDNSVerified(ctx context.Context, domain string, targets []string, fa
 	propagationNoted := false
 
 	verify := func() bool {
-		if !serverSideVerified && serverVerifyRpcFailure < 3 {
+		if !serverSideVerified {
 			err := fab.VerifyDNSSetup(ctx, &defangv1.VerifyDNSSetupRequest{Domain: domain, Targets: targets})
 			switch {
 			case err == nil:
 				serverSideVerified = true
 			case isNegativeVerify(err):
-				// Server says "not yet" — don't count against the RPC budget.
+				// Server says "not yet" — it's authoritative, so keep polling it.
 				term.Debugf("Server side DNS verification for %v negative: %v", domain, err)
 			default:
+				// Transient RPC failure: keep re-probing the server on later
+				// ticks (a recovered fabric is picked up) but, once it has been
+				// unreachable enough times, fall back to local DNS below so a
+				// server outage doesn't block issuance indefinitely.
 				serverVerifyRpcFailure++
-				term.Debugf("Server side DNS verification request for %v failed (%d/3): %v", domain, serverVerifyRpcFailure, err)
+				term.Debugf("Server side DNS verification request for %v failed (%d): %v", domain, serverVerifyRpcFailure, err)
 			}
 		}
 		if serverSideVerified || serverVerifyRpcFailure >= 3 {

--- a/src/pkg/cli/cert_test.go
+++ b/src/pkg/cli/cert_test.go
@@ -13,12 +13,14 @@ import (
 	"slices"
 	"sort"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/DefangLabs/defang/src/pkg/cli/client"
 	"github.com/DefangLabs/defang/src/pkg/cli/compose"
 	"github.com/DefangLabs/defang/src/pkg/dns"
+	"github.com/DefangLabs/defang/src/pkg/term"
 	defangv1 "github.com/DefangLabs/defang/src/protos/io/defang/v1"
 	composetypes "github.com/compose-spec/compose-go/v2/types"
 )
@@ -241,27 +243,48 @@ func (m *mockCertProvider) GetServices(ctx context.Context, req *defangv1.GetSer
 
 type mockCertFabricClient struct {
 	client.MockFabricClient
+	mu             sync.Mutex
 	verifyDNSCalls int
 }
 
 func (m *mockCertFabricClient) VerifyDNSSetup(ctx context.Context, req *defangv1.VerifyDNSSetupRequest) error {
+	m.mu.Lock()
 	m.verifyDNSCalls++
+	m.mu.Unlock()
 	return nil // DNS verified successfully
+}
+
+func (m *mockCertFabricClient) calls() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.verifyDNSCalls
 }
 
 // mockCertIssuerProvider extends mockCertProvider with the CertIssuer
 // interface so GenerateLetsEncryptCert's `provider.(CertIssuer)` succeeds.
 // Captures every (project, service, hostname) tuple the SUT calls IssueCert
-// with, and lets the test inject an error per call.
+// with, and lets the test inject an error per call. The mutex makes the call
+// log safe under the new parallel-worker dispatch.
 type mockCertIssuerProvider struct {
 	mockCertProvider
+	mu        sync.Mutex
 	issueErr  error
 	issueCall []string
 }
 
 func (m *mockCertIssuerProvider) IssueCert(_ context.Context, projectName, serviceName, hostname string, _ func(string) dns.Resolver) error {
+	m.mu.Lock()
 	m.issueCall = append(m.issueCall, fmt.Sprintf("%s/%s/%s", projectName, serviceName, hostname))
+	m.mu.Unlock()
 	return m.issueErr
+}
+
+func (m *mockCertIssuerProvider) sortedCalls() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := slices.Clone(m.issueCall)
+	sort.Strings(out)
+	return out
 }
 
 func TestGenerateLetsEncryptCert(t *testing.T) {
@@ -337,7 +360,7 @@ func TestGenerateLetsEncryptCert(t *testing.T) {
 		}
 	})
 
-	t.Run("calls generateCert for UseAcmeCert service", func(t *testing.T) {
+	t.Run("calls ACME workflow for UseAcmeCert service", func(t *testing.T) {
 		fabricClient := &mockCertFabricClient{}
 		provider := &mockCertProvider{
 			services: &defangv1.GetServicesResponse{
@@ -364,15 +387,21 @@ func TestGenerateLetsEncryptCert(t *testing.T) {
 				},
 			},
 		}
-		// Use short timeout so generateCert doesn't block on TLS/HTTP waits
+		// Short ctx ensures we don't block on the real 10-minute waitForTLS.
+		// With preflight returning verified, the worker proceeds to the post-
+		// verification stages and the deadline trips during the propagation
+		// sleep — so the error is expected. The point of the test is that
+		// the preflight RPC actually ran (i.e. we reached the ACME path).
 		ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
 		defer cancel()
 		err := GenerateLetsEncryptCert(ctx, project, fabricClient, provider)
-		if err != nil {
-			t.Errorf("expected no error, got: %v", err)
+		if err == nil {
+			t.Error("expected deadline-related error from the short ctx, got nil")
+		} else if !strings.Contains(err.Error(), "example.com") {
+			t.Errorf("error should name the failing domain, got: %v", err)
 		}
-		if fabricClient.verifyDNSCalls == 0 {
-			t.Error("expected VerifyDNSSetup to be called (generateCert was reached)")
+		if fabricClient.calls() == 0 {
+			t.Error("expected VerifyDNSSetup to be called (ACME path was reached)")
 		}
 	})
 
@@ -411,14 +440,16 @@ func TestGenerateLetsEncryptCert(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected err: %v", err)
 		}
-		want := []string{"myproj/web/example.com", "myproj/web/alias.example.com"}
-		if !slices.Equal(provider.issueCall, want) {
-			t.Errorf("IssueCert calls = %v, want %v", provider.issueCall, want)
+		// Order-insensitive: workers run in parallel so the calls can land in
+		// either order. Set membership is what we care about.
+		want := []string{"myproj/web/alias.example.com", "myproj/web/example.com"}
+		if got := provider.sortedCalls(); !slices.Equal(got, want) {
+			t.Errorf("IssueCert calls = %v, want %v (any order)", got, want)
 		}
-		// Issuer path is short-circuited — the legacy generateCert codepath
-		// (which calls VerifyDNSSetup) must not run.
-		if fabricClient.verifyDNSCalls != 0 {
-			t.Errorf("VerifyDNSSetup should not be called when CertIssuer is used (got %d calls)", fabricClient.verifyDNSCalls)
+		// Issuer path is short-circuited — the ACME codepath (which calls
+		// VerifyDNSSetup) must not run.
+		if fabricClient.calls() != 0 {
+			t.Errorf("VerifyDNSSetup should not be called when CertIssuer is used (got %d calls)", fabricClient.calls())
 		}
 	})
 
@@ -457,6 +488,200 @@ func TestGenerateLetsEncryptCert(t *testing.T) {
 			t.Errorf("error %q should name the failing domain", err)
 		}
 	})
+}
+
+// preflightFabricClient lets a test program responses per-domain so we can
+// drive the preflight-bucketing logic without touching the network.
+type preflightFabricClient struct {
+	client.MockFabricClient
+	mu        sync.Mutex
+	responses map[string]error // domain -> err returned from VerifyDNSSetup
+	calls     []string         // captured domains, in call order
+}
+
+func (m *preflightFabricClient) VerifyDNSSetup(_ context.Context, req *defangv1.VerifyDNSSetupRequest) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.calls = append(m.calls, req.Domain)
+	if err, ok := m.responses[req.Domain]; ok {
+		return err
+	}
+	return nil
+}
+
+func TestPreflightDNS(t *testing.T) {
+	jobs := []domainJob{
+		{serviceName: "web", domain: "ok.example.com", targets: []string{"def-abc"}},
+		{serviceName: "web", domain: "bad.example.com", targets: []string{"def-abc"}},
+		{serviceName: "api", domain: "also-ok.example.com", targets: []string{"def-xyz"}},
+	}
+	fab := &preflightFabricClient{responses: map[string]error{
+		"bad.example.com": errors.New("not ready"),
+	}}
+
+	verified := preflightDNS(t.Context(), jobs, fab)
+
+	if !verified["ok.example.com"] || !verified["also-ok.example.com"] {
+		t.Errorf("expected ok and also-ok to be verified, got %v", verified)
+	}
+	if verified["bad.example.com"] {
+		t.Errorf("expected bad to not be verified, got %v", verified)
+	}
+	if got, want := len(fab.calls), len(jobs); got != want {
+		t.Errorf("VerifyDNSSetup calls = %d, want %d (once per job)", got, want)
+	}
+}
+
+func TestCollectDomainJobs(t *testing.T) {
+	tests := []struct {
+		name     string
+		services []*defangv1.ServiceInfo
+		project  *compose.Project
+		want     []string // domains, in order
+	}{
+		{
+			name: "skips UseAcmeCert=false",
+			services: []*defangv1.ServiceInfo{
+				{Service: &defangv1.Service{Name: "web"}, UseAcmeCert: false, Domainname: "skip.example.com"},
+			},
+			project: &compose.Project{Services: compose.Services{
+				"web": {Name: "web", DomainName: "skip.example.com"},
+			}},
+			want: nil,
+		},
+		{
+			name: "skips service not in project",
+			services: []*defangv1.ServiceInfo{
+				{Service: &defangv1.Service{Name: "ghost"}, UseAcmeCert: true, Domainname: "ghost.example.com"},
+			},
+			project: &compose.Project{Services: compose.Services{}},
+			want:    nil,
+		},
+		{
+			name: "skips when deployed Domainname is empty",
+			services: []*defangv1.ServiceInfo{
+				{Service: &defangv1.Service{Name: "web"}, UseAcmeCert: true, Domainname: ""},
+			},
+			project: &compose.Project{Services: compose.Services{
+				"web": {Name: "web", DomainName: "wishful.example.com"},
+			}},
+			want: nil,
+		},
+		{
+			name: "flattens primary domain plus default-network aliases",
+			services: []*defangv1.ServiceInfo{
+				{Service: &defangv1.Service{Name: "web"}, UseAcmeCert: true, Domainname: "web.example.com"},
+			},
+			project: &compose.Project{Services: compose.Services{
+				"web": {Name: "web", DomainName: "web.example.com", Networks: map[string]*composetypes.ServiceNetworkConfig{
+					"default": {Aliases: []string{"alt.example.com", "third.example.com"}},
+				}},
+			}},
+			want: []string{"web.example.com", "alt.example.com", "third.example.com"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			jobs := collectDomainJobs(tt.project, tt.services)
+			got := make([]string, len(jobs))
+			for i, j := range jobs {
+				got[i] = j.domain
+			}
+			if !slices.Equal(got, tt.want) {
+				t.Errorf("domains = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNewDomainLogger_PrefixAlignment(t *testing.T) {
+	stdout, _ := term.SetupTestTerm(t)
+
+	// Pad to the longest domain so columns line up across workers.
+	pad := len("longest.example.com")
+	short := newDomainLogger("a.example.com", pad)
+	long := newDomainLogger("longest.example.com", pad)
+	short("hello")
+	long("hello")
+
+	got := stripANSI(stdout.String())
+	// Each line should start with a bracketed domain followed by enough
+	// spaces that the message column lines up.
+	lines := strings.Split(strings.TrimRight(got, "\n"), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 output lines, got %d: %q", len(lines), got)
+	}
+	if !strings.HasPrefix(lines[0], " * [a.example.com]") {
+		t.Errorf("short line missing bracket prefix: %q", lines[0])
+	}
+	if !strings.HasPrefix(lines[1], " * [longest.example.com]") {
+		t.Errorf("long line missing bracket prefix: %q", lines[1])
+	}
+	// Find the "hello" column on both lines — they must match for alignment.
+	col0 := strings.Index(lines[0], "hello")
+	col1 := strings.Index(lines[1], "hello")
+	if col0 != col1 {
+		t.Errorf("message column not aligned: %d vs %d (%q / %q)", col0, col1, lines[0], lines[1])
+	}
+}
+
+// TestRunIssuerJobs_ParallelMultipleDomains exercises the parallel issuer
+// path: with N>1 jobs, IssueCert must be called for every job (set-equality)
+// and concurrency cap must not deadlock.
+func TestRunIssuerJobs_ParallelMultipleDomains(t *testing.T) {
+	provider := &mockCertIssuerProvider{
+		mockCertProvider: mockCertProvider{
+			services: &defangv1.GetServicesResponse{
+				Services: []*defangv1.ServiceInfo{
+					{Service: &defangv1.Service{Name: "web"}, UseAcmeCert: true, Domainname: "a.example.com"},
+					{Service: &defangv1.Service{Name: "api"}, UseAcmeCert: true, Domainname: "b.example.com"},
+					{Service: &defangv1.Service{Name: "admin"}, UseAcmeCert: true, Domainname: "c.example.com"},
+				},
+			},
+		},
+	}
+	project := &compose.Project{
+		Name: "multi",
+		Services: compose.Services{
+			"web":   {Name: "web", DomainName: "a.example.com"},
+			"api":   {Name: "api", DomainName: "b.example.com"},
+			"admin": {Name: "admin", DomainName: "c.example.com"},
+		},
+	}
+	if err := GenerateLetsEncryptCert(t.Context(), project, &mockCertFabricClient{}, provider); err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	want := []string{
+		"multi/admin/c.example.com",
+		"multi/api/b.example.com",
+		"multi/web/a.example.com",
+	}
+	if got := provider.sortedCalls(); !slices.Equal(got, want) {
+		t.Errorf("issued = %v, want %v (any order)", got, want)
+	}
+}
+
+// stripANSI removes the colour escape sequences that term.Infof prepends so
+// tests can assert on the post-formatting plain text. The escapes are simple
+// CSI sequences (ESC `[` … `m`) which is all we generate.
+func stripANSI(s string) string {
+	var b strings.Builder
+	for i := 0; i < len(s); {
+		if s[i] == 0x1b && i+1 < len(s) && s[i+1] == '[' {
+			j := i + 2
+			for j < len(s) && s[j] != 'm' {
+				j++
+			}
+			if j < len(s) {
+				i = j + 1
+				continue
+			}
+		}
+		b.WriteByte(s[i])
+		i++
+	}
+	return b.String()
 }
 
 func TestGetDomainTargets(t *testing.T) {

--- a/src/pkg/cli/cert_test.go
+++ b/src/pkg/cli/cert_test.go
@@ -231,6 +231,90 @@ func TestHttpClient(t *testing.T) {
 	}
 }
 
+// concurrentResolver is a thread-safe MockResolver replacement for the
+// dnsCache race test: each goroutine's transport calls LookupIPAddr, so the
+// resolver itself must not race either.
+type concurrentResolver struct {
+	mu    sync.Mutex
+	calls int
+}
+
+func (r *concurrentResolver) LookupIPAddr(_ context.Context, _ string) ([]net.IPAddr, error) {
+	r.mu.Lock()
+	r.calls++
+	r.mu.Unlock()
+	return []net.IPAddr{{IP: net.ParseIP("127.0.0.1")}}, nil
+}
+func (r *concurrentResolver) LookupCNAME(context.Context, string) (string, error) {
+	return "", nil
+}
+func (r *concurrentResolver) LookupNS(context.Context, string) ([]*net.NS, error) {
+	return nil, nil
+}
+func (r *concurrentResolver) LookupTXT(context.Context, string) ([]string, error) {
+	return nil, nil
+}
+
+// TestCertHTTPClient_DNSCacheConcurrent guards the parallel-cert-gen change:
+// newCertHTTPClient's DialContext closure reads/writes the package-level
+// dnsCache, and the orchestrator now drives multiple workers through
+// triggerCertGen concurrently. Without the mutex around dnsCache this test
+// fails under `-race` (concurrent map writes); with it, it passes cleanly.
+func TestCertHTTPClient_DNSCacheConcurrent(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, "ok")
+	}))
+	defer ts.Close()
+
+	_, port, err := net.SplitHostPort(strings.TrimPrefix(ts.URL, "http://"))
+	if err != nil {
+		t.Fatalf("split server addr: %v", err)
+	}
+
+	// Reset the package cache so this test sees its own writes, and restore
+	// it on exit so we don't leak state into TestHttpClient.
+	dnsCacheMu.Lock()
+	saved := dnsCache
+	dnsCache = make(map[string]DNSResult)
+	dnsCacheMu.Unlock()
+	t.Cleanup(func() {
+		dnsCacheMu.Lock()
+		dnsCache = saved
+		dnsCacheMu.Unlock()
+	})
+
+	// Use distinct hosts per goroutine so the DialContext does a cache miss
+	// → LookupIPAddr → cache write on every call, maximizing chances of
+	// catching a race on writes.
+	const N = 16
+	resolver := &concurrentResolver{}
+	tc := newCertHTTPClient(resolver)
+
+	var wg sync.WaitGroup
+	errs := make([]error, N)
+	for i := range N {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			url := fmt.Sprintf("http://host-%d.test:%s/", i, port)
+			req, _ := http.NewRequest("GET", url, nil)
+			resp, err := tc.Do(req)
+			if err != nil {
+				errs[i] = err
+				return
+			}
+			resp.Body.Close()
+		}(i)
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Errorf("goroutine %d: %v", i, err)
+		}
+	}
+}
+
 type mockCertProvider struct {
 	client.MockProvider
 	services *defangv1.GetServicesResponse


### PR DESCRIPTION
## Description
To speed up cert generation

## Checklist

- [x] I have performed a self-review of my code
- [X] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Certificate issuance is now per-domain and runs concurrently with bounded parallelism for faster, more reliable processing.
  * DNS preflight verifies domains up-front and prints a single grouped instruction block for any required DNS updates.
  * Clearer per-domain output, including warnings for domain mismatches and skipping services with empty domain values.
* **Bug Fixes**
  * Reduced race conditions by making DNS resolution/caching safe under concurrent certificate operations.
* **Tests**
  * Added/strengthened unit tests covering concurrent DNS-cache behavior, DNS preflight bucketing, domain job collection, logging alignment, and parallel issuer dispatch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->