### PR TITLE
feat(compose): support --env-file and COMPOSE_ENV_FILES for compose up

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ Invoke-Expression -Command (defang completion powershell | Out-String)
 The Defang CLI recognizes the following environment variables:
 
 - `COMPOSE_DISABLE_ENV_FILE` - Whether to disable loading environment variables from a `.env` file in the current directory; defaults to `false`
+- `COMPOSE_ENV_FILES` - A comma-separated list of environment file(s) to use for interpolation instead of `.env`; overridden by the `--env-file` flag
 - `COMPOSE_FILE` - The Compose file(s) to use; defaults to `compose.yaml`, `compose.yml`, `docker-compose.yaml`, or `docker-compose.yml` in the current directory
 - `COMPOSE_PATH_SEPARATOR` - The path separator to use for `COMPOSE_FILE`; defaults to `:` on Unix/MacOS and `;` on Windows
 - `COMPOSE_PROJECT_NAME` - The name of the project to use; overrides the `name` in the Compose file

--- a/pkgs/npm/README.md
+++ b/pkgs/npm/README.md
@@ -23,6 +23,7 @@ The Defang Command-Line Interface [(CLI)](https://docs.defang.io/docs/getting-st
 The Defang CLI recognizes the following environment variables:
 
 - `COMPOSE_DISABLE_ENV_FILE` - Whether to disable loading environment variables from a `.env` file in the current directory; defaults to `false`
+- `COMPOSE_ENV_FILES` - A comma-separated list of environment file(s) to use for interpolation instead of `.env`; overridden by the `--env-file` flag
 - `COMPOSE_FILE` - The Compose file(s) to use; defaults to `compose.yaml`, `compose.yml`, `docker-compose.yaml`, or `docker-compose.yml` in the current directory
 - `COMPOSE_PATH_SEPARATOR` - The path separator to use for `COMPOSE_FILE`; defaults to `:` on Unix/MacOS and `;` on Windows
 - `COMPOSE_PROJECT_NAME` - The name of the project to use; overrides the `name` in the Compose file

--- a/src/README.md
+++ b/src/README.md
@@ -23,6 +23,7 @@ The Defang Command-Line Interface [(CLI)](https://docs.defang.io/docs/getting-st
 The Defang CLI recognizes the following environment variables:
 
 - `COMPOSE_DISABLE_ENV_FILE` - Whether to disable loading environment variables from a `.env` file in the current directory; defaults to `false`
+- `COMPOSE_ENV_FILES` - A comma-separated list of environment file(s) to use for interpolation instead of `.env`; overridden by the `--env-file` flag
 - `COMPOSE_FILE` - The Compose file(s) to use; defaults to `compose.yaml`, `compose.yml`, `docker-compose.yaml`, or `docker-compose.yml` in the current directory
 - `COMPOSE_PATH_SEPARATOR` - The path separator to use for `COMPOSE_FILE`; defaults to `:` on Unix/MacOS and `;` on Windows
 - `COMPOSE_PROJECT_NAME` - The name of the project to use; overrides the `name` in the Compose file

--- a/src/cmd/cli/command/compose.go
+++ b/src/cmd/cli/command/compose.go
@@ -211,6 +211,8 @@ func makeComposeUpCmd() *cobra.Command {
 	_ = composeUpCmd.Flags().MarkHidden("wait")
 	composeUpCmd.Flags().Int("wait-timeout", -1, "maximum duration to wait for the project to be running|healthy") // docker-compose compatibility
 	composeUpCmd.Flags().Bool("allow-upgrade", pkg.GetenvBool("DEFANG_ALLOW_UPGRADE"), "allow upgrading the CD image and Pulumi version to the latest available")
+	composeUpCmd.Flags().StringArray("env-file", nil, "compose environment file(s) for interpolation; defaults to .env") // docker-compose compatibility
+	_ = composeUpCmd.MarkFlagFilename("env-file")
 	return composeUpCmd
 }
 
@@ -783,7 +785,7 @@ services:
 	}
 	// Compose Command
 	// composeCmd.Flags().Bool("compatibility", false, "Run compose in backward compatibility mode"); TODO: Implement compose option
-	// composeCmd.Flags().String("env-file", "", "Specify an alternate environment file."); TODO: Implement compose option
+	// --env-file is implemented per-subcommand (see makeComposeUpCmd) and via the COMPOSE_ENV_FILES env var.
 	// composeCmd.Flags().Int("parallel", -1, "Control max parallelism, -1 for unlimited (default -1)"); TODO: Implement compose option
 	// composeCmd.Flags().String("profile", "", "Specify a profile to enable"); TODO: Implement compose option
 	// composeCmd.Flags().String("project-directory", "", "Specify an alternate working directory"); TODO: Implement compose option

--- a/src/cmd/cli/command/session.go
+++ b/src/cmd/cli/command/session.go
@@ -92,7 +92,26 @@ func loaderOptionsForCommand(cmd *cobra.Command) compose.LoaderOptions {
 	return compose.LoaderOptions{
 		ConfigPaths: configPaths,
 		ProjectName: projectName,
+		EnvFiles:    envFilesForCommand(cmd),
 	}
+}
+
+// composeEnvFilesEnvVar lists the env file(s) to load when --env-file is not
+// passed, matching `docker compose`'s COMPOSE_ENV_FILES (comma-separated).
+const composeEnvFilesEnvVar = "COMPOSE_ENV_FILES"
+
+// envFilesForCommand resolves the --env-file flag, falling back to the
+// COMPOSE_ENV_FILES environment variable. The flag takes precedence, like
+// docker compose. Returns nil when neither is set, so the loader keeps its
+// default behavior of loading PWD/.env.
+func envFilesForCommand(cmd *cobra.Command) []string {
+	if envFiles, _ := cmd.Flags().GetStringArray("env-file"); len(envFiles) > 0 {
+		return envFiles
+	}
+	if envFiles := os.Getenv(composeEnvFilesEnvVar); envFiles != "" {
+		return strings.Split(envFiles, ",")
+	}
+	return nil
 }
 
 func doubleCheckProjectName(projectName string) {

--- a/src/cmd/cli/command/session_test.go
+++ b/src/cmd/cli/command/session_test.go
@@ -11,6 +11,63 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestLoaderOptionsEnvFile(t *testing.T) {
+	tests := []struct {
+		name           string
+		flagValues     []string // values passed via --env-file
+		composeEnvFile string   // value of COMPOSE_ENV_FILES; "" means unset
+		expected       []string
+	}{
+		{
+			name:     "no env-file flag and no env var",
+			expected: nil,
+		},
+		{
+			name:       "single --env-file",
+			flagValues: []string{"prod.env"},
+			expected:   []string{"prod.env"},
+		},
+		{
+			name:       "multiple --env-file",
+			flagValues: []string{"a.env", "b.env"},
+			expected:   []string{"a.env", "b.env"},
+		},
+		{
+			name:           "COMPOSE_ENV_FILES is used when the flag is absent",
+			composeEnvFile: "one.env,two.env",
+			expected:       []string{"one.env", "two.env"},
+		},
+		{
+			name:           "--env-file takes precedence over COMPOSE_ENV_FILES",
+			flagValues:     []string{"flag.env"},
+			composeEnvFile: "ignored.env",
+			expected:       []string{"flag.env"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.composeEnvFile != "" {
+				t.Setenv("COMPOSE_ENV_FILES", tt.composeEnvFile)
+			} else {
+				// Ensure a value inherited from the environment does not leak in.
+				os.Unsetenv("COMPOSE_ENV_FILES")
+			}
+
+			cmd := &cobra.Command{}
+			cmd.Flags().StringArray("file", nil, "")
+			cmd.Flags().String("project-name", "", "")
+			cmd.Flags().StringArray("env-file", nil, "")
+			for _, v := range tt.flagValues {
+				require.NoError(t, cmd.Flags().Set("env-file", v))
+			}
+
+			opts := loaderOptionsForCommand(cmd)
+			assert.Equal(t, tt.expected, opts.EnvFiles)
+		})
+	}
+}
+
 func TestNewStackManager(t *testing.T) {
 	tests := []struct {
 		name           string

--- a/src/pkg/cli/compose/loader.go
+++ b/src/pkg/cli/compose/loader.go
@@ -33,6 +33,7 @@ type BuildConfig = composeTypes.BuildConfig
 type LoaderOptions struct {
 	ConfigPaths []string
 	ProjectName string
+	EnvFiles    []string
 }
 
 type Loader struct {
@@ -51,6 +52,15 @@ func WithPath(paths ...string) LoaderOption {
 func WithProjectName(name string) LoaderOption {
 	return func(o *LoaderOptions) {
 		o.ProjectName = name
+	}
+}
+
+// WithEnvFiles sets the env file(s) used to populate the project environment for
+// interpolation, mirroring `docker compose --env-file`. When empty, the default
+// PWD/.env file is loaded (if present).
+func WithEnvFiles(paths ...string) LoaderOption {
+	return func(o *LoaderOptions) {
+		o.EnvFiles = paths
 	}
 }
 
@@ -145,8 +155,8 @@ func (l *Loader) newProjectOptions(suppressWarn bool) (*cli.ProjectOptions, erro
 		// First apply os.Environment, always win
 		// -- DISABLED FOR DEFANG -- cli.WithOsEnv,
 		cli.WithEnv(onlyComposeEnv),
-		// Load PWD/.env if present and no explicit --env-file has been set
-		cli.WithEnvFiles(), // TODO: Support --env-file to be added as param to this call
+		// Load the explicit --env-file(s), or PWD/.env if none were set
+		cli.WithEnvFiles(l.options.EnvFiles...),
 		// read dot env file to populate project environment
 		cli.WithDotEnv,
 		// get compose file path set by COMPOSE_FILE
@@ -155,7 +165,7 @@ func (l *Loader) newProjectOptions(suppressWarn bool) (*cli.ProjectOptions, erro
 		cli.WithDefaultConfigPath,
 		// Calling the 2 functions below the 2nd time as the loaded env in first call modifies the behavior of the 2nd call:
 		// .. and then, a project directory != PWD maybe has been set so let's load .env file
-		cli.WithEnvFiles(), // TODO: Support --env-file to be added as param to this call
+		cli.WithEnvFiles(l.options.EnvFiles...),
 		cli.WithDotEnv,
 		// eventually COMPOSE_PROFILES should have been set
 		// cli.WithDefaultProfiles(c.Profiles...), TODO: Support --profile to be added as param to this call

--- a/src/pkg/cli/compose/loader_test.go
+++ b/src/pkg/cli/compose/loader_test.go
@@ -115,3 +115,75 @@ func TestComposeEnv(t *testing.T) {
 	assert.Len(t, p.Services, 2)
 	assert.Equal(t, types.NewMappingWithEquals([]string{"A=${A}"}), p.Services["service1"].Environment)
 }
+
+func TestWithEnvFiles(t *testing.T) {
+	// A minimal project whose interpolation depends on env-file values.
+	const composeYAML = `name: envfiletest
+services:
+  web:
+    image: alpine
+    environment:
+      - GREETING=${GREETING}
+      - SOURCE=${SOURCE}
+`
+	dir := t.TempDir()
+	writeFile := func(name, content string) string {
+		t.Helper()
+		p := filepath.Join(dir, name)
+		if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		return p
+	}
+
+	composePath := writeFile("compose.yaml", composeYAML)
+	// The default .env sits next to the compose file and is loaded when no --env-file is given.
+	writeFile(".env", "GREETING=from_dotenv\nSOURCE=default\n")
+	// The explicit env-file only defines GREETING.
+	prodEnv := writeFile("prod.env", "GREETING=from_prod\n")
+	// A second env-file to verify multiple --env-file values merge (last wins for duplicates).
+	extraEnv := writeFile("extra.env", "SOURCE=from_extra\n")
+
+	tests := []struct {
+		name     string
+		envFiles []string
+		expected map[string]string
+	}{
+		{
+			name:     "default .env is used when no env-file is given",
+			envFiles: nil,
+			expected: map[string]string{"GREETING": "from_dotenv", "SOURCE": "default"},
+		},
+		{
+			name:     "explicit env-file overrides the default .env",
+			envFiles: []string{prodEnv},
+			// SOURCE is absent from prod.env and the default .env is no longer
+			// loaded, so it stays unresolved for resolution later by CD.
+			expected: map[string]string{"GREETING": "from_prod", "SOURCE": "${SOURCE}"},
+		},
+		{
+			name:     "multiple env-files are merged",
+			envFiles: []string{prodEnv, extraEnv},
+			expected: map[string]string{"GREETING": "from_prod", "SOURCE": "from_extra"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			loader := NewLoader(WithPath(composePath), WithEnvFiles(tt.envFiles...))
+			p, err := loader.LoadProject(t.Context())
+			if err != nil {
+				t.Fatal(err)
+			}
+			env := p.Services["web"].Environment
+			for k, want := range tt.expected {
+				got := env[k]
+				if got == nil {
+					t.Errorf("environment variable %q not found", k)
+					continue
+				}
+				assert.Equal(t, want, *got, "environment variable %q", k)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Adds a `--env-file` flag to `defang compose up` (and the top-level `defang up`) that selects the environment file(s) used for Compose interpolation, matching `docker compose --env-file`. Also honors the `COMPOSE_ENV_FILES` environment variable (comma-separated) — the same variable Docker Compose uses — when the flag is not passed.

This implements the long-standing `TODO: Support --env-file` in the compose loader.

## Behavior (conforms to docker compose)

- `--env-file` selects the env file(s) for `${VAR}` interpolation; when set, it **replaces** the default `.env` (an unresolved var is left as `${VAR}` for CD, as today).
- Precedence: `--env-file` flag → `COMPOSE_ENV_FILES` env var → default `.env`.
- Multiple files merge; later files win on duplicate keys.
- Because resolution lives in `loaderOptionsForCommand`, `COMPOSE_ENV_FILES` also applies to other project-loading commands (e.g. `compose config`).

## Changes

- `pkg/cli/compose/loader.go`: add `EnvFiles` to `LoaderOptions` + `WithEnvFiles` option; pass explicit files to compose-go's `WithEnvFiles`.
- `cmd/cli/command/compose.go`: register `--env-file` on `compose up`.
- `cmd/cli/command/session.go`: resolve flag → `COMPOSE_ENV_FILES` → nil.
- `README.md`, `src/README.md`: document `COMPOSE_ENV_FILES`.

## Tests (added first)

- `TestWithEnvFiles`: interpolation resolves from a custom env-file; explicit file overrides default `.env`; multiple files merge.
- `TestLoaderOptionsEnvFile`: flag single/multiple, env-var fallback, and flag-beats-env-var precedence.

## Verification

- `go test -short ./...` passes; `golangci-lint` (v2.5.0) reports 0 issues.
- End-to-end: `COMPOSE_ENV_FILES=prod.env defang compose config` resolved the overriding value and left absent vars unresolved.

A companion PR adds an `env-file` input to `defang-github-action`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sw7j9FYnbChZJbYArxbhuo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for specifying Compose environment files with repeatable `--env-file` options.
  * Added support for `COMPOSE_ENV_FILES` (comma-separated) for Compose interpolation.
  * `--env-file` takes precedence over `COMPOSE_ENV_FILES`.
  * Multiple environment files are supported, with later files overriding earlier values.
* **Documentation**
  * Updated environment variable documentation to include `COMPOSE_ENV_FILES` and clarify precedence with `--env-file`.
* **Tests**
  * Added coverage for `--env-file`/`COMPOSE_ENV_FILES` resolution and env-file merge behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->