### PR TITLE
fix(cli): authenticate provider before running cd ls/down/destroy/etc

### DIFF
--- a/src/cmd/cli/command/cd.go
+++ b/src/cmd/cli/command/cd.go
@@ -46,6 +46,10 @@ func cdCommand(cmd *cobra.Command, command client.CdCommand, args []string, fabr
 			continue
 		}
 		provider := cli.NewProvider(ctx, providerID, fabric, stackName)
+		if err := authenticateProvider(ctx, provider); err != nil {
+			errs = append(errs, fmt.Errorf("authenticating provider for %q: %w", arg, err))
+			continue
+		}
 		err := canIUseProvider(ctx, provider, projectName, 0, allowUpgrade)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("validating provider for %q: %w", arg, err))
@@ -147,17 +151,20 @@ var cdListCmd = &cobra.Command{
 		}
 		provider := cli.NewProvider(ctx, providerID, global.Client, "") // stack name is not needed for listing projects
 
-		if remote {
-			if all {
-				return errors.New("--all cannot be used with --remote")
-			}
+		if remote && all {
+			return errors.New("--all cannot be used with --remote")
+		}
 
+		if err := authenticateProvider(ctx, provider); err != nil {
+			return err
+		}
+
+		if remote {
 			err := canIUseProvider(ctx, provider, "", 0, true) // safe to use latest CD image
 			if err != nil {
 				return err
 			}
 
-			// FIXME: this needs auth because it spawns the CD task
 			return cli.CdCommandAndTail(ctx, provider, "", global.Verbose, client.CdCommandList, global.Client)
 		} else {
 			return cli.CdListFromStorage(ctx, provider, all || global.Verbose)

--- a/src/cmd/cli/command/commands.go
+++ b/src/cmd/cli/command/commands.go
@@ -494,3 +494,14 @@ func isUpgradeCommand(cmd *cobra.Command) bool {
 func canIUseProvider(ctx context.Context, provider client.Provider, projectName string, serviceCount int, allowUpgrade bool) error {
 	return client.CanIUseProvider(ctx, global.Client, provider, projectName, serviceCount, allowUpgrade)
 }
+
+// authenticateProvider must be called before any direct use of a provider that was
+// constructed outside of newCommandSession (e.g. via cli.NewProvider), so that
+// provider-specific login paths such as GitHub Actions OIDC federation run instead of
+// falling through to the plain default credential chain.
+func authenticateProvider(ctx context.Context, provider client.Provider) error {
+	if err := provider.Authenticate(ctx, !global.NonInteractive); err != nil {
+		return fmt.Errorf("failed to authenticate with provider: %w", err)
+	}
+	return nil
+}

--- a/src/cmd/cli/command/commands_test.go
+++ b/src/cmd/cli/command/commands_test.go
@@ -450,6 +450,58 @@ func TestNewProvider(t *testing.T) {
 	})
 }
 
+type fakeAuthenticateProvider struct {
+	client.MockProvider
+	err            error
+	gotInteractive bool
+	calledInteract bool
+}
+
+func (f *fakeAuthenticateProvider) Authenticate(ctx context.Context, interactive bool) error {
+	f.calledInteract = true
+	f.gotInteractive = interactive
+	return f.err
+}
+
+func TestAuthenticateProvider(t *testing.T) {
+	oldNonInteractive := global.NonInteractive
+	t.Cleanup(func() { global.NonInteractive = oldNonInteractive })
+
+	t.Run("propagates non-interactive flag and succeeds", func(t *testing.T) {
+		global.NonInteractive = true
+		p := &fakeAuthenticateProvider{}
+		if err := authenticateProvider(t.Context(), p); err != nil {
+			t.Fatalf("authenticateProvider() failed: %v", err)
+		}
+		if !p.calledInteract {
+			t.Fatal("expected Authenticate to be called")
+		}
+		if p.gotInteractive {
+			t.Error("expected interactive=false when global.NonInteractive is true")
+		}
+	})
+
+	t.Run("propagates interactive flag", func(t *testing.T) {
+		global.NonInteractive = false
+		p := &fakeAuthenticateProvider{}
+		if err := authenticateProvider(t.Context(), p); err != nil {
+			t.Fatalf("authenticateProvider() failed: %v", err)
+		}
+		if !p.gotInteractive {
+			t.Error("expected interactive=true when global.NonInteractive is false")
+		}
+	})
+
+	t.Run("wraps the underlying error", func(t *testing.T) {
+		wantErr := errors.New("no valid credentials found")
+		p := &fakeAuthenticateProvider{err: wantErr}
+		err := authenticateProvider(t.Context(), p)
+		if !errors.Is(err, wantErr) {
+			t.Fatalf("authenticateProvider() error = %v, want wrapped %v", err, wantErr)
+		}
+	})
+}
+
 func TestErrIfStackAndProvider(t *testing.T) {
 	// RootCmd is wired up by TestMain via SetupCommands, so exercise its real flags.
 	stackFlag := RootCmd.Flags().Lookup("stack")


### PR DESCRIPTION
Blocks azure cleanup in https://github.com/DefangLabs/defang-mvp/pull/3060

## Summary
- `defang cd ls`, `down`, `destroy`, `refresh`, `cancel`, and `outputs` built their `Provider` via `cli.NewProvider` and used it directly, without ever calling `Provider.Authenticate()`. For Azure and GCP, the GitHub Actions OIDC federation path lives entirely inside `Authenticate()`, so these subcommands fell through to the plain default credential chain and failed on GitHub-hosted runners even after a successful `defang login` via OIDC.
- Added a small `authenticateProvider` helper (mirroring what `newCommandSession` already does for other commands) and call it right after constructing the provider in `cdCommand` and `cdListCmd`, before any direct provider/cloud API calls.

## Test plan
- [x] `cd src && make lint`
- [x] `cd src && make test` (includes `go test -race -short ./...` via the pre-push hook)
- [x] Added `TestAuthenticateProvider` covering: interactive-flag propagation (both directions) and error wrapping

Fixes #2159

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `cd` handling by authenticating provider access for each project/stack entry and showing clearer errors when authentication fails.
  * `list --remote` now checks provider access before running and returns a clearer error path if authentication is needed.
  * Added an upfront validation so `--all` can’t be used with `--remote`, preventing invalid command combinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->