### PR TITLE
feat(aws): use DEFANG_AWS_APN_ID for AWS resource tagging

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ The Defang CLI recognizes the following environment variables:
 - `COMPOSE_PROJECT_NAME` - The name of the project to use; overrides the `name` in the Compose file
 - `DEFANG_ACCESS_TOKEN` - The access token to use for authentication; if not specified, uses token from `defang login`
 - `DEFANG_ALLOW_UPGRADE` - If set to `true`, allows upgrading the CD image and Pulumi version to the latest available; defaults to `false`, ie. previously deployed versions will be used to avoid unexpected upgrades
+- `DEFANG_AWS_APN_ID` - The AWS APN ID to use for attribution, eg. use `pc-123456789abcdefgh` for AWS Marketplace products
 - `DEFANG_BUILD_CONTEXT_LIMIT` - The maximum size of the build context when building container images; defaults to `100MiB`
 - `DEFANG_CD_BUCKET` - The S3 bucket to use for the BYOC CD pipeline; defaults to `defang-cd-bucket-…`
 - `DEFANG_CD_IMAGE` - The image to use for the Continuous Deployment (CD) pipeline; defaults to `public.ecr.aws/defang-io/cd:public-beta`

--- a/pkgs/npm/README.md
+++ b/pkgs/npm/README.md
@@ -28,6 +28,7 @@ The Defang CLI recognizes the following environment variables:
 - `COMPOSE_PROJECT_NAME` - The name of the project to use; overrides the `name` in the Compose file
 - `DEFANG_ACCESS_TOKEN` - The access token to use for authentication; if not specified, uses token from `defang login`
 - `DEFANG_ALLOW_UPGRADE` - If set to `true`, allows upgrading the CD image and Pulumi version to the latest available; defaults to `false`, ie. previously deployed versions will be used to avoid unexpected upgrades
+- `DEFANG_AWS_APN_ID` - The AWS APN ID to use for attribution, eg. use `pc-123456789abcdefgh` for AWS Marketplace products
 - `DEFANG_BUILD_CONTEXT_LIMIT` - The maximum size of the build context when building container images; defaults to `100MiB`
 - `DEFANG_CD_BUCKET` - The S3 bucket to use for the BYOC CD pipeline; defaults to `defang-cd-bucket-…`
 - `DEFANG_CD_IMAGE` - The image to use for the Continuous Deployment (CD) pipeline; defaults to `public.ecr.aws/defang-io/cd:public-beta`

--- a/src/README.md
+++ b/src/README.md
@@ -28,6 +28,7 @@ The Defang CLI recognizes the following environment variables:
 - `COMPOSE_PROJECT_NAME` - The name of the project to use; overrides the `name` in the Compose file
 - `DEFANG_ACCESS_TOKEN` - The access token to use for authentication; if not specified, uses token from `defang login`
 - `DEFANG_ALLOW_UPGRADE` - If set to `true`, allows upgrading the CD image and Pulumi version to the latest available; defaults to `false`, ie. previously deployed versions will be used to avoid unexpected upgrades
+- `DEFANG_AWS_APN_ID` - The AWS APN ID to use for attribution, eg. use `pc-123456789abcdefgh` for AWS Marketplace products
 - `DEFANG_BUILD_CONTEXT_LIMIT` - The maximum size of the build context when building container images; defaults to `100MiB`
 - `DEFANG_CD_BUCKET` - The S3 bucket to use for the BYOC CD pipeline; defaults to `defang-cd-bucket-…`
 - `DEFANG_CD_IMAGE` - The image to use for the Continuous Deployment (CD) pipeline; defaults to `public.ecr.aws/defang-io/cd:public-beta`

