### PR TITLE
Fix azure log query

### DIFF
--- a/src/cmd/cli/command/compose.go
+++ b/src/cmd/cli/command/compose.go
@@ -688,8 +688,8 @@ func handleLogsCmd(cmd *cobra.Command, args []string) error {
 		servicesWithBuild := make([]string, 0, len(services)*2)
 		for _, service := range services {
 			servicesWithBuild = append(servicesWithBuild, service)
-			if !strings.HasSuffix(service, "-image") {
-				servicesWithBuild = append(servicesWithBuild, service+"-image")
+			if !strings.HasSuffix(service, logs.BuildServiceNameSuffix) {
+				servicesWithBuild = append(servicesWithBuild, service+logs.BuildServiceNameSuffix)
 			}
 		}
 		services = servicesWithBuild

--- a/src/pkg/cli/client/byoc/azure/byoc.go
+++ b/src/pkg/cli/client/byoc/azure/byoc.go
@@ -946,7 +946,9 @@ func (b *ByocAzure) QueryLogs(ctx context.Context, req *defangv1.TailRequest) (i
 					continue
 				}
 				if svc.Err != nil {
-					term.Debugf("Container Apps log error for %q: %v", svc.AppName, svc.Err)
+					// Non-fatal: warn (so the failure isn't silently swallowed) but keep
+					// reading the other sources rather than ending the whole tail.
+					term.Warnf("Could not read service logs for %q: %v", svc.AppName, svc.Err)
 					continue
 				}
 				if !yield(&defangv1.TailResponse{
@@ -967,7 +969,8 @@ func (b *ByocAzure) QueryLogs(ctx context.Context, req *defangv1.TailRequest) (i
 					continue
 				}
 				if build.Err != nil {
-					term.Debugf("ACR build log error for %q: %v", build.Service, build.Err)
+					// Non-fatal: warn but keep reading the other sources (see above).
+					term.Warnf("Could not read build logs for %q: %v", build.Service, build.Err)
 					continue
 				}
 				if !yield(&defangv1.TailResponse{

--- a/src/pkg/cli/client/byoc/azure/byoc.go
+++ b/src/pkg/cli/client/byoc/azure/byoc.go
@@ -270,9 +270,10 @@ func (b *ByocAzure) syncJobToCdLocation() {
 }
 
 // projectResourceGroupName returns the resource group name for project-specific resources
-// (App Configuration store and deployed services).
-// Format: defang-{project}-{stack}-{location}, e.g. "defang-myapp-test-westus2".
-// This group is owned by one project+stack and is separate from the shared CD resource group.
+// (Key Vault config store and deployed services). It must match what the Pulumi Azure
+// program creates: {Prefix}-{project}-{stack}, e.g. "Defang-portal-production" for the
+// bare project name "portal" on stack "production". This group is separate from the
+// shared CD resource group.
 func (b *ByocAzure) projectResourceGroupName(projectName string) string {
 	return b.Prefix + "-" + projectName + "-" + b.PulumiStack
 }
@@ -462,7 +463,7 @@ func (b *ByocAzure) runCdCommand(ctx context.Context, cmd cdCommand) (string, er
 		return "", err
 	}
 	if cmd.etag != "" {
-		env["ETAG"] = cmd.etag
+		env[aca.EnvVarEtag] = cmd.etag
 	}
 	env["DEFANG_MODE"] = strings.ToLower(cmd.mode.String())
 
@@ -792,154 +793,200 @@ func (b *ByocAzure) PutConfig(ctx context.Context, req *defangv1.PutConfigReques
 	return nil
 }
 
-// QueryLogs implements client.Provider.
-// Only CD container logs are supported; service logs are not yet implemented.
+// QueryLogs implements client.Provider. It merges three log sources for the project:
+// CD (deployment) logs from the Container Apps Job, service logs from the project's
+// Container Apps, and build logs from ACR. When req.Follow is set each source streams
+// live; otherwise each returns a one-shot snapshot and the iterator ends once all are
+// drained.
 func (b *ByocAzure) QueryLogs(ctx context.Context, req *defangv1.TailRequest) (iter.Seq2[*defangv1.TailResponse, error], error) {
-	// Match the request etag to the stored CD etag so we tail the correct run.
-	if b.cdRunID == "" || (req.Etag != "" && req.Etag != b.cdEtag) {
-		return nil, fmt.Errorf("QueryLogs: no matching CD deployment for etag %q", req.Etag)
+	const cdServiceName = "defang-cd"
+
+	// setUpLocation resolves AZURE_LOCATION/AZURE_SUBSCRIPTION_ID onto the driver and
+	// job (no API calls). The service and build watchers below use b.driver.Azure, so
+	// this must run even when there's no etag to look up a CD run by.
+	if err := b.setUpLocation(); err != nil {
+		return nil, err
 	}
 
-	const cdServiceName = "defang-cd"
+	// Resolve the CD job execution for this request. The deploying process caches
+	// the run ID in memory; a standalone `defang logs` has none, so recover it by
+	// matching the request etag against each execution's recorded ETAG env var.
+	runID := b.cdRunID
 	etag := b.cdEtag
+	if req.Etag != "" && req.Etag != b.cdEtag {
+		runID, etag = "", req.Etag
+	}
+	if runID == "" && etag != "" {
+		found, err := b.job.FindExecutionByEtag(ctx, etag)
+		if err != nil {
+			return nil, fmt.Errorf("failed to find CD deployment for etag %q: %w", etag, err)
+		}
+		runID = found
+	}
+	if runID == "" {
+		// Unknown or empty etag: no CD run to tail. Service and build logs are keyed
+		// by resource group rather than the CD execution, so still surface those.
+		term.Warnf("No CD logs found for etag %q; showing service and build logs only", req.Etag)
+	}
 
-	if req.Follow {
-		logIter, err := b.job.TailJobLogs(ctx, b.cdRunID)
+	// CD logs. cdCh stays nil when there's no CD run, which makes the select below skip
+	// it and treat the CD source as already drained. Follow streams line-by-line; the
+	// snapshot reads the whole buffered run content once.
+	type cdLogEntry struct {
+		line string
+		err  error
+	}
+	var cdCh chan cdLogEntry
+	if runID != "" {
+		cdCh = make(chan cdLogEntry)
+		if req.Follow {
+			logIter, err := b.job.TailJobLogs(ctx, runID)
+			if err != nil {
+				return nil, err
+			}
+			go func() {
+				defer close(cdCh)
+				for line, err := range logIter {
+					select {
+					case cdCh <- cdLogEntry{line: line, err: err}:
+					case <-ctx.Done():
+						return
+					}
+				}
+			}()
+		} else {
+			content, err := b.job.ReadJobLogs(ctx, runID)
+			if err != nil {
+				return nil, err
+			}
+			go func() {
+				defer close(cdCh)
+				if content == "" {
+					return
+				}
+				select {
+				case cdCh <- cdLogEntry{line: content}:
+				case <-ctx.Done():
+				}
+			}()
+		}
+	}
+
+	projectRG := b.projectResourceGroupName(req.Project)
+
+	// Service logs from the project's Container Apps and build logs from ACR both
+	// live in the PROJECT resource group (independent of the CD run). For a one-shot
+	// query, if that group doesn't exist the project isn't deployed under this
+	// name/stack — surface one clear message instead of letting both watchers fail
+	// with raw "ResourceGroupNotFound" errors. In follow mode we skip the check: the
+	// group may be created mid-session (deploy-then-tail), so the watchers poll for it.
+	var acaCh <-chan aca.ServiceLogEntry
+	var buildCh <-chan acr.BuildLogEntry
+	startWatchers := true
+	if !req.Follow {
+		exists, err := b.driver.ResourceGroupExists(ctx, projectRG)
 		if err != nil {
 			return nil, err
 		}
-
-		// Run ACR log iterator in a goroutine so we can select over it and ACA logs.
-		type cdLogEntry struct {
-			line string
-			err  error
+		if !exists {
+			term.Warnf("No deployed services found for project %q on stack %q (resource group %q not found)", req.Project, b.PulumiStack, projectRG)
+			startWatchers = false
 		}
-		cdCh := make(chan cdLogEntry)
-		go func() {
-			defer close(cdCh)
-			for line, err := range logIter {
-				select {
-				case cdCh <- cdLogEntry{line: line, err: err}:
-				case <-ctx.Done():
-					return
-				}
-			}
-		}()
-
-		projectRG := b.projectResourceGroupName(req.Project)
-
-		// Watch Container App logs from the PROJECT resource group.
+	}
+	if startWatchers {
 		acaClient := &aca.ContainerApp{
 			Azure:         b.driver.Azure,
 			ResourceGroup: projectRG,
 		}
-		acaCh := acaClient.WatchLogs(ctx)
+		acaCh = acaClient.WatchLogs(ctx, req.Follow)
 
-		// Watch ACR build logs from the PROJECT resource group.
 		buildWatcher := &acr.BuildLogWatcher{
 			Azure:         b.driver.Azure,
 			ResourceGroup: projectRG,
 		}
-		buildCh := buildWatcher.WatchBuildLogs(ctx)
-
-		return func(yield func(*defangv1.TailResponse, error) bool) {
-			for {
-				select {
-				case entry, ok := <-cdCh:
-					if !ok {
-						cdCh = nil
-						continue
-					}
-					if entry.err != nil {
-						if !yield(nil, entry.err) {
-							return
-						}
-						continue
-					}
-					if !yield(&defangv1.TailResponse{
-						Entries: []*defangv1.LogEntry{{
-							Message:   entry.line,
-							Service:   cdServiceName,
-							Etag:      etag,
-							Timestamp: timestamppb.Now(),
-						}},
-						Service: cdServiceName,
-						Etag:    etag,
-					}, nil) {
-						return
-					}
-				case svc, ok := <-acaCh:
-					if !ok {
-						acaCh = nil
-						continue
-					}
-					if svc.Err != nil {
-						term.Debugf("Container Apps log error for %q: %v", svc.AppName, svc.Err)
-						continue
-					}
-					if !yield(&defangv1.TailResponse{
-						Entries: []*defangv1.LogEntry{{
-							Message:   svc.Message,
-							Service:   svc.AppName,
-							Etag:      etag,
-							Timestamp: timestamppb.Now(),
-						}},
-						Service: svc.AppName,
-						Etag:    etag,
-					}, nil) {
-						return
-					}
-				case build, ok := <-buildCh:
-					if !ok {
-						buildCh = nil
-						continue
-					}
-					if build.Err != nil {
-						term.Debugf("ACR build log error for %q: %v", build.Service, build.Err)
-						continue
-					}
-					if !yield(&defangv1.TailResponse{
-						Entries: []*defangv1.LogEntry{{
-							Message:   build.Line,
-							Service:   build.Service + "-build",
-							Etag:      etag,
-							Stderr:    true, // show build logs even when not verbose
-							Timestamp: timestamppb.Now(),
-						}},
-						Service: build.Service + "-build",
-						Etag:    etag,
-					}, nil) {
-						return
-					}
-				case <-ctx.Done():
-					return
-				}
-				if cdCh == nil && acaCh == nil && buildCh == nil {
-					return
-				}
-			}
-		}, nil
+		buildCh = buildWatcher.WatchBuildLogs(ctx, req.Follow)
 	}
 
-	// Non-follow: return a snapshot of current log content.
-	content, err := b.job.ReadJobLogs(ctx, b.cdRunID)
-	if err != nil {
-		return nil, err
-	}
 	return func(yield func(*defangv1.TailResponse, error) bool) {
-		if content == "" {
-			return
+		for {
+			// Check for completion at the top: a closed source is set to nil below, and
+			// selecting over all-nil channels would block forever (the non-follow case
+			// where every source drains). In follow mode the channels stay open until
+			// ctx is cancelled.
+			if cdCh == nil && acaCh == nil && buildCh == nil {
+				return
+			}
+			select {
+			case entry, ok := <-cdCh:
+				if !ok {
+					cdCh = nil
+					continue
+				}
+				if entry.err != nil {
+					if !yield(nil, entry.err) {
+						return
+					}
+					continue
+				}
+				if !yield(&defangv1.TailResponse{
+					Entries: []*defangv1.LogEntry{{
+						Message:   entry.line,
+						Service:   cdServiceName,
+						Etag:      etag,
+						Timestamp: timestamppb.Now(),
+					}},
+					Service: cdServiceName,
+					Etag:    etag,
+				}, nil) {
+					return
+				}
+			case svc, ok := <-acaCh:
+				if !ok {
+					acaCh = nil
+					continue
+				}
+				if svc.Err != nil {
+					term.Debugf("Container Apps log error for %q: %v", svc.AppName, svc.Err)
+					continue
+				}
+				if !yield(&defangv1.TailResponse{
+					Entries: []*defangv1.LogEntry{{
+						Message:   svc.Message,
+						Service:   svc.AppName,
+						Etag:      etag,
+						Timestamp: timestamppb.Now(),
+					}},
+					Service: svc.AppName,
+					Etag:    etag,
+				}, nil) {
+					return
+				}
+			case build, ok := <-buildCh:
+				if !ok {
+					buildCh = nil
+					continue
+				}
+				if build.Err != nil {
+					term.Debugf("ACR build log error for %q: %v", build.Service, build.Err)
+					continue
+				}
+				if !yield(&defangv1.TailResponse{
+					Entries: []*defangv1.LogEntry{{
+						Message:   build.Line,
+						Service:   build.Service + "-build",
+						Etag:      etag,
+						Stderr:    true, // show build logs even when not verbose
+						Timestamp: timestamppb.Now(),
+					}},
+					Service: build.Service + "-build",
+					Etag:    etag,
+				}, nil) {
+					return
+				}
+			case <-ctx.Done():
+				return
+			}
 		}
-		yield(&defangv1.TailResponse{
-			Entries: []*defangv1.LogEntry{{
-				Message:   content,
-				Service:   cdServiceName,
-				Etag:      etag,
-				Timestamp: timestamppb.Now(),
-			}},
-			Service: cdServiceName,
-			Etag:    etag,
-		}, nil)
 	}, nil
 }
 

--- a/src/pkg/cli/client/byoc/azure/byoc_test.go
+++ b/src/pkg/cli/client/byoc/azure/byoc_test.go
@@ -3,6 +3,7 @@ package azure
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -267,8 +268,8 @@ func TestQueryLogsDiscoversRunByEtag(t *testing.T) {
 	ctx, cancel := context.WithTimeout(t.Context(), 3*time.Second)
 	defer cancel()
 	_, err := b.QueryLogs(ctx, &defangv1.TailRequest{Etag: "some-etag"})
-	if err == nil {
-		t.Error("QueryLogs should surface the lookup error when the run can't be discovered")
+	if err == nil || !strings.Contains(err.Error(), "failed to find CD deployment for etag") {
+		t.Errorf("expected etag-lookup failure, got: %v", err)
 	}
 }
 
@@ -282,8 +283,8 @@ func TestQueryLogsEtagMismatchTriggersLookup(t *testing.T) {
 	ctx, cancel := context.WithTimeout(t.Context(), 3*time.Second)
 	defer cancel()
 	_, err := b.QueryLogs(ctx, &defangv1.TailRequest{Etag: "etag-B"})
-	if err == nil {
-		t.Error("QueryLogs should look up the mismatched etag and surface the lookup error")
+	if err == nil || !strings.Contains(err.Error(), "failed to find CD deployment for etag") {
+		t.Errorf("expected mismatched-etag lookup failure, got: %v", err)
 	}
 }
 

--- a/src/pkg/cli/client/byoc/azure/byoc_test.go
+++ b/src/pkg/cli/client/byoc/azure/byoc_test.go
@@ -86,6 +86,8 @@ func TestProjectResourceGroupName(t *testing.T) {
 	if err := b.setUpLocation(); err != nil {
 		t.Fatalf("setUpLocation: %v", err)
 	}
+	// The RG must match what Pulumi creates: {Prefix}-{project}-{stack}, using the bare
+	// project name (the stack is a separate axis, not baked into the project name).
 	got := b.projectResourceGroupName("myapp")
 	want := "Defang-myapp-test-stack"
 	if got != want {
@@ -256,23 +258,32 @@ func TestGetProjectUpdateCredError(t *testing.T) {
 	}
 }
 
-func TestQueryLogsUnknownEtag(t *testing.T) {
+func TestQueryLogsDiscoversRunByEtag(t *testing.T) {
+	// A standalone `defang logs` has no cached cdRunID, so QueryLogs must look the
+	// CD run up by etag. When that lookup can't reach Azure it surfaces the error
+	// (rather than the old "no matching CD deployment" rejection).
+	useFakeCred(t, "", errors.New("denied"))
 	b := newTestProvider(t, cloudazure.LocationEastUS, "sub")
-	// cdRunID is empty — QueryLogs should reject the request rather than panic.
-	_, err := b.QueryLogs(t.Context(), &defangv1.TailRequest{Etag: "some-etag"})
+	ctx, cancel := context.WithTimeout(t.Context(), 3*time.Second)
+	defer cancel()
+	_, err := b.QueryLogs(ctx, &defangv1.TailRequest{Etag: "some-etag"})
 	if err == nil {
-		t.Error("QueryLogs should reject when cdRunID is empty")
+		t.Error("QueryLogs should surface the lookup error when the run can't be discovered")
 	}
-	var _ = errors.New // silence unused when build tag trims
 }
 
-func TestQueryLogsEtagMismatch(t *testing.T) {
+func TestQueryLogsEtagMismatchTriggersLookup(t *testing.T) {
+	// A request etag that differs from the cached run no longer rejects outright;
+	// it falls back to discovering the matching run by etag.
+	useFakeCred(t, "", errors.New("denied"))
 	b := newTestProvider(t, cloudazure.LocationEastUS, "sub")
 	b.cdRunID = "run-1"
 	b.cdEtag = "etag-A"
-	_, err := b.QueryLogs(t.Context(), &defangv1.TailRequest{Etag: "etag-B"})
+	ctx, cancel := context.WithTimeout(t.Context(), 3*time.Second)
+	defer cancel()
+	_, err := b.QueryLogs(ctx, &defangv1.TailRequest{Etag: "etag-B"})
 	if err == nil {
-		t.Error("QueryLogs should reject etag mismatch")
+		t.Error("QueryLogs should look up the mismatched etag and surface the lookup error")
 	}
 }
 

--- a/src/pkg/cli/tail.go
+++ b/src/pkg/cli/tail.go
@@ -156,26 +156,45 @@ func Tail(ctx context.Context, provider client.Provider, projectName string, opt
 	}
 
 	if len(options.Services) > 0 {
+		// Cache lookups so "web" and its build alias "web-image" (which both resolve
+		// to "web") aren't queried or warned about twice. A non-NotFound error isn't
+		// proof of absence, so it's surfaced but treated as "present".
 		checked := make(map[string]bool, len(options.Services))
-		for _, service := range options.Services {
-			// A "<service>-image" entry refers to the build logs of "<service>",
-			// not a separate service, so validate (and de-dupe on) the base name —
-			// otherwise requesting build logs warns about a non-existent service.
-			name := strings.TrimSuffix(service, logs.BuildServiceNameSuffix)
-			if checked[name] {
-				continue
+		serviceExists := func(name string) bool {
+			if present, ok := checked[name]; ok {
+				return present
 			}
-			checked[name] = true
-			// Show a warning if the service doesn't exist (yet); TODO: could do fuzzy matching and suggest alternatives
+			present := true
 			if _, err := provider.GetService(ctx, &defangv1.GetRequest{Project: projectName, Name: name}); err != nil {
 				switch connect.CodeOf(err) {
 				case connect.CodeNotFound:
-					term.Warnf("Service does not exist (yet): %q", name)
+					present = false
 				case connect.CodeUnknown:
 					// Ignore unknown (nil) errors
 				default:
 					term.Warn(err) // TODO: use client.PrettyError(…)
 				}
+			}
+			checked[name] = present
+			return present
+		}
+		warned := make(map[string]bool)
+		for _, service := range options.Services {
+			// Validate the exact name first; only on a miss do we treat a
+			// "<service>-image" entry as the build logs of "<service>" and check the
+			// base name. Checking the literal name first avoids mis-warning when a
+			// real service happens to be named with the "-image" suffix.
+			if serviceExists(service) {
+				continue
+			}
+			name := strings.TrimSuffix(service, logs.BuildServiceNameSuffix)
+			if name != service && serviceExists(name) {
+				continue
+			}
+			// Show a warning if the service doesn't exist (yet); TODO: could do fuzzy matching and suggest alternatives
+			if !warned[name] {
+				warned[name] = true
+				term.Warnf("Service does not exist (yet): %q", name)
 			}
 		}
 	}

--- a/src/pkg/cli/tail.go
+++ b/src/pkg/cli/tail.go
@@ -156,12 +156,21 @@ func Tail(ctx context.Context, provider client.Provider, projectName string, opt
 	}
 
 	if len(options.Services) > 0 {
+		checked := make(map[string]bool, len(options.Services))
 		for _, service := range options.Services {
+			// A "<service>-image" entry refers to the build logs of "<service>",
+			// not a separate service, so validate (and de-dupe on) the base name —
+			// otherwise requesting build logs warns about a non-existent service.
+			name := strings.TrimSuffix(service, logs.BuildServiceNameSuffix)
+			if checked[name] {
+				continue
+			}
+			checked[name] = true
 			// Show a warning if the service doesn't exist (yet); TODO: could do fuzzy matching and suggest alternatives
-			if _, err := provider.GetService(ctx, &defangv1.GetRequest{Project: projectName, Name: service}); err != nil {
+			if _, err := provider.GetService(ctx, &defangv1.GetRequest{Project: projectName, Name: name}); err != nil {
 				switch connect.CodeOf(err) {
 				case connect.CodeNotFound:
-					term.Warnf("Service does not exist (yet): %q", service)
+					term.Warnf("Service does not exist (yet): %q", name)
 				case connect.CodeUnknown:
 					// Ignore unknown (nil) errors
 				default:

--- a/src/pkg/cli/tail_test.go
+++ b/src/pkg/cli/tail_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"io"
 	"os"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -17,6 +18,7 @@ import (
 	"connectrpc.com/connect"
 	"github.com/DefangLabs/defang/src/pkg/cli/client"
 	awscodebuild "github.com/DefangLabs/defang/src/pkg/clouds/aws/codebuild"
+	"github.com/DefangLabs/defang/src/pkg/dryrun"
 	"github.com/DefangLabs/defang/src/pkg/logs"
 	"github.com/DefangLabs/defang/src/pkg/term"
 	defangv1 "github.com/DefangLabs/defang/src/protos/io/defang/v1"
@@ -86,11 +88,24 @@ type mockTailProvider struct {
 	client.Provider
 	Iters []iter.Seq2[*defangv1.TailResponse, error]
 	Reqs  []*defangv1.TailRequest
+
+	// existingServices, when non-nil, makes GetService return the named services
+	// and NotFound for anything else; getServiceCalls records each requested name.
+	existingServices map[string]bool
+	getServiceCalls  []string
 }
 
 func (mockTailProvider) DelayBeforeRetry(ctx context.Context) error {
 	// No delay for mock
 	return ctx.Err()
+}
+
+func (m *mockTailProvider) GetService(_ context.Context, req *defangv1.GetRequest) (*defangv1.ServiceInfo, error) {
+	m.getServiceCalls = append(m.getServiceCalls, req.Name)
+	if m.existingServices[req.Name] {
+		return &defangv1.ServiceInfo{Service: &defangv1.Service{Name: req.Name}}, nil
+	}
+	return nil, connect.NewError(connect.CodeNotFound, errors.New("not found"))
 }
 
 func (m *mockTailProvider) QueryLogs(ctx context.Context, req *defangv1.TailRequest) (iter.Seq2[*defangv1.TailResponse, error], error) {
@@ -219,6 +234,47 @@ func TestTail(t *testing.T) {
 	}
 	if p.Reqs[1].Since == nil {
 		t.Errorf("Tail() sent request with since nil, want not nil")
+	}
+}
+
+func TestTailBuildImageServiceValidation(t *testing.T) {
+	stdout, _, cleanup := setupTestTerminal()
+	t.Cleanup(cleanup)
+
+	// Short-circuit Tail right after the service validation so we only exercise it.
+	dryrun.DoDryRun = true
+	t.Cleanup(func() { dryrun.DoDryRun = false })
+
+	p := &mockTailProvider{existingServices: map[string]bool{"web": true}}
+
+	// Build logs are requested as "<service>-image"; the deployed service is "web".
+	err := Tail(t.Context(), p, "project1", TailOptions{Services: []string{"web", "web-image"}})
+	if err != dryrun.ErrDryRun {
+		t.Fatalf("Tail() error = %v, want ErrDryRun", err)
+	}
+
+	// "web-image" must validate against the base service "web", and the duplicate
+	// base name must be checked only once.
+	if want := []string{"web"}; !slices.Equal(p.getServiceCalls, want) {
+		t.Errorf("GetService called with %v, want %v", p.getServiceCalls, want)
+	}
+	if s := term.StripAnsi(stdout.String()); strings.Contains(s, "does not exist") {
+		t.Errorf("unexpected does-not-exist warning for build logs: %q", s)
+	}
+}
+
+func TestTailMissingServiceWarns(t *testing.T) {
+	stdout, _, cleanup := setupTestTerminal()
+	t.Cleanup(cleanup)
+	dryrun.DoDryRun = true
+	t.Cleanup(func() { dryrun.DoDryRun = false })
+
+	p := &mockTailProvider{existingServices: map[string]bool{"web": true}}
+	if err := Tail(t.Context(), p, "project1", TailOptions{Services: []string{"nope"}}); err != dryrun.ErrDryRun {
+		t.Fatalf("Tail() error = %v, want ErrDryRun", err)
+	}
+	if s := term.StripAnsi(stdout.String()); !strings.Contains(s, `Service does not exist (yet): "nope"`) {
+		t.Errorf("expected does-not-exist warning, got %q", s)
 	}
 }
 

--- a/src/pkg/cli/tail_test.go
+++ b/src/pkg/cli/tail_test.go
@@ -253,13 +253,33 @@ func TestTailBuildImageServiceValidation(t *testing.T) {
 		t.Fatalf("Tail() error = %v, want ErrDryRun", err)
 	}
 
-	// "web-image" must validate against the base service "web", and the duplicate
-	// base name must be checked only once.
-	if want := []string{"web"}; !slices.Equal(p.getServiceCalls, want) {
+	// "web-image" is checked literally first (a miss), then falls back to the base
+	// "web" (cached from the earlier lookup) — so no spurious does-not-exist warning.
+	if want := []string{"web", "web-image"}; !slices.Equal(p.getServiceCalls, want) {
 		t.Errorf("GetService called with %v, want %v", p.getServiceCalls, want)
 	}
 	if s := term.StripAnsi(stdout.String()); strings.Contains(s, "does not exist") {
 		t.Errorf("unexpected does-not-exist warning for build logs: %q", s)
+	}
+}
+
+func TestTailRealImageSuffixServiceNotMisWarned(t *testing.T) {
+	stdout, _, cleanup := setupTestTerminal()
+	t.Cleanup(cleanup)
+	dryrun.DoDryRun = true
+	t.Cleanup(func() { dryrun.DoDryRun = false })
+
+	// A service genuinely named "foo-image" exists; the base "foo" does not. The
+	// literal name must validate so we don't mis-warn or strip it to "foo".
+	p := &mockTailProvider{existingServices: map[string]bool{"foo-image": true}}
+	if err := Tail(t.Context(), p, "project1", TailOptions{Services: []string{"foo-image"}}); err != dryrun.ErrDryRun {
+		t.Fatalf("Tail() error = %v, want ErrDryRun", err)
+	}
+	if want := []string{"foo-image"}; !slices.Equal(p.getServiceCalls, want) {
+		t.Errorf("GetService called with %v, want %v", p.getServiceCalls, want)
+	}
+	if s := term.StripAnsi(stdout.String()); strings.Contains(s, "does not exist") {
+		t.Errorf("unexpected does-not-exist warning for real -image service: %q", s)
 	}
 }
 

--- a/src/pkg/clouds/azure/aca/job.go
+++ b/src/pkg/clouds/azure/aca/job.go
@@ -576,7 +576,7 @@ func (j *Job) FindExecutionByEtag(ctx context.Context, etag string) (string, err
 			return "", fmt.Errorf("failed to list job executions: %w", err)
 		}
 		for _, exec := range page.Value {
-			if exec.Name == nil || exec.Properties == nil || !templateHasEtag(exec.Properties.Template, etag) {
+			if exec == nil || exec.Name == nil || exec.Properties == nil || !templateHasEtag(exec.Properties.Template, etag) {
 				continue
 			}
 			// Retries reuse the etag, so prefer the most recently started run.
@@ -599,7 +599,13 @@ func templateHasEtag(tmpl *armappcontainersv3.JobExecutionTemplate, etag string)
 		return false
 	}
 	for _, c := range tmpl.Containers {
+		if c == nil {
+			continue
+		}
 		for _, e := range c.Env {
+			if e == nil {
+				continue
+			}
 			if e.Name != nil && *e.Name == EnvVarEtag && e.Value != nil && *e.Value == etag {
 				return true
 			}

--- a/src/pkg/clouds/azure/aca/job.go
+++ b/src/pkg/clouds/azure/aca/job.go
@@ -28,6 +28,9 @@ const (
 	cdJobName          = "defang-cd"
 	cdEnvironmentName  = "defang-cd"
 	cdLogWorkspaceName = "defang-cd"
+	// EnvVarEtag is the environment variable the CD execution is launched with so
+	// its run can later be matched back to a deployment etag (see FindExecutionByEtag).
+	EnvVarEtag         = "ETAG"
 	jobLogPollInterval = 3 * time.Second
 	// jobAPIVersion is required for job getAuthToken / executions/replicas which
 	// are not yet exposed in the stable SDK or the 2023-05-01 API version.
@@ -550,6 +553,59 @@ func (j *Job) GetJobExecutionStatus(ctx context.Context, executionName string) (
 		}
 	}
 	return nil, fmt.Errorf("execution %q not found", executionName)
+}
+
+// FindExecutionByEtag returns the name of the most recent CD job execution whose
+// EnvVarEtag environment variable matches the given etag, or "" (no error) when
+// none match. This lets a fresh process (e.g. a standalone `defang logs`) recover
+// the CD run without the in-memory run ID that only the deploying process holds.
+func (j *Job) FindExecutionByEtag(ctx context.Context, etag string) (string, error) {
+	execClient, err := j.newJobsExecutionsClient()
+	if err != nil {
+		return "", err
+	}
+
+	var (
+		bestName  string
+		bestStart time.Time
+	)
+	pager := execClient.NewListPager(j.ResourceGroup, cdJobName, nil)
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			return "", fmt.Errorf("failed to list job executions: %w", err)
+		}
+		for _, exec := range page.Value {
+			if exec.Name == nil || exec.Properties == nil || !templateHasEtag(exec.Properties.Template, etag) {
+				continue
+			}
+			// Retries reuse the etag, so prefer the most recently started run.
+			var start time.Time
+			if exec.Properties.StartTime != nil {
+				start = *exec.Properties.StartTime
+			}
+			if bestName == "" || start.After(bestStart) {
+				bestName, bestStart = *exec.Name, start
+			}
+		}
+	}
+	return bestName, nil
+}
+
+// templateHasEtag reports whether any container in the execution template was
+// launched with EnvVarEtag set to etag.
+func templateHasEtag(tmpl *armappcontainersv3.JobExecutionTemplate, etag string) bool {
+	if tmpl == nil {
+		return false
+	}
+	for _, c := range tmpl.Containers {
+		for _, e := range c.Env {
+			if e.Name != nil && *e.Name == EnvVarEtag && e.Value != nil && *e.Value == etag {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // TailJobLogs streams real-time container logs from the running job execution

--- a/src/pkg/clouds/azure/aca/job_test.go
+++ b/src/pkg/clouds/azure/aca/job_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	armappcontainersv3 "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appcontainers/armappcontainers/v3"
 	cloudazure "github.com/DefangLabs/defang/src/pkg/clouds/azure"
 )
@@ -639,6 +640,37 @@ func TestFetchLogsFromWorkspaceSDKError(t *testing.T) {
 	// the SDK (will fail), then bails.
 	if _, err := j.fetchLogsFromWorkspace(t.Context(), "exec"); err == nil {
 		t.Error("expected error from fetchLogsFromWorkspace")
+	}
+}
+
+func TestTemplateHasEtag(t *testing.T) {
+	tmplWith := func(envs ...*armappcontainersv3.EnvironmentVar) *armappcontainersv3.JobExecutionTemplate {
+		return &armappcontainersv3.JobExecutionTemplate{
+			Containers: []*armappcontainersv3.JobExecutionContainer{{Env: envs}},
+		}
+	}
+	etagVar := &armappcontainersv3.EnvironmentVar{Name: to.Ptr(EnvVarEtag), Value: to.Ptr("etag-A")}
+	otherVar := &armappcontainersv3.EnvironmentVar{Name: to.Ptr("DEFANG_MODE"), Value: to.Ptr("development")}
+	secretRef := &armappcontainersv3.EnvironmentVar{Name: to.Ptr(EnvVarEtag), SecretRef: to.Ptr("etag")}
+
+	tests := []struct {
+		name string
+		tmpl *armappcontainersv3.JobExecutionTemplate
+		etag string
+		want bool
+	}{
+		{"match", tmplWith(otherVar, etagVar), "etag-A", true},
+		{"different value", tmplWith(etagVar), "etag-B", false},
+		{"no etag var", tmplWith(otherVar), "etag-A", false},
+		{"nil template", nil, "etag-A", false},
+		{"value-less etag var", tmplWith(secretRef), "etag-A", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := templateHasEtag(tt.tmpl, tt.etag); got != tt.want {
+				t.Errorf("templateHasEtag() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }
 

--- a/src/pkg/clouds/azure/aca/tail.go
+++ b/src/pkg/clouds/azure/aca/tail.go
@@ -23,10 +23,11 @@ type ServiceLogEntry struct {
 	LogEntry
 }
 
-// WatchLogs polls the resource group for Container Apps every watchInterval and streams
-// logs from each one as soon as it is discovered. New apps that appear after the initial
-// poll are picked up automatically.
-func (c *ContainerApp) WatchLogs(ctx context.Context) <-chan ServiceLogEntry {
+// WatchLogs polls the resource group for Container Apps and streams logs from each one
+// as soon as it is discovered. When follow is true it keeps polling every watchInterval
+// (picking up apps that appear later) and tails each app's logs live; when false it polls
+// once, drains the currently-buffered logs from each app, and closes the channel.
+func (c *ContainerApp) WatchLogs(ctx context.Context, follow bool) <-chan ServiceLogEntry {
 	out := make(chan ServiceLogEntry)
 	go func() {
 		// streaming tracks apps that currently have a live tail goroutine. An
@@ -54,7 +55,7 @@ func (c *ContainerApp) WatchLogs(ctx context.Context) <-chan ServiceLogEntry {
 					delete(streaming, appName)
 					mu.Unlock()
 				}()
-				appCh, err := c.StreamLogs(ctx, appName, "", "", "", true)
+				appCh, err := c.StreamLogs(ctx, appName, "", "", "", follow)
 				if err != nil {
 					select {
 					case out <- ServiceLogEntry{AppName: appName, LogEntry: LogEntry{Err: err}}:
@@ -110,6 +111,11 @@ func (c *ContainerApp) WatchLogs(ctx context.Context) <-chan ServiceLogEntry {
 		}
 
 		poll()
+		if !follow {
+			// One-shot snapshot: the deferred senders.Wait()+close(out) runs once
+			// every per-app stream (opened with follow=false) drains.
+			return
+		}
 		ticker := time.NewTicker(watchInterval)
 		defer ticker.Stop()
 		for {

--- a/src/pkg/clouds/azure/aca/tail_test.go
+++ b/src/pkg/clouds/azure/aca/tail_test.go
@@ -21,11 +21,32 @@ func TestWatchLogsCancelled(t *testing.T) {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 	defer cancel()
-	ch := c.WatchLogs(ctx)
+	ch := c.WatchLogs(ctx, true)
 	for range ch {
 		// drain
 	}
 	// If we got here, WatchLogs properly exits on ctx cancellation.
+}
+
+func TestWatchLogsNonFollowClosesChannel(t *testing.T) {
+	// In non-follow mode WatchLogs must poll once and close the channel rather than
+	// keep polling — otherwise a non-follow `defang logs` would block forever. Here
+	// the (fake) list-apps call fails, so no apps are tailed and the channel should
+	// close promptly even though the context has plenty of time left.
+	useFakeCred(t, "tok", nil)
+	c := &ContainerApp{
+		Azure:         cloudazure.Azure{SubscriptionID: "sub", Location: cloudazure.LocationWestUS2},
+		ResourceGroup: "rg",
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	ch := c.WatchLogs(ctx, false)
+	for range ch {
+		// drain
+	}
+	if ctx.Err() != nil {
+		t.Error("non-follow WatchLogs should close the channel before the context expires")
+	}
 }
 
 func TestStreamLogsResolveFailure(t *testing.T) {
@@ -244,7 +265,7 @@ func TestWatchLogsNewClientOK(t *testing.T) {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
 	defer cancel()
-	ch := c.WatchLogs(ctx)
+	ch := c.WatchLogs(ctx, true)
 	for range ch {
 	}
 }

--- a/src/pkg/clouds/azure/acr/buildlogs.go
+++ b/src/pkg/clouds/azure/acr/buildlogs.go
@@ -139,7 +139,7 @@ func (w *BuildLogWatcher) WatchBuildLogs(ctx context.Context, follow bool) <-cha
 					senders.Add(1)
 					go func() {
 						defer senders.Done()
-						w.streamRunLog(ctx, runsClient, w.ResourceGroup, registryName, runID, service, out)
+						w.streamRunLog(ctx, runsClient, w.ResourceGroup, registryName, runID, service, follow, out)
 					}()
 				}
 			}
@@ -147,9 +147,9 @@ func (w *BuildLogWatcher) WatchBuildLogs(ctx context.Context, follow bool) <-cha
 
 		poll()
 		if !follow {
-			// One-shot snapshot: the deferred senders.Wait()+close(out) runs once
-			// each discovered run's streamRunLog returns (it exits when the run is
-			// terminal, which is the case for any already-finished build).
+			// One-shot snapshot: each discovered run's streamRunLog emits its
+			// currently-available lines and returns (without waiting for the run to
+			// terminate), so the deferred senders.Wait()+close(out) runs promptly.
 			return
 		}
 		ticker := time.NewTicker(buildPollInterval)
@@ -167,10 +167,14 @@ func (w *BuildLogWatcher) WatchBuildLogs(ctx context.Context, follow bool) <-cha
 }
 
 // streamRunLog polls GetLogSasURL for a run and streams new log content as it grows.
+// When follow is false it emits whatever content is available once and returns, rather
+// than polling until the run reaches a terminal status — otherwise a snapshot query
+// would block until an in-progress build finishes.
 func (w *BuildLogWatcher) streamRunLog(
 	ctx context.Context,
 	runsClient *armcontainerregistry.RunsClient,
 	rgName, registryName, runID, service string,
+	follow bool,
 	out chan<- BuildLogEntry,
 ) {
 	var lastLen int
@@ -213,6 +217,12 @@ func (w *BuildLogWatcher) streamRunLog(
 					return
 				}
 			}
+		}
+
+		if !follow {
+			// Snapshot mode: emitted the currently-available lines, so stop here
+			// instead of waiting for the run to reach a terminal status.
+			return
 		}
 
 		// Check if run is still active.

--- a/src/pkg/clouds/azure/acr/buildlogs.go
+++ b/src/pkg/clouds/azure/acr/buildlogs.go
@@ -33,7 +33,10 @@ type BuildLogWatcher struct {
 // runs, and streams their build log output. The registry itself is created lazily by
 // Pulumi during the CD run, so registry discovery is retried on every poll until one
 // appears (or ctx is cancelled). The returned channel is closed when ctx is cancelled.
-func (w *BuildLogWatcher) WatchBuildLogs(ctx context.Context) <-chan BuildLogEntry {
+// WatchBuildLogs streams ACR build (task run) logs from the resource group. When follow
+// is true it keeps polling for new runs every buildPollInterval; when false it polls once
+// for recent runs, drains their logs, and closes the channel.
+func (w *BuildLogWatcher) WatchBuildLogs(ctx context.Context, follow bool) <-chan BuildLogEntry {
 	out := make(chan BuildLogEntry)
 	go func() {
 		// senders tracks the per-run streaming goroutines started by poll().
@@ -143,6 +146,12 @@ func (w *BuildLogWatcher) WatchBuildLogs(ctx context.Context) <-chan BuildLogEnt
 		}
 
 		poll()
+		if !follow {
+			// One-shot snapshot: the deferred senders.Wait()+close(out) runs once
+			// each discovered run's streamRunLog returns (it exits when the run is
+			// terminal, which is the case for any already-finished build).
+			return
+		}
 		ticker := time.NewTicker(buildPollInterval)
 		defer ticker.Stop()
 		for {

--- a/src/pkg/clouds/azure/acr/buildlogs_test.go
+++ b/src/pkg/clouds/azure/acr/buildlogs_test.go
@@ -175,7 +175,7 @@ func TestStreamRunLogCancelled(t *testing.T) {
 	out := make(chan BuildLogEntry)
 	done := make(chan struct{})
 	go func() {
-		w.streamRunLog(ctx, runsClient, "rg", "registry", "run-id", "svc", out)
+		w.streamRunLog(ctx, runsClient, "rg", "registry", "run-id", "svc", true, out)
 		close(done)
 	}()
 	go func() {

--- a/src/pkg/clouds/azure/acr/buildlogs_test.go
+++ b/src/pkg/clouds/azure/acr/buildlogs_test.go
@@ -128,7 +128,7 @@ func TestWatchBuildLogsCredError(t *testing.T) {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
-	ch := w.WatchBuildLogs(ctx)
+	ch := w.WatchBuildLogs(ctx, true)
 	// With good credential but a non-existent RG, the watcher retries indefinitely
 	// until ctx cancels. With bad credential (like here), clients may still be
 	// constructed but will error on each call; the goroutine should still exit
@@ -199,7 +199,7 @@ func TestWatchBuildLogsCancelled(t *testing.T) {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
 	defer cancel()
-	ch := w.WatchBuildLogs(ctx)
+	ch := w.WatchBuildLogs(ctx, true)
 	for range ch {
 	}
 	// If we got here, the channel was closed — good.

--- a/src/pkg/clouds/azure/cd/driver_test.go
+++ b/src/pkg/clouds/azure/cd/driver_test.go
@@ -120,6 +120,15 @@ func TestCreateResourceGroupCredError(t *testing.T) {
 	}
 }
 
+func TestResourceGroupExistsCredError(t *testing.T) {
+	useFakeCred(t, "", errors.New("denied"))
+	d := New("defang-cd", azure.LocationWestUS2)
+	d.SubscriptionID = "sub"
+	if _, err := d.ResourceGroupExists(t.Context(), "rg"); err == nil {
+		t.Error("ResourceGroupExists should surface credential error")
+	}
+}
+
 func TestTearDownCredError(t *testing.T) {
 	useFakeCred(t, "", errors.New("denied"))
 	d := New("defang-cd", azure.LocationWestUS2)

--- a/src/pkg/clouds/azure/cd/setup.go
+++ b/src/pkg/clouds/azure/cd/setup.go
@@ -46,6 +46,21 @@ func (d *Driver) CreateResourceGroup(ctx context.Context, name string) error {
 	return nil
 }
 
+// ResourceGroupExists reports whether the named resource group exists in the
+// subscription. Used to short-circuit read paths (e.g. log tailing) cleanly
+// when a project's resource group hasn't been deployed.
+func (d *Driver) ResourceGroupExists(ctx context.Context, name string) (bool, error) {
+	rgClient, err := d.newResourceGroupClient()
+	if err != nil {
+		return false, err
+	}
+	resp, err := rgClient.CheckExistence(ctx, name, nil)
+	if err != nil {
+		return false, fmt.Errorf("checking resource group %q: %w", name, err)
+	}
+	return resp.Success, nil
+}
+
 // SetUpResourceGroup ensures the shared CD resource group ("defang-cd")
 // exists and resolves d.cdLocation (the primary CD region).
 //

--- a/src/pkg/logs/log_type.go
+++ b/src/pkg/logs/log_type.go
@@ -24,6 +24,12 @@ const (
 	LogTypeAll         LogType = math.MaxUint32
 )
 
+// BuildServiceNameSuffix is appended to a service name to refer to that
+// service's build logs (e.g. "web-image" is the build for "web"). Build logs
+// have no service of their own, so callers strip this suffix to recover the
+// underlying service name.
+const BuildServiceNameSuffix = "-image"
+
 var AllLogTypes = []LogType{
 	LogTypeCD,
 	LogTypeRun,


### PR DESCRIPTION
## Description
azure `defang log` didn't work due to the logic requiring cd run id, updated to use etag to find the right run from azure.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added one-shot snapshot mode for service, CD, and build logs when not following, alongside continuous streaming.

* **Improvements**
  * Enhanced log retrieval to discover CD runs via etag and warn instead of failing when metadata is missing.
  * Improved follow vs snapshot handling across CD, service, and build log watchers.
  * Refined service-name validation and “not found yet” warnings, including consistent handling of `-image` build service suffixes.

* **Tests**
  * Updated/added unit tests for etag discovery, follow vs snapshot behavior, and service-name validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->