### PR TITLE
feat(compose): update Docker Model Runner syntax support

### DIFF
--- a/src/pkg/cli/compose/fixup.go
+++ b/src/pkg/cli/compose/fixup.go
@@ -76,6 +76,7 @@ func FixupServices(ctx context.Context, provider client.Provider, project *compo
 			term.Warnf("service %q: service name is longer than 16 characters, you may run into issues with resource name length", svccfg.Name)
 		}
 
+		// beta docker compose model runner syntax
 		if svccfg.Provider != nil && svccfg.Provider.Type == "model" && svccfg.Image == "" && svccfg.Build == nil {
 			fixupModelProvider(&svccfg, project, accountInfo)
 		}
@@ -99,6 +100,7 @@ func FixupServices(ctx context.Context, provider client.Provider, project *compo
 		project.Services[svccfg.Name] = svccfg
 	}
 
+	// modern docker compose model runner syntax
 	for name, model := range project.Models {
 		model.Name = name // ensure the model has a name
 		svccfg := fixupModel(model, project, accountInfo)
@@ -368,15 +370,22 @@ func fixupIngressPorts(svccfg *composeTypes.ServiceConfig) {
 const modelProviderNetwork = "model_provider_private"
 
 func fixupModel(model composeTypes.ModelConfig, project *composeTypes.Project, info *client.AccountInfo) *composeTypes.ServiceConfig {
+	if model.ContextSize != 0 {
+		term.Warnf("model %q: context_size is a Docker Model Runner parameter and is not supported for cloud deployments", model.Name)
+	}
+	if len(model.RuntimeFlags) > 0 {
+		term.Warnf("model %q: runtime_flags is a Docker Model Runner parameter and is not supported for cloud deployments", model.Name)
+	}
 	svccfg := &composeTypes.ServiceConfig{
 		Name:       model.Name,
 		Extensions: model.Extensions,
 	}
-	makeAccessGatewayService(svccfg, project, model.Model, info) // TODO: pass other model options too
+	makeAccessGatewayService(svccfg, project, model.Model, info)
 	return svccfg
 }
 
 func fixupModelProvider(svccfg *composeTypes.ServiceConfig, project *composeTypes.Project, info *client.AccountInfo) {
+	term.Warnf("service %q: 'provider: type: model' is deprecated; use a top-level 'models:' entry instead", svccfg.Name)
 	var model string
 	if modelVals := svccfg.Provider.Options["model"]; len(modelVals) == 1 {
 		model = modelVals[0]

--- a/src/testdata/models/compose.yaml
+++ b/src/testdata/models/compose.yaml
@@ -13,6 +13,11 @@ services:
     models:
       my_model:
         endpoint_var: MODEL_URL
+  withmodelvar:
+    image: app
+    models:
+      ai_model:
+        model_var: MY_MODEL_NAME
 
 models:
   ai_model:

--- a/src/testdata/models/compose.yaml.fixup
+++ b/src/testdata/models/compose.yaml.fixup
@@ -114,5 +114,29 @@
       "default": null,
       "model_provider_private": null
     }
+  },
+  "withmodelvar": {
+    "command": null,
+    "depends_on": {
+      "ai_model": {
+        "condition": "service_started",
+        "required": true
+      }
+    },
+    "entrypoint": null,
+    "environment": {
+      "AI_MODEL_URL": "http://mock-ai-model:4000/v1/",
+      "MY_MODEL_NAME": "ai/model"
+    },
+    "image": "app",
+    "models": {
+      "ai_model": {
+        "model_var": "MY_MODEL_NAME"
+      }
+    },
+    "networks": {
+      "default": null,
+      "model_provider_private": null
+    }
   }
 }

--- a/src/testdata/models/compose.yaml.golden
+++ b/src/testdata/models/compose.yaml.golden
@@ -20,6 +20,13 @@ services:
         endpoint_var: MODEL_URL
     networks:
       default: null
+  withmodelvar:
+    image: app
+    models:
+      ai_model:
+        model_var: MY_MODEL_NAME
+    networks:
+      default: null
 networks:
   default:
     name: models_default

--- a/src/testdata/models/compose.yaml.warnings
+++ b/src/testdata/models/compose.yaml.warnings
@@ -1,3 +1,5 @@
+ ! model "my_model": context_size is a Docker Model Runner parameter and is not supported for cloud deployments
+ ! model "my_model": runtime_flags is a Docker Model Runner parameter and is not supported for cloud deployments
  ! service "ai_model": environment "LITELLM_MASTER_KEY" may contain sensitive information; consider using 'defang config set LITELLM_MASTER_KEY' to securely store this value
  ! service "ai_model": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors
  ! service "modellist": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors
@@ -5,3 +7,4 @@
  ! service "my_model": environment "LITELLM_MASTER_KEY" may contain sensitive information; consider using 'defang config set LITELLM_MASTER_KEY' to securely store this value
  ! service "my_model": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors
  ! service "withendpoint": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors
+ ! service "withmodelvar": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors

--- a/src/testdata/provider/compose.yaml.warnings
+++ b/src/testdata/provider/compose.yaml.warnings
@@ -1,3 +1,4 @@
+ ! service "ai_runner": 'provider: type: model' is deprecated; use a top-level 'models:' entry instead
  ! service "ai_runner": environment "LITELLM_MASTER_KEY" may contain sensitive information; consider using 'defang config set LITELLM_MASTER_KEY' to securely store this value
  ! service "ai_runner": missing memory reservation; using provider-specific defaults. Specify deploy.resources.reservations.memory to avoid out-of-memory errors
  ! service "chat": environment "OPENAI_API_KEY" may contain sensitive information; consider using 'defang config set OPENAI_API_KEY' to securely store this value


### PR DESCRIPTION
- Warn on `context_size` and `runtime_flags` in model definitions (Docker Model Runner-only parameters, not applicable to cloud deployments)
- Deprecate `provider: type: model` beta syntax with a warning pointing to the top-level `models:` form; behavior is preserved for compatibility
- Add `withmodelvar` fixture to cover the untested `model_var` override path in wireDependentServices

## Description

<!-- Concise description of what this PR is tackling. -->

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added warnings for unsupported model parameters (`context_size`, `runtime_flags`) in cloud deployments.
  * Added deprecation warning for legacy provider type syntax.

* **Refactor**
  * Streamlined model configuration handling by removing duplicated logic.
  * Improved model-related warning emission and access gateway service construction.

* **Tests**
  * Added test coverage for model variable-based configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->