### PR TITLE
Small stack UX fixes

### DIFF
--- a/src/pkg/cli/client/playground.go
+++ b/src/pkg/cli/client/playground.go
@@ -15,6 +15,8 @@ import (
 	defangv1 "github.com/DefangLabs/defang/src/protos/io/defang/v1"
 )
 
+var ErrNoPlaygroundProject = errors.New("no Playground projects found")
+
 type PlaygroundProvider struct {
 	FabricClient
 	RetryDelayer
@@ -157,8 +159,30 @@ func (g *PlaygroundProvider) SetUpCD(ctx context.Context, force bool) error {
 	return errors.New("this command is not valid for the Defang playground; did you forget --stack or --provider?")
 }
 
-func (g *PlaygroundProvider) CdList(context.Context, bool) (iter.Seq[byocState.Info], error) {
-	return nil, errors.New("this command is not valid for the Defang playground; did you forget --stack or --provider?")
+func (g *PlaygroundProvider) CdList(ctx context.Context, _ bool) (iter.Seq[byocState.Info], error) {
+	// CdList is used to check whether there are any active deployments for a stack.
+	// For Playground, we can just check if there are any services in the current project.
+	project, err := g.RemoteProjectName(ctx)
+	if err != nil {
+		// If there are no projects, return an empty list instead of an error
+		if !errors.Is(err, ErrNoPlaygroundProject) {
+			return nil, err
+		}
+	}
+	whoami, err := g.WhoAmI(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return func(yield func(byocState.Info) bool) {
+		if project != "" {
+			yield(byocState.Info{
+				Project:   project,
+				Stack:     g.GetStackName(),
+				Workspace: whoami.GetTenantId(),
+				CdRegion:  whoami.GetRegion(),
+			})
+		}
+	}, nil
 }
 
 func (g *PlaygroundProvider) ServicePrivateDNS(name string) string {
@@ -185,7 +209,7 @@ func (g *PlaygroundProvider) RemoteProjectName(ctx context.Context) (string, err
 		return "", err
 	}
 	if resp.Project == "" {
-		return "", errors.New("no Playground projects found")
+		return "", ErrNoPlaygroundProject
 	}
 	term.Debug("Using default Playground project: ", resp.Project)
 	return resp.Project, nil

--- a/src/pkg/cli/stacks.go
+++ b/src/pkg/cli/stacks.go
@@ -5,12 +5,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"slices"
 
 	"github.com/DefangLabs/defang/src/pkg/cli/client"
 	"github.com/DefangLabs/defang/src/pkg/cli/client/byoc/state"
 	"github.com/DefangLabs/defang/src/pkg/elicitations"
 	"github.com/DefangLabs/defang/src/pkg/stacks"
+	"github.com/DefangLabs/defang/src/pkg/term"
 	defangv1 "github.com/DefangLabs/defang/src/protos/io/defang/v1"
 )
 
@@ -76,7 +78,15 @@ func RemoveStack(ctx context.Context, client StacksRemover, provider client.Prov
 		return fmt.Errorf("failed to delete remote stack record: %w", err)
 	}
 
-	return stacks.RemoveInDirectory(".", name)
+	err := stacks.RemoveInDirectory(".", name)
+	if err != nil {
+		// If the file doesn't exist, consider it a success since the end state is the same (the stack file is gone)
+		if !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+		term.Warnf("local stack file could not be deleted: %s", err)
+	}
+	return nil
 }
 
 func stackHasActiveDeployment(ctx context.Context, provider client.Provider, projectName, name string) (bool, error) {

--- a/src/pkg/stacks/manager.go
+++ b/src/pkg/stacks/manager.go
@@ -169,11 +169,17 @@ func (e *ErrOutside) Error() string {
 func (sm *manager) Load(ctx context.Context, name string) (*Parameters, error) {
 	params, err := sm.LoadLocal(name)
 	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			term.Infof("stack file not found, attempting to import from previous deployments: %v", err)
-			return sm.GetRemote(ctx, name)
+		if !errors.Is(err, os.ErrNotExist) {
+			return nil, err
 		}
-		return nil, err
+		// Local stack file not found, attempting import from previous deployment
+		var err2 error
+		params, err2 = sm.GetRemote(ctx, name)
+		if err2 != nil {
+			// Error: could not load stack parameters: stack "beta" does not exist for project "foobar"; open .defang/beta: no such file or directory
+			return nil, fmt.Errorf("%w; %w", err2, err)
+		}
+		term.Info("Stack file imported from previous deployment")
 	}
 	return params, nil
 }


### PR DESCRIPTION
## Description

Mostly to make `defang stack rm` idempotent, eg. 2nd invocation is successful. I used this to delete all smoketest stacks from DefangLabs workspace. 

`defang stack rm` was also failing for Playground projects, because its implementation relied on `CdList` to check whether there were active deployments (any workspace) for a given stack, but `CdList` wasn't implemented in the playground provider. Current implementation only checks current workspace (playground is tenanted), but that's good enough.

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary

