### PR TITLE
feat: auto-trigger debugger in CI

### DIFF
--- a/pkgs/defang/cli.nix
+++ b/pkgs/defang/cli.nix
@@ -7,7 +7,7 @@ buildGo125Module {
   pname = "defang-cli";
   version = "git";
   src = lib.cleanSource ../../src;
-  vendorHash = "sha256-qNsk3rEco0mzBIPodsp3GZpzgaIzthAPSIMmVCja50I=";
+  vendorHash = "sha256-eNm2ChvQ10xAYPJ6jN+Cm4CCnZfqk2e2MFGQ1Uj6T3w=";
 
   subPackages = [ "cmd/cli" ];
 

--- a/src/cmd/cli/command/compose.go
+++ b/src/cmd/cli/command/compose.go
@@ -137,7 +137,7 @@ func makeComposeUpCmd() *cobra.Command {
 			})
 			if err != nil {
 				composeErr := err
-				debugger, err := debug.NewDebugger(ctx, global.FabricAddr, session.Stack)
+				debugger, err := debug.NewDebugger(ctx, global.FabricAddr, session.Stack, !global.NonInteractive)
 				if err != nil {
 					return err
 				}
@@ -166,7 +166,7 @@ func makeComposeUpCmd() *cobra.Command {
 			serviceStates, err := cli.TailAndMonitor(ctx, project, session.Provider, time.Duration(waitTimeout)*time.Second, tailOptions)
 			if err != nil {
 				deploymentErr := err
-				debugger, err := debug.NewDebugger(ctx, global.FabricAddr, session.Stack)
+				debugger, err := debug.NewDebugger(ctx, global.FabricAddr, session.Stack, !global.NonInteractive)
 				if err != nil {
 					term.Warn("Failed to initialize debugger:", err)
 					return deploymentErr
@@ -320,7 +320,11 @@ func handleComposeUpErr(ctx context.Context, debugger *debug.Debugger, project *
 		return nil
 	}
 
-	if global.NonInteractive || errors.Is(originalErr, byoc.ErrLocalPulumiStopped) {
+	if errors.Is(originalErr, byoc.ErrLocalPulumiStopped) {
+		return originalErr
+	}
+	// In CI only paid accounts auto-run the debugger; others just get the error.
+	if global.NonInteractive && !debugger.AutoApprove() {
 		return originalErr
 	}
 
@@ -365,7 +369,9 @@ func handleTailAndMonitorErr(ctx context.Context, err error, debugger *debug.Deb
 			debugConfig.FailedServices = []string{errDeploymentFailed.Service}
 		}
 
-		if global.NonInteractive {
+		// In CI there is no one to prompt, so only paid accounts (which auto-approve) run the
+		// debugger automatically; everyone else gets a hint to debug interactively.
+		if global.NonInteractive && !debugger.AutoApprove() {
 			printDefangHint("To debug the deployment, do:", debugConfig.String())
 			return
 		}
@@ -485,7 +491,7 @@ func makeComposeDownCmd() *cobra.Command {
 				// A failed destroy (e.g. CodeBuild exit status) is when resources get orphaned, so prompt
 				// the AI debugger just like `up` does; it can guide the user through cleanup.
 				deploymentErr := err
-				debugger, dbgErr := debug.NewDebugger(cmd.Context(), global.FabricAddr, session.Stack)
+				debugger, dbgErr := debug.NewDebugger(cmd.Context(), global.FabricAddr, session.Stack, !global.NonInteractive)
 				if dbgErr != nil {
 					term.Warn("Failed to initialize debugger:", dbgErr)
 					return deploymentErr

--- a/src/cmd/cli/command/compose.go
+++ b/src/cmd/cli/command/compose.go
@@ -485,6 +485,7 @@ func makeComposeDownCmd() *cobra.Command {
 				}
 				// A failed destroy (e.g. CodeBuild exit status) is when resources get orphaned, so prompt
 				// the AI debugger just like `up` does; it can guide the user through cleanup.
+				// handleTailAndMonitorErr skips the prompt in non-interactive mode.
 				deploymentErr := err
 				debugger, dbgErr := debug.NewDebugger(cmd.Context(), global.FabricAddr, session.Stack)
 				if dbgErr != nil {

--- a/src/cmd/cli/command/compose.go
+++ b/src/cmd/cli/command/compose.go
@@ -137,7 +137,7 @@ func makeComposeUpCmd() *cobra.Command {
 			})
 			if err != nil {
 				composeErr := err
-				debugger, err := debug.NewDebugger(ctx, global.FabricAddr, session.Stack)
+				debugger, err := debug.NewDebugger(ctx, global.FabricAddr, session.Stack, !global.NonInteractive)
 				if err != nil {
 					return err
 				}
@@ -166,7 +166,7 @@ func makeComposeUpCmd() *cobra.Command {
 			serviceStates, err := cli.TailAndMonitor(ctx, project, session.Provider, time.Duration(waitTimeout)*time.Second, tailOptions)
 			if err != nil {
 				deploymentErr := err
-				debugger, err := debug.NewDebugger(ctx, global.FabricAddr, session.Stack)
+				debugger, err := debug.NewDebugger(ctx, global.FabricAddr, session.Stack, !global.NonInteractive)
 				if err != nil {
 					term.Warn("Failed to initialize debugger:", err)
 					return deploymentErr
@@ -321,7 +321,11 @@ func handleComposeUpErr(ctx context.Context, debugger *debug.Debugger, project *
 		return nil
 	}
 
-	if global.NonInteractive || errors.Is(originalErr, byoc.ErrLocalPulumiStopped) {
+	if errors.Is(originalErr, byoc.ErrLocalPulumiStopped) {
+		return originalErr
+	}
+	// In CI only paid accounts auto-run the debugger; others just get the error.
+	if global.NonInteractive && !debugger.AutoApprove() {
 		return originalErr
 	}
 
@@ -366,7 +370,9 @@ func handleTailAndMonitorErr(ctx context.Context, err error, debugger *debug.Deb
 			debugConfig.FailedServices = []string{errDeploymentFailed.Service}
 		}
 
-		if global.NonInteractive {
+		// In CI there is no one to prompt, so only paid accounts (which auto-approve) run the
+		// debugger automatically; everyone else gets a hint to debug interactively.
+		if global.NonInteractive && !debugger.AutoApprove() {
 			printDefangHint("To debug the deployment, do:", debugConfig.String())
 			return
 		}
@@ -487,7 +493,7 @@ func makeComposeDownCmd() *cobra.Command {
 				// the AI debugger just like `up` does; it can guide the user through cleanup.
 				// handleTailAndMonitorErr skips the prompt in non-interactive mode.
 				deploymentErr := err
-				debugger, dbgErr := debug.NewDebugger(cmd.Context(), global.FabricAddr, session.Stack)
+				debugger, dbgErr := debug.NewDebugger(cmd.Context(), global.FabricAddr, session.Stack, !global.NonInteractive)
 				if dbgErr != nil {
 					term.Warn("Failed to initialize debugger:", dbgErr)
 					return deploymentErr

--- a/src/cmd/cli/command/compose.go
+++ b/src/cmd/cli/command/compose.go
@@ -483,7 +483,22 @@ func makeComposeDownCmd() *cobra.Command {
 					term.Warn("Unable to tail logs. Detaching.")
 					return nil
 				}
-				return err
+				// A failed destroy (e.g. CodeBuild exit status) is when resources get orphaned, so prompt
+				// the AI debugger just like `up` does; it can guide the user through cleanup.
+				deploymentErr := err
+				debugger, dbgErr := debug.NewDebugger(cmd.Context(), global.FabricAddr, session.Stack)
+				if dbgErr != nil {
+					term.Warn("Failed to initialize debugger:", dbgErr)
+					return deploymentErr
+				}
+				handleTailAndMonitorErr(cmd.Context(), deploymentErr, debugger, debug.DebugConfig{
+					Deployment: deployment,
+					ProviderID: &session.Stack.Provider,
+					Stack:      session.Stack.Name,
+					Since:      since,
+					Until:      time.Now(),
+				})
+				return deploymentErr
 			}
 			term.Info("Done.")
 

--- a/src/cmd/cli/command/compose.go
+++ b/src/cmd/cli/command/compose.go
@@ -308,7 +308,7 @@ func promptToCreateStack(ctx context.Context, targetDirectory string, params sta
 
 func handleComposeUpErr(ctx context.Context, debugger *debug.Debugger, project *compose.Project, provider client.Provider, originalErr error) error {
 	if errors.Is(originalErr, types.ErrComposeFileNotFound) {
-		// TODO: generate a compose file based on the current project
+		// TODO: suggest to generate a compose file based on the current project
 		printDefangHint("To start a new project, do:", "new")
 	}
 

--- a/src/cmd/cli/command/debug.go
+++ b/src/cmd/cli/command/debug.go
@@ -35,7 +35,7 @@ var debugCmd = &cobra.Command{
 			return err
 		}
 
-		debugger, err := debug.NewDebugger(ctx, global.FabricAddr, session.Stack)
+		debugger, err := debug.NewDebugger(ctx, global.FabricAddr, session.Stack, !global.NonInteractive)
 		if err != nil {
 			return err
 		}

--- a/src/cmd/cli/command/session.go
+++ b/src/cmd/cli/command/session.go
@@ -174,7 +174,7 @@ func handleInvalidComposeFileErr(ctx context.Context, loadErr error) error {
 		return fmt.Errorf("%w; original error: %w", err, loadErr)
 	}
 
-	debugger, err := debug.NewDebugger(ctx, global.FabricAddr, &stacks.Parameters{})
+	debugger, err := debug.NewDebugger(ctx, global.FabricAddr, &stacks.Parameters{}, !global.NonInteractive)
 	if err != nil {
 		return fmt.Errorf("%w; original error: %w", err, loadErr)
 	}

--- a/src/cmd/cli/command/session.go
+++ b/src/cmd/cli/command/session.go
@@ -186,7 +186,7 @@ func handleInvalidComposeFileErr(ctx context.Context, loadErr error) error {
 		return fmt.Errorf("%w; original error: %w", err, loadErr)
 	}
 
-	debugger, err := debug.NewDebugger(ctx, global.FabricAddr, &stacks.Parameters{})
+	debugger, err := debug.NewDebugger(ctx, global.FabricAddr, &stacks.Parameters{}, !global.NonInteractive)
 	if err != nil {
 		return fmt.Errorf("%w; original error: %w", err, loadErr)
 	}

--- a/src/pkg/agent/agent.go
+++ b/src/pkg/agent/agent.go
@@ -31,9 +31,31 @@ type Agent struct {
 	generator *Generator
 	printer   Printer
 	system    string
+	// interactive controls whether the agent runs a REPL and prompts for input/elicitations.
+	// When false (e.g. CI), the agent handles the initial message once and returns.
+	interactive bool
 }
 
-func New(ctx context.Context, fabricAddr string, stack *stacks.Parameters) (*Agent, error) {
+// Option configures an Agent created by New.
+type Option func(*agentConfig)
+
+type agentConfig struct {
+	interactive bool
+}
+
+// WithNonInteractive runs the agent in one-shot mode: it handles the initial message to
+// completion and returns, without a REPL, continue-prompts, or tool elicitations. Suitable for
+// non-interactive environments such as CI.
+func WithNonInteractive() Option {
+	return func(c *agentConfig) { c.interactive = false }
+}
+
+func New(ctx context.Context, fabricAddr string, stack *stacks.Parameters, opts ...Option) (*Agent, error) {
+	cfg := agentConfig{interactive: true}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
 	accessToken := client.GetExistingToken(fabricAddr)
 	aiProvider := "fabric"
 	var providerPlugin api.Plugin
@@ -62,8 +84,8 @@ func New(ctx context.Context, fabricAddr string, stack *stacks.Parameters) (*Age
 		genkit.WithPlugins(providerPlugin),
 	)
 
-	elicitationsClient := elicitations.NewSurveyClient(os.Stdin, os.Stdout, os.Stderr)
-	ec := elicitations.NewController(elicitationsClient)
+	ec := elicitations.NewController(elicitations.NewSurveyClient(os.Stdin, os.Stdout, os.Stderr))
+	ec.SetSupported(cfg.interactive)
 
 	printer := printer{outStream: os.Stdout}
 	toolManager := NewToolManager(gk, printer)
@@ -87,9 +109,10 @@ func New(ctx context.Context, fabricAddr string, stack *stacks.Parameters) (*Age
 	}
 
 	a := &Agent{
-		printer:   printer,
-		generator: generator,
-		system:    preparedSystemPrompt,
+		printer:     printer,
+		generator:   generator,
+		system:      preparedSystemPrompt,
+		interactive: cfg.interactive,
 	}
 
 	return a, nil
@@ -108,12 +131,20 @@ func (a *Agent) StartWithMessage(ctx context.Context, msg string) error {
 func (a *Agent) startSession(ctx context.Context, initialMessage string) error {
 	signal.Reset(os.Interrupt) // unsubscribe the top-level signal handler
 
-	a.printer.Printf("Type '/exit' to quit.\n")
+	if a.interactive {
+		a.printer.Printf("Type '/exit' to quit.\n")
+	}
 
 	if initialMessage != "" {
 		if err := a.handleUserMessage(ctx, initialMessage); err != nil {
 			return fmt.Errorf("error handling initial message: %w", err)
 		}
+	}
+
+	// In non-interactive mode there is no one to prompt for further input: stop after the
+	// initial message has been handled to completion.
+	if !a.interactive {
+		return nil
 	}
 
 	for {
@@ -164,6 +195,11 @@ func (a *Agent) handleUserMessage(ctx context.Context, msg string) error {
 		}
 		if _, ok := err.(*maxTurnsReachedError); !ok {
 			return err
+		}
+
+		// Without a user to ask, stop at the turn limit instead of prompting to continue.
+		if !a.interactive {
+			return nil
 		}
 
 		var continueSession bool

--- a/src/pkg/debug/debug.go
+++ b/src/pkg/debug/debug.go
@@ -77,10 +77,17 @@ type Debugger struct {
 	// defaultPermission is the default answer to the "debug with AI?" prompt. Paid accounts
 	// default to yes so they flow into the agent (and its cleanup tooling) seamlessly.
 	defaultPermission bool
+	// interactive is false in environments without a user to prompt (e.g. CI). When false the
+	// debugger only runs if defaultPermission is true (paid), and does so without prompting.
+	interactive bool
 }
 
-func NewDebugger(ctx context.Context, fabricAddr string, stack *stacks.Parameters) (*Debugger, error) {
-	agent, err := agent.New(ctx, fabricAddr, stack)
+func NewDebugger(ctx context.Context, fabricAddr string, stack *stacks.Parameters, interactive bool) (*Debugger, error) {
+	var opts []agent.Option
+	if !interactive {
+		opts = append(opts, agent.WithNonInteractive())
+	}
+	agent, err := agent.New(ctx, fabricAddr, stack, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -88,7 +95,15 @@ func NewDebugger(ctx context.Context, fabricAddr string, stack *stacks.Parameter
 		agent:             agent,
 		surveyor:          &surveyor{},
 		defaultPermission: isPaidAccount(ctx, fabricAddr),
+		interactive:       interactive,
 	}, nil
+}
+
+// AutoApprove reports whether the debugger will run without an interactive prompt. This is true
+// for paid accounts and lets callers decide whether to invoke the debugger in non-interactive
+// environments (CI) or just print a hint.
+func (d *Debugger) AutoApprove() bool {
+	return d.defaultPermission
 }
 
 // isPaidAccount reports whether the signed-in account is on a paid plan. Any error falls back to
@@ -146,16 +161,22 @@ func (d *Debugger) promptAndTrackDebugSession(fn func() error, eventName string,
 		return err
 	}
 
-	good, err := d.promptForFeedback()
-	if err != nil {
-		track.Evt(eventName+" Feedback Prompt Failed", append([]track.Property{P("reason", err)}, eventProperty...)...)
-		return err
+	if d.interactive {
+		good, err := d.promptForFeedback()
+		if err != nil {
+			track.Evt(eventName+" Feedback Prompt Failed", append([]track.Property{P("reason", err)}, eventProperty...)...)
+			return err
+		}
+		track.Evt(eventName+" Feedback Prompt Answered", append([]track.Property{P("feedback", good)}, eventProperty...)...)
 	}
-	track.Evt(eventName+" Feedback Prompt Answered", append([]track.Property{P("feedback", good)}, eventProperty...)...)
 	return nil
 }
 
 func (d *Debugger) promptForPermission() (bool, error) {
+	if !d.interactive {
+		// No user to prompt: proceed only if this account auto-approves (paid).
+		return d.defaultPermission, nil
+	}
 	var aiDebug bool
 	err := d.surveyor.AskOne(&survey.Confirm{
 		Message: "Would you like to debug this with the Defang AI Agent?",

--- a/src/pkg/debug/debug.go
+++ b/src/pkg/debug/debug.go
@@ -129,12 +129,12 @@ func (d *Debugger) promptAndTrackDebugSession(fn func() error, eventName string,
 		return err
 	}
 
-	good, err := d.promptForFeedback()
+	feedback, err := d.promptForFeedback()
 	if err != nil {
 		track.Evt(eventName+" Feedback Prompt Failed", append([]track.Property{P("reason", err)}, eventProperty...)...)
 		return err
 	}
-	track.Evt(eventName+" Feedback Prompt Answered", append([]track.Property{P("feedback", good)}, eventProperty...)...)
+	track.Evt(eventName+" Feedback Prompt Answered", append([]track.Property{P("feedback", feedback)}, eventProperty...)...)
 	return nil
 }
 
@@ -154,17 +154,17 @@ func (d *Debugger) promptForPermission() (bool, error) {
 	return aiDebug, err
 }
 
-func (d *Debugger) promptForFeedback() (bool, error) {
-	var good bool
-	err := d.surveyor.AskOne(&survey.Confirm{
+func (d *Debugger) promptForFeedback() (string, error) {
+	var feedback string
+	err := d.surveyor.AskOne(&survey.Input{
 		Message: "Was the debugging helpful?",
 		Help:    "Please provide feedback to help us improve the debugging experience.",
-	}, &good, survey.WithStdio(term.DefaultTerm.Stdio()))
+	}, &feedback, survey.WithStdio(term.DefaultTerm.Stdio()))
 	if err != nil {
-		return false, err
+		return "", err
 	}
 
-	return good, err
+	return feedback, err
 }
 
 func buildDeploymentDebugPrompt(debugConfig DebugConfig) string {

--- a/src/pkg/debug/debug.go
+++ b/src/pkg/debug/debug.go
@@ -142,6 +142,9 @@ func (d *Debugger) promptForPermission() (bool, error) {
 	var aiDebug bool
 	err := d.surveyor.AskOne(&survey.Confirm{
 		Message: "Would you like to debug this with the Defang AI Agent?",
+		// Default to Yes for everyone; the server selects an appropriate model per account, so
+		// there is no need to gate the prompt client-side.
+		Default: true,
 		Help:    "This will send logs and artifacts to our backend and attempt to diagnose the issue and provide a solution.",
 	}, &aiDebug, survey.WithStdio(term.DefaultTerm.Stdio()))
 	if err != nil {

--- a/src/pkg/debug/debug.go
+++ b/src/pkg/debug/debug.go
@@ -91,10 +91,16 @@ func NewDebugger(ctx context.Context, fabricAddr string, stack *stacks.Parameter
 	if err != nil {
 		return nil, err
 	}
+	// The paid-tier lookup is a network round-trip and only matters when there is no user to
+	// prompt, so skip it for interactive sessions (where the prompt default is always Yes).
+	defaultPermission := false
+	if !interactive {
+		defaultPermission = isPaidAccount(ctx, fabricAddr)
+	}
 	return &Debugger{
 		agent:             agent,
 		surveyor:          &surveyor{},
-		defaultPermission: isPaidAccount(ctx, fabricAddr),
+		defaultPermission: defaultPermission,
 		interactive:       interactive,
 	}, nil
 }
@@ -130,14 +136,14 @@ func (d *Debugger) DebugDeployment(ctx context.Context, debugConfig DebugConfig)
 
 func (d *Debugger) DebugDeploymentError(ctx context.Context, debugConfig DebugConfig, deployErr error) error {
 	return d.promptAndTrackDebugSession(func() error {
-		prompt := buildDeploymentDebugPrompt(debugConfig) + " The error encountered was: " + deployErr.Error()
+		prompt := buildDeploymentDebugPrompt(debugConfig) + " The error encountered was: " + truncateTail(deployErr.Error(), maxPromptErrorLen)
 		return d.agent.StartWithMessage(ctx, prompt)
 	}, "Debug Deployment Error", P("etag", debugConfig.Deployment), P("deployErr", deployErr))
 }
 
 func (d *Debugger) DebugComposeLoadError(ctx context.Context, debugConfig DebugConfig, loadErr error) error {
 	return d.promptAndTrackDebugSession(func() error {
-		prompt := "The following error occurred while loading the compose file. Help troubleshoot and recommend a solution.\n\n" + loadErr.Error()
+		prompt := "The following error occurred while loading the compose file. Help troubleshoot and recommend a solution.\n\n" + truncateTail(loadErr.Error(), maxPromptErrorLen)
 		return d.agent.StartWithMessage(ctx, prompt)
 	}, "Debug Load", P("etag", debugConfig.Deployment), P("composeErr", loadErr))
 }
@@ -196,7 +202,7 @@ func (d *Debugger) promptForFeedback() (string, error) {
 	var feedback string
 	err := d.surveyor.AskOne(&survey.Input{
 		Message: "Was the debugging helpful?",
-		Help:    "Please provide feedback to help us improve the debugging experience.",
+		Help:    "Your answer is sent to Defang to help us improve the debugging experience.",
 	}, &feedback, survey.WithStdio(term.DefaultTerm.Stdio()))
 	if err != nil {
 		return "", err
@@ -237,8 +243,33 @@ func buildDeploymentDebugPrompt(debugConfig DebugConfig) string {
 		prompt += fmt.Sprintf(
 			"The compose files are at %s. The compose file is as follows:\n\n%s",
 			debugConfig.Project.ComposeFiles,
-			yaml,
+			truncateHead(string(yaml), maxPromptComposeLen),
 		)
 	}
 	return prompt
+}
+
+// The initial prompt must always fit in the model context, no matter how big the project or the
+// deployment failure: cap each payload and let the agent page through the rest with its tools
+// (e.g. the logs tool fetches 100 lines per call).
+const (
+	maxPromptErrorLen   = 2048
+	maxPromptComposeLen = 8192
+)
+
+// truncateHead keeps the first max bytes of s; the start of a compose file (project and service
+// definitions) is the most useful part.
+func truncateHead(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen] + "\n... (truncated; ask the user or use your tools for the rest)"
+}
+
+// truncateTail keeps the last max bytes of s; the end of an error is where the root cause lands.
+func truncateTail(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return "(truncated) ..." + s[len(s)-maxLen:]
 }

--- a/src/pkg/debug/debug.go
+++ b/src/pkg/debug/debug.go
@@ -74,17 +74,49 @@ type DebugAgent interface {
 type Debugger struct {
 	agent    DebugAgent
 	surveyor Surveyor
+	// defaultPermission is the default answer to the "debug with AI?" prompt. Paid accounts
+	// default to yes so they flow into the agent (and its cleanup tooling) seamlessly.
+	defaultPermission bool
+	// interactive is false in environments without a user to prompt (e.g. CI). When false the
+	// debugger only runs if defaultPermission is true (paid), and does so without prompting.
+	interactive bool
 }
 
-func NewDebugger(ctx context.Context, fabricAddr string, stack *stacks.Parameters) (*Debugger, error) {
-	agent, err := agent.New(ctx, fabricAddr, stack)
+func NewDebugger(ctx context.Context, fabricAddr string, stack *stacks.Parameters, interactive bool) (*Debugger, error) {
+	var opts []agent.Option
+	if !interactive {
+		opts = append(opts, agent.WithNonInteractive())
+	}
+	agent, err := agent.New(ctx, fabricAddr, stack, opts...)
 	if err != nil {
 		return nil, err
 	}
 	return &Debugger{
-		agent:    agent,
-		surveyor: &surveyor{},
+		agent:             agent,
+		surveyor:          &surveyor{},
+		defaultPermission: isPaidAccount(ctx, fabricAddr),
+		interactive:       interactive,
 	}, nil
+}
+
+// AutoApprove reports whether the debugger will run without an interactive prompt. This is true
+// for paid accounts and lets callers decide whether to invoke the debugger in non-interactive
+// environments (CI) or just print a hint.
+func (d *Debugger) AutoApprove() bool {
+	return d.defaultPermission
+}
+
+// isPaidAccount reports whether the signed-in account is on a paid plan. Any error falls back to
+// false so the prompt stays opt-in.
+func isPaidAccount(ctx context.Context, fabricAddr string) bool {
+	host := client.NormalizeHost(fabricAddr)
+	fabricClient := client.NewGrpcClient(host, client.GetExistingToken(host), "")
+	resp, err := fabricClient.WhoAmI(ctx)
+	if err != nil {
+		term.Debug("Could not determine subscription tier for debug prompt default:", err)
+		return false
+	}
+	return pkg.IsPaidTier(resp.Tier)
 }
 
 func (d *Debugger) DebugDeployment(ctx context.Context, debugConfig DebugConfig) error {
@@ -129,16 +161,22 @@ func (d *Debugger) promptAndTrackDebugSession(fn func() error, eventName string,
 		return err
 	}
 
-	feedback, err := d.promptForFeedback()
-	if err != nil {
-		track.Evt(eventName+" Feedback Prompt Failed", append([]track.Property{P("reason", err)}, eventProperty...)...)
-		return err
+	if d.interactive {
+		feedback, err := d.promptForFeedback()
+		if err != nil {
+			track.Evt(eventName+" Feedback Prompt Failed", append([]track.Property{P("reason", err)}, eventProperty...)...)
+			return err
+		}
+		track.Evt(eventName+" Feedback Prompt Answered", append([]track.Property{P("feedback", feedback)}, eventProperty...)...)
 	}
-	track.Evt(eventName+" Feedback Prompt Answered", append([]track.Property{P("feedback", feedback)}, eventProperty...)...)
 	return nil
 }
 
 func (d *Debugger) promptForPermission() (bool, error) {
+	if !d.interactive {
+		// No user to prompt: proceed only if this account auto-approves (paid).
+		return d.defaultPermission, nil
+	}
 	var aiDebug bool
 	err := d.surveyor.AskOne(&survey.Confirm{
 		Message: "Would you like to debug this with the Defang AI Agent?",

--- a/src/pkg/debug/debug_test.go
+++ b/src/pkg/debug/debug_test.go
@@ -29,11 +29,9 @@ type mockSurveyor struct {
 }
 
 func (s *mockSurveyor) AskOne(q survey.Prompt, response interface{}, opts ...survey.AskOpt) error {
-	b, ok := response.(*bool)
-	if !ok {
-		panic("response must be a *bool for this mock")
+	if boolptr, ok := response.(*bool); ok {
+		*boolptr = s.response
 	}
-	*b = s.response
 	return nil
 }
 

--- a/src/pkg/debug/debug_test.go
+++ b/src/pkg/debug/debug_test.go
@@ -86,8 +86,9 @@ func TestDebugDeployment(t *testing.T) {
 			response: tt.permission,
 		}
 		debugger := &Debugger{
-			agent:    mockAgent,
-			surveyor: mockSurveyor,
+			agent:       mockAgent,
+			surveyor:    mockSurveyor,
+			interactive: true,
 		}
 		t.Run(tt.name, func(t *testing.T) {
 			mockAgent.ExpectedCalls = nil
@@ -142,8 +143,9 @@ func TestDebugComposeLoadError(t *testing.T) {
 			response: tt.permission,
 		}
 		debugger := &Debugger{
-			agent:    mockAgent,
-			surveyor: mockSurveyor,
+			agent:       mockAgent,
+			surveyor:    mockSurveyor,
+			interactive: true,
 		}
 		t.Run(tt.name, func(t *testing.T) {
 			mockAgent.ExpectedCalls = nil
@@ -175,6 +177,53 @@ func TestDebugComposeLoadError(t *testing.T) {
 			}
 
 			if tt.permission {
+				mockAgent.AssertCalled(t, "StartWithMessage", ctx, expectedPrompt)
+			} else {
+				mockAgent.AssertNotCalled(t, "StartWithMessage", mock.Anything, mock.Anything)
+			}
+		})
+	}
+}
+
+// failSurveyor fails the test if any prompt is attempted; used to prove the non-interactive path
+// never prompts.
+type failSurveyor struct{ t *testing.T }
+
+func (s failSurveyor) AskOne(survey.Prompt, interface{}, ...survey.AskOpt) error {
+	s.t.Fatal("non-interactive debugger must not prompt")
+	return nil
+}
+
+func TestDebugDeploymentNonInteractive(t *testing.T) {
+	ctx := t.Context()
+	const expectedPrompt = `An error occurred while deploying this project with Defang. Help troubleshoot and recommend a solution. Look at the logs to understand what happened. The deployment ID is "test-deployment".`
+
+	tests := []struct {
+		name        string
+		autoApprove bool
+		expectRun   bool
+	}{
+		{name: "paid account auto-runs without prompting", autoApprove: true, expectRun: true},
+		{name: "free account does not run", autoApprove: false, expectRun: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockAgent := &mockAgent{}
+			if tt.expectRun {
+				mockAgent.On("StartWithMessage", ctx, expectedPrompt).Return(nil)
+			}
+			debugger := &Debugger{
+				agent:             mockAgent,
+				surveyor:          failSurveyor{t}, // must never be called when non-interactive
+				defaultPermission: tt.autoApprove,
+				interactive:       false,
+			}
+
+			err := debugger.DebugDeployment(ctx, DebugConfig{Deployment: "test-deployment"})
+			assert.NoError(t, err)
+
+			if tt.expectRun {
 				mockAgent.AssertCalled(t, "StartWithMessage", ctx, expectedPrompt)
 			} else {
 				mockAgent.AssertNotCalled(t, "StartWithMessage", mock.Anything, mock.Anything)

--- a/src/pkg/debug/debug_test.go
+++ b/src/pkg/debug/debug_test.go
@@ -229,3 +229,26 @@ func TestDebugDeploymentNonInteractive(t *testing.T) {
 		})
 	}
 }
+
+func TestTruncatePromptPayloads(t *testing.T) {
+	tests := []struct {
+		name string
+		fn   func(string, int) string
+		in   string
+		max  int
+		want string
+	}{
+		{name: "head: short string unchanged", fn: truncateHead, in: "abc", max: 5, want: "abc"},
+		{name: "head: exact length unchanged", fn: truncateHead, in: "abcde", max: 5, want: "abcde"},
+		{name: "head: keeps the start", fn: truncateHead, in: "abcdefgh", max: 5, want: "abcde\n... (truncated; ask the user or use your tools for the rest)"},
+		{name: "tail: short string unchanged", fn: truncateTail, in: "abc", max: 5, want: "abc"},
+		{name: "tail: exact length unchanged", fn: truncateTail, in: "abcde", max: 5, want: "abcde"},
+		{name: "tail: keeps the end", fn: truncateTail, in: "abcdefgh", max: 5, want: "(truncated) ...defgh"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.fn(tt.in, tt.max))
+		})
+	}
+}

--- a/src/pkg/debug/debug_test.go
+++ b/src/pkg/debug/debug_test.go
@@ -84,8 +84,9 @@ func TestDebugDeployment(t *testing.T) {
 			response: tt.permission,
 		}
 		debugger := &Debugger{
-			agent:    mockAgent,
-			surveyor: mockSurveyor,
+			agent:       mockAgent,
+			surveyor:    mockSurveyor,
+			interactive: true,
 		}
 		t.Run(tt.name, func(t *testing.T) {
 			mockAgent.ExpectedCalls = nil
@@ -140,8 +141,9 @@ func TestDebugComposeLoadError(t *testing.T) {
 			response: tt.permission,
 		}
 		debugger := &Debugger{
-			agent:    mockAgent,
-			surveyor: mockSurveyor,
+			agent:       mockAgent,
+			surveyor:    mockSurveyor,
+			interactive: true,
 		}
 		t.Run(tt.name, func(t *testing.T) {
 			mockAgent.ExpectedCalls = nil
@@ -173,6 +175,53 @@ func TestDebugComposeLoadError(t *testing.T) {
 			}
 
 			if tt.permission {
+				mockAgent.AssertCalled(t, "StartWithMessage", ctx, expectedPrompt)
+			} else {
+				mockAgent.AssertNotCalled(t, "StartWithMessage", mock.Anything, mock.Anything)
+			}
+		})
+	}
+}
+
+// failSurveyor fails the test if any prompt is attempted; used to prove the non-interactive path
+// never prompts.
+type failSurveyor struct{ t *testing.T }
+
+func (s failSurveyor) AskOne(survey.Prompt, interface{}, ...survey.AskOpt) error {
+	s.t.Fatal("non-interactive debugger must not prompt")
+	return nil
+}
+
+func TestDebugDeploymentNonInteractive(t *testing.T) {
+	ctx := t.Context()
+	const expectedPrompt = `An error occurred while deploying this project with Defang. Help troubleshoot and recommend a solution. Look at the logs to understand what happened. The deployment ID is "test-deployment".`
+
+	tests := []struct {
+		name        string
+		autoApprove bool
+		expectRun   bool
+	}{
+		{name: "paid account auto-runs without prompting", autoApprove: true, expectRun: true},
+		{name: "free account does not run", autoApprove: false, expectRun: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockAgent := &mockAgent{}
+			if tt.expectRun {
+				mockAgent.On("StartWithMessage", ctx, expectedPrompt).Return(nil)
+			}
+			debugger := &Debugger{
+				agent:             mockAgent,
+				surveyor:          failSurveyor{t}, // must never be called when non-interactive
+				defaultPermission: tt.autoApprove,
+				interactive:       false,
+			}
+
+			err := debugger.DebugDeployment(ctx, DebugConfig{Deployment: "test-deployment"})
+			assert.NoError(t, err)
+
+			if tt.expectRun {
 				mockAgent.AssertCalled(t, "StartWithMessage", ctx, expectedPrompt)
 			} else {
 				mockAgent.AssertNotCalled(t, "StartWithMessage", mock.Anything, mock.Anything)

--- a/src/pkg/elicitations/elicitations.go
+++ b/src/pkg/elicitations/elicitations.go
@@ -2,6 +2,7 @@ package elicitations
 
 import (
 	"context"
+	"errors"
 	"fmt"
 )
 
@@ -51,6 +52,11 @@ type Response struct {
 	Content map[string]any
 }
 
+// ErrNotSupported is returned by elicitation requests when the controller is marked unsupported
+// (e.g. non-interactive/CI). Callers that want to degrade gracefully should check IsSupported()
+// before requesting.
+var ErrNotSupported = errors.New("elicitation is not supported in this environment")
+
 func NewController(client Client) Controller {
 	return &controller{
 		client:    client,
@@ -82,6 +88,11 @@ func (c *controller) RequestEnum(ctx context.Context, message, field string, opt
 }
 
 func (c *controller) requestField(ctx context.Context, message, field string, schema map[string]any, validator Validator) (string, error) {
+	// Enforce the supported flag here so it is authoritative: a caller that doesn't first check
+	// IsSupported() fails fast instead of blocking on a transport that has no user to answer.
+	if !c.supported {
+		return "", ErrNotSupported
+	}
 	response, err := c.client.Request(ctx, Request{
 		Message: message,
 		Schema: map[string]any{

--- a/src/pkg/utils.go
+++ b/src/pkg/utils.go
@@ -146,6 +146,16 @@ func SubscriptionTierToString(tier defangv1.SubscriptionTier) string {
 	}
 }
 
+// IsPaidTier reports whether the subscription tier is a paid plan (Personal, Pro, or Team).
+func IsPaidTier(tier defangv1.SubscriptionTier) bool {
+	switch tier {
+	case defangv1.SubscriptionTier_PERSONAL, defangv1.SubscriptionTier_PRO, defangv1.SubscriptionTier_TEAM:
+		return true
+	default:
+		return false
+	}
+}
+
 func Ensure(cond bool, msg string) {
 	if !cond {
 		panic(msg)


### PR DESCRIPTION
## Description

Trigger the AI debugger on failure in CI.

## Linked Issues

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved interactive and non-interactive debugging workflows.
  * Non-interactive deployments can run automatically when account permissions allow, without prompts.
  * Added feedback text entry to interactive debugging sessions.
  * Added clearer handling when interactive prompts are unavailable.
* **Bug Fixes**
  * Improved error handling and debugging during compose start, stop, and log-monitoring operations.
  * Long deployment errors and configuration details are now shortened for easier review.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->