### PR TITLE
feat: add --remove to down/destroy

### DIFF
--- a/src/cmd/cli/command/compose.go
+++ b/src/cmd/cli/command/compose.go
@@ -452,9 +452,12 @@ func makeComposeDownCmd() *cobra.Command {
 
 			term.Info("Deleted services, deployment ID", deployment)
 
+			// Captured here because err is reassigned below, leaving listConfigs unsafe to dereference later.
+			var configNames []string
 			listConfigs, err := session.Provider.ListConfig(cmd.Context(), &defangv1.ListConfigsRequest{Project: projectName})
 			if err == nil {
-				if len(listConfigs.Names) > 0 && !remove {
+				configNames = listConfigs.Names
+				if len(configNames) > 0 && !remove {
 					// With --remove these configs are deleted below, since they are stored per-stack.
 					term.Warn("Stored project configs are not deleted.")
 				}
@@ -483,15 +486,15 @@ func makeComposeDownCmd() *cobra.Command {
 			}
 			term.Info("Done.")
 
-			if len(listConfigs.Names) > 0 {
+			if len(configNames) > 0 {
 				if remove {
 					// Configs are stored per-stack, so they would be orphaned once the stack is gone: delete them first.
-					if err := cli.ConfigDelete(cmd.Context(), projectName, session.Provider, listConfigs.Names...); err != nil {
+					if err := cli.ConfigDelete(cmd.Context(), projectName, session.Provider, configNames...); err != nil {
 						return fmt.Errorf("failed to delete stored project configs: %w", err)
 					}
 					term.Info("Deleted stored project configs")
 				} else {
-					printDefangHint("To delete stored project configs, run:", "config rm --project-name="+projectName+" "+strings.Join(listConfigs.Names, " "))
+					printDefangHint("To delete stored project configs, run:", "config rm --project-name="+projectName+" "+strings.Join(configNames, " "))
 				}
 			}
 

--- a/src/cmd/cli/command/compose.go
+++ b/src/cmd/cli/command/compose.go
@@ -418,6 +418,11 @@ func makeComposeDownCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var detach, _ = cmd.Flags().GetBool("detach")
 			var allowUpgrade, _ = cmd.Flags().GetBool("allow-upgrade")
+			var remove, _ = cmd.Flags().GetBool("remove")
+
+			if remove && detach {
+				return errors.New("cannot use --remove with --detach: the stack can only be removed after the down completes")
+			}
 
 			session, err := newCommandSession(cmd)
 			if err != nil {
@@ -449,7 +454,8 @@ func makeComposeDownCmd() *cobra.Command {
 
 			listConfigs, err := session.Provider.ListConfig(cmd.Context(), &defangv1.ListConfigsRequest{Project: projectName})
 			if err == nil {
-				if len(listConfigs.Names) > 0 {
+				if len(listConfigs.Names) > 0 && !remove {
+					// With --remove these configs are deleted below, since they are stored per-stack.
 					term.Warn("Stored project configs are not deleted.")
 				}
 			} else {
@@ -476,9 +482,27 @@ func makeComposeDownCmd() *cobra.Command {
 				return err
 			}
 			term.Info("Done.")
+
 			if len(listConfigs.Names) > 0 {
-				printDefangHint("To delete stored project configs, run:", "config rm --project-name="+projectName+" "+strings.Join(listConfigs.Names, " "))
+				if remove {
+					// Configs are stored per-stack, so they would be orphaned once the stack is gone: delete them first.
+					if err := cli.ConfigDelete(cmd.Context(), projectName, session.Provider, listConfigs.Names...); err != nil {
+						return fmt.Errorf("failed to delete stored project configs: %w", err)
+					}
+					term.Info("Deleted stored project configs")
+				} else {
+					printDefangHint("To delete stored project configs, run:", "config rm --project-name="+projectName+" "+strings.Join(listConfigs.Names, " "))
+				}
 			}
+
+			if remove {
+				// The down succeeded, so there is no active deployment left to confirm: remove without prompting.
+				if err := cli.RemoveStack(cmd.Context(), global.Client, session.Provider, ec, projectName, session.Stack.Name, true); err != nil {
+					return err
+				}
+				term.Infof("Removed stack %q", session.Stack.Name)
+			}
+
 			return nil
 		},
 	}
@@ -486,6 +510,7 @@ func makeComposeDownCmd() *cobra.Command {
 	composeDownCmd.Flags().Bool("tail", false, "tail the service logs after deleting") // no-op, but keep for backwards compatibility
 	_ = composeDownCmd.Flags().MarkHidden("tail")
 	composeDownCmd.Flags().Bool("allow-upgrade", pkg.GetenvBool("DEFANG_ALLOW_UPGRADE"), "allow upgrading the CD image and Pulumi version to the latest available")
+	composeDownCmd.Flags().Bool("remove", false, "delete the stack after a successful down")
 	return composeDownCmd
 }
 

--- a/src/cmd/cli/command/compose_test.go
+++ b/src/cmd/cli/command/compose_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"os"
+	"strings"
 	"testing"
 
 	"connectrpc.com/connect"
@@ -11,6 +12,21 @@ import (
 	"github.com/DefangLabs/defang/src/pkg/term"
 	defangv1 "github.com/DefangLabs/defang/src/protos/io/defang/v1"
 )
+
+func TestComposeDownRemoveDetachConflict(t *testing.T) {
+	cmd := makeComposeDownCmd()
+	cmd.SetArgs([]string{"--remove", "--detach"})
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when combining --remove and --detach, got nil")
+	}
+	if !strings.Contains(err.Error(), "cannot use --remove with --detach") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
 
 func TestInitializeTailCmd(t *testing.T) {
 	t.Run("", func(t *testing.T) {


### PR DESCRIPTION
## Description

This would be like doing `stack rm` after successful down. 

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `--remove` option to the compose down command to fully remove the project stack after a successful shutdown.
  * When enabled, stored per-project configurations are cleaned up and confirmations are shown.
  * Added validation that prevents using `--remove` together with `--detach`.

* **Tests**
  * Added a test to verify the `--remove` and `--detach` flag conflict is correctly detected and reported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->