--- a/src/pkg/cli/client/byoc/aws/byoc.go
+++ b/src/pkg/cli/client/byoc/aws/byoc.go
@@ -488,6 +488,7 @@ func (b *ByocAws) environment(projectName string) (map[string]string, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	env := map[string]string{
 		// "AWS_REGION":               region.String(), should be set by ECS (because of CD task role)
 		"DEFANG_DEBUG":               os.Getenv("DEFANG_DEBUG"), // TODO: use the global DoDebug flag
@@ -541,6 +542,11 @@ func (b *ByocAws) runCdCommand(ctx context.Context, cmd cdCommand) (awscodebuild
 	env, err := b.environment(cmd.project)
 	if err != nil {
 		return nil, err
+	}
+
+	// APN attribution is set by Fabric via CanIUse; allow a local env override for ISVs.
+	if awsApnId := pkg.Getenv("DEFANG_AWS_APN_ID", b.CanIUseConfig.AwsApnId); awsApnId != "" {
+		env["DEFANG_AWS_APN_ID"] = awsApnId
 	}
 	if cmd.delegationSetId != "" {
 		env["DELEGATION_SET_ID"] = cmd.delegationSetId

--- a/src/pkg/cli/client/byoc/baseclient.go
+++ b/src/pkg/cli/client/byoc/baseclient.go
@@ -43,6 +43,7 @@ type CanIUseConfig struct {
 	AllowScaling  bool
 	CDImage       string
 	PulumiVersion string
+	AwsApnId      string
 }
 
 type ByocBaseClient struct {
@@ -84,6 +85,7 @@ func (b *ByocBaseClient) SetCanIUseConfig(quotas *defangv1.CanIUseResponse) {
 	b.CanIUseConfig.AllowScaling = quotas.AllowScaling
 	b.CanIUseConfig.CDImage = quotas.CdImage
 	b.CanIUseConfig.PulumiVersion = quotas.PulumiVersion
+	b.CanIUseConfig.AwsApnId = quotas.AwsApnId
 }
 
 // getServiceLabel returns a DNS-safe label for the given service

--- a/src/protos/io/defang/v1/fabric.pb.go
+++ b/src/protos/io/defang/v1/fabric.pb.go
@@ -2687,6 +2687,7 @@ type CanIUseResponse struct {
 	Signature     []byte                 `protobuf:"bytes,6,opt,name=signature,proto3" json:"signature,omitempty"`
 	ForcedVersion bool                   `protobuf:"varint,7,opt,name=forced_version,json=forcedVersion,proto3" json:"forced_version,omitempty"` // force use of the returned CD image and Pulumi version
 	ForcedReason  string                 `protobuf:"bytes,8,opt,name=forced_reason,json=forcedReason,proto3" json:"forced_reason,omitempty"`
+	AwsApnId      string                 `protobuf:"bytes,9,opt,name=aws_apn_id,json=awsApnId,proto3" json:"aws_apn_id,omitempty"` // optional; if set, must be used for AWS deployments
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -2766,6 +2767,13 @@ func (x *CanIUseResponse) GetForcedVersion() bool {
 func (x *CanIUseResponse) GetForcedReason() string {
 	if x != nil {
 		return x.ForcedReason
+	}
+	return ""
+}
+
+func (x *CanIUseResponse) GetAwsApnId() string {
+	if x != nil {
+		return x.AwsApnId
 	}
 	return ""
 }
@@ -6669,7 +6677,7 @@ const file_io_defang_v1_fabric_proto_rawDesc = "" +
 	"\x06driver\x18\t \x01(\tR\x06driver\x12\x1f\n" +
 	"\vcli_version\x18\n" +
 	" \x01(\tR\n" +
-	"cliVersion\"\xfa\x01\n" +
+	"cliVersion\"\x98\x02\n" +
 	"\x0fCanIUseResponse\x12\x19\n" +
 	"\bcd_image\x18\x02 \x01(\tR\acdImage\x12\x10\n" +
 	"\x03gpu\x18\x03 \x01(\bR\x03gpu\x12#\n" +
@@ -6677,7 +6685,9 @@ const file_io_defang_v1_fabric_proto_rawDesc = "" +
 	"\x0epulumi_version\x18\x05 \x01(\tR\rpulumiVersion\x12\x1c\n" +
 	"\tsignature\x18\x06 \x01(\fR\tsignature\x12%\n" +
 	"\x0eforced_version\x18\a \x01(\bR\rforcedVersion\x12#\n" +
-	"\rforced_reason\x18\b \x01(\tR\fforcedReasonJ\x04\b\x01\x10\x02\"\xc7\x02\n" +
+	"\rforced_reason\x18\b \x01(\tR\fforcedReason\x12\x1c\n" +
+	"\n" +
+	"aws_apn_id\x18\t \x01(\tR\bawsApnIdJ\x04\b\x01\x10\x02\"\xc7\x02\n" +
 	"\rDeployRequest\x12\x1c\n" +
 	"\aproject\x18\x02 \x01(\tB\x02\x18\x01R\aproject\x120\n" +
 	"\x04mode\x18\x03 \x01(\x0e2\x1c.io.defang.v1.DeploymentModeR\x04mode\x12\x18\n" +

--- a/src/protos/io/defang/v1/fabric.proto
+++ b/src/protos/io/defang/v1/fabric.proto
@@ -390,6 +390,7 @@ message CanIUseResponse {
   bytes signature = 6;
   bool forced_version = 7; // force use of the returned CD image and Pulumi version
   string forced_reason = 8;
+  string aws_apn_id = 9; // optional; if set, must be used for AWS deployments
 }
 
 message DeployRequest {


### PR DESCRIPTION
## Description

Introduce `DEFANG_AWS_APN_ID` environment variable, passed to CD task for tagging AWS resources during AWS deployments. Added `aws_apn_id` to `CanIUse` rpc response for customers that bought Defang Pro through the AWS Marketplace.

## Linked Issues

Fixes #2154 

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring AWS APN attribution via a new environment variable.
  * This value can now be passed through to deployment and build environments when available.

* **Documentation**
  * Updated environment variable documentation in the main, package, and source READMEs with the new setting and example format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->