### PR TITLE
fix(compose): honor COMPOSE_ENV_FILES set by a stack file

### DIFF
--- a/src/cmd/cli/command/session.go
+++ b/src/cmd/cli/command/session.go
@@ -96,20 +96,13 @@ func loaderOptionsForCommand(cmd *cobra.Command) compose.LoaderOptions {
 	}
 }
 
-// composeEnvFilesEnvVar lists the env file(s) to load when --env-file is not
-// passed, matching `docker compose`'s COMPOSE_ENV_FILES (comma-separated).
-const composeEnvFilesEnvVar = "COMPOSE_ENV_FILES"
-
-// envFilesForCommand resolves the --env-file flag, falling back to the
-// COMPOSE_ENV_FILES environment variable. The flag takes precedence, like
-// docker compose. Returns nil when neither is set, so the loader keeps its
-// default behavior of loading PWD/.env.
+// envFilesForCommand returns the --env-file flag value(s). The COMPOSE_ENV_FILES
+// fallback is resolved by the loader at project-load time (see compose.Loader),
+// so a value set by the selected stack file is also honored. Returns nil when
+// the flag is absent, letting the loader apply that fallback.
 func envFilesForCommand(cmd *cobra.Command) []string {
 	if envFiles, _ := cmd.Flags().GetStringArray("env-file"); len(envFiles) > 0 {
 		return envFiles
-	}
-	if envFiles := os.Getenv(composeEnvFilesEnvVar); envFiles != "" {
-		return strings.Split(envFiles, ",")
 	}
 	return nil
 }

--- a/src/cmd/cli/command/session_test.go
+++ b/src/cmd/cli/command/session_test.go
@@ -12,14 +12,16 @@ import (
 )
 
 func TestLoaderOptionsEnvFile(t *testing.T) {
+	// Only the --env-file flag is resolved here; the COMPOSE_ENV_FILES fallback
+	// is applied by the loader at project-load time (see compose.TestWithEnvFiles),
+	// so it can also pick up a value injected by the selected stack file.
 	tests := []struct {
-		name           string
-		flagValues     []string // values passed via --env-file
-		composeEnvFile string   // value of COMPOSE_ENV_FILES; "" means unset
-		expected       []string
+		name       string
+		flagValues []string // values passed via --env-file
+		expected   []string
 	}{
 		{
-			name:     "no env-file flag and no env var",
+			name:     "no env-file flag",
 			expected: nil,
 		},
 		{
@@ -32,28 +34,10 @@ func TestLoaderOptionsEnvFile(t *testing.T) {
 			flagValues: []string{"a.env", "b.env"},
 			expected:   []string{"a.env", "b.env"},
 		},
-		{
-			name:           "COMPOSE_ENV_FILES is used when the flag is absent",
-			composeEnvFile: "one.env,two.env",
-			expected:       []string{"one.env", "two.env"},
-		},
-		{
-			name:           "--env-file takes precedence over COMPOSE_ENV_FILES",
-			flagValues:     []string{"flag.env"},
-			composeEnvFile: "ignored.env",
-			expected:       []string{"flag.env"},
-		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if tt.composeEnvFile != "" {
-				t.Setenv("COMPOSE_ENV_FILES", tt.composeEnvFile)
-			} else {
-				// Ensure a value inherited from the environment does not leak in.
-				os.Unsetenv("COMPOSE_ENV_FILES")
-			}
-
 			cmd := &cobra.Command{}
 			cmd.Flags().StringArray("file", nil, "")
 			cmd.Flags().String("project-name", "", "")

--- a/src/pkg/cli/compose/loader.go
+++ b/src/pkg/cli/compose/loader.go
@@ -30,6 +30,10 @@ type Services = composeTypes.Services
 
 type BuildConfig = composeTypes.BuildConfig
 
+// composeEnvFilesEnvVar lists the env file(s) to load when no explicit env
+// file is set, matching `docker compose`'s COMPOSE_ENV_FILES (comma-separated).
+const composeEnvFilesEnvVar = "COMPOSE_ENV_FILES"
+
 type LoaderOptions struct {
 	ConfigPaths []string
 	ProjectName string
@@ -56,8 +60,9 @@ func WithProjectName(name string) LoaderOption {
 }
 
 // WithEnvFiles sets the env file(s) used to populate the project environment for
-// interpolation, mirroring `docker compose --env-file`. When empty, the default
-// PWD/.env file is loaded (if present).
+// interpolation, mirroring `docker compose --env-file`. When empty, the loader
+// falls back to the COMPOSE_ENV_FILES environment variable, and finally to the
+// default PWD/.env file (if present).
 func WithEnvFiles(paths ...string) LoaderOption {
 	return func(o *LoaderOptions) {
 		o.EnvFiles = paths
@@ -149,6 +154,18 @@ func (l *Loader) newProjectOptions(suppressWarn bool) (*cli.ProjectOptions, erro
 		return !strings.HasPrefix(kv, "COMPOSE_") // only keep COMPOSE_* variables
 	})
 
+	// The explicit --env-file(s) win; otherwise fall back to COMPOSE_ENV_FILES,
+	// symmetric to how ConfigPaths overrides COMPOSE_FILE (cli.WithConfigFileEnv)
+	// below. Reading the env var here (at load time) rather than up front is what
+	// lets a value injected by the selected stack file (via LoadStackEnv) take
+	// effect, since the stack env is applied before the project is loaded.
+	envFiles := l.options.EnvFiles
+	if len(envFiles) == 0 {
+		if v := os.Getenv(composeEnvFilesEnvVar); v != "" {
+			envFiles = strings.Split(v, ",")
+		}
+	}
+
 	// Based on how docker compose setup its own project options
 	// https://github.com/docker/compose/blob/1a14fcb1e6645dd92f5a4f2da00071bd59c2e887/cmd/compose/compose.go#L326-L346
 	return cli.NewProjectOptions(l.options.ConfigPaths,
@@ -156,7 +173,7 @@ func (l *Loader) newProjectOptions(suppressWarn bool) (*cli.ProjectOptions, erro
 		// -- DISABLED FOR DEFANG -- cli.WithOsEnv,
 		cli.WithEnv(onlyComposeEnv),
 		// Load the explicit --env-file(s), or PWD/.env if none were set
-		cli.WithEnvFiles(l.options.EnvFiles...),
+		cli.WithEnvFiles(envFiles...),
 		// read dot env file to populate project environment
 		cli.WithDotEnv,
 		// get compose file path set by COMPOSE_FILE
@@ -165,7 +182,7 @@ func (l *Loader) newProjectOptions(suppressWarn bool) (*cli.ProjectOptions, erro
 		cli.WithDefaultConfigPath,
 		// Calling the 2 functions below the 2nd time as the loaded env in first call modifies the behavior of the 2nd call:
 		// .. and then, a project directory != PWD maybe has been set so let's load .env file
-		cli.WithEnvFiles(l.options.EnvFiles...),
+		cli.WithEnvFiles(envFiles...),
 		cli.WithDotEnv,
 		// eventually COMPOSE_PROFILES should have been set
 		// cli.WithDefaultProfiles(c.Profiles...), TODO: Support --profile to be added as param to this call

--- a/src/pkg/cli/compose/loader_test.go
+++ b/src/pkg/cli/compose/loader_test.go
@@ -187,3 +187,74 @@ services:
 		})
 	}
 }
+
+// TestWithEnvFilesFromEnvVar covers the COMPOSE_ENV_FILES fallback. This is the
+// path a stack file uses: LoadStackEnv sets COMPOSE_ENV_FILES in the process env
+// before the project is loaded, so resolving it here (rather than up front) is
+// what makes a stack-scoped env file take effect. Regression test for that bug.
+func TestWithEnvFilesFromEnvVar(t *testing.T) {
+	const composeYAML = `name: envfilevartest
+services:
+  web:
+    image: alpine
+    environment:
+      - GREETING=${GREETING}
+`
+	dir := t.TempDir()
+	writeFile := func(name, content string) string {
+		t.Helper()
+		p := filepath.Join(dir, name)
+		if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		return p
+	}
+
+	composePath := writeFile("compose.yaml", composeYAML)
+	writeFile(".env", "GREETING=from_dotenv\n")
+	stackEnv := writeFile("stack.env", "GREETING=from_stack\n")
+	flagEnv := writeFile("flag.env", "GREETING=from_flag\n")
+
+	tests := []struct {
+		name     string
+		envFiles []string // explicit --env-file (WithEnvFiles)
+		envVar   string   // COMPOSE_ENV_FILES; "" means unset
+		expected string
+	}{
+		{
+			name:     "COMPOSE_ENV_FILES is honored when no explicit env-file is set",
+			envVar:   stackEnv,
+			expected: "from_stack",
+		},
+		{
+			name:     "explicit env-file overrides COMPOSE_ENV_FILES",
+			envFiles: []string{flagEnv},
+			envVar:   stackEnv,
+			expected: "from_flag",
+		},
+		{
+			name:     "default .env is used when neither is set",
+			expected: "from_dotenv",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.envVar != "" {
+				t.Setenv(composeEnvFilesEnvVar, tt.envVar)
+			} else {
+				os.Unsetenv(composeEnvFilesEnvVar)
+			}
+			loader := NewLoader(WithPath(composePath), WithEnvFiles(tt.envFiles...))
+			p, err := loader.LoadProject(t.Context())
+			if err != nil {
+				t.Fatal(err)
+			}
+			got := p.Services["web"].Environment["GREETING"]
+			if got == nil {
+				t.Fatal("environment variable GREETING not found")
+			}
+			assert.Equal(t, tt.expected, *got)
+		})
+	}
+}


### PR DESCRIPTION
Follow-up to #2178 (the `--env-file` / `COMPOSE_ENV_FILES` support).

## Problem

Setting `COMPOSE_ENV_FILES` in a `.defang` **stack file** (e.g. to select Bedrock model names when a stack targets AWS) had no effect on compose interpolation.

## Root cause — load ordering

The env-file list was resolved from `os.Getenv("COMPOSE_ENV_FILES")` **up front**, in `loaderOptionsForCommand`, while building `LoaderOptions`. But a stack file's variables aren't pushed into the process environment until later — `stacks.LoadStackEnv` (`os.Setenv`) runs during `LoadSession`, *after* the loader's env-file list has already been frozen. So the stack's `COMPOSE_ENV_FILES` was set in the environment too late to influence which files the loader reads.

The tell: **ordinary** stack variables interpolate fine, because interpolation reads the live environment at `LoadProject` time (which is after `LoadStackEnv`). `COMPOSE_ENV_FILES` is special — it selects *which files to load*, and that decision was made before the stack env existed.

## Fix (localized to the loader)

Resolve the `COMPOSE_ENV_FILES` fallback in `Loader.newProjectOptions` at project-load time, with an explicit `--env-file` as the override. This is symmetric to how `ConfigPaths` overrides `COMPOSE_FILE` via `cli.WithConfigFileEnv`, and because it reads the live environment *after* `LoadStackEnv`, a stack-scoped value now takes effect. It also fixes every loader construction site (`agent/common`, `generate.go`, `commands.go`), not just the session path.

`envFilesForCommand` now resolves only the `--env-file` flag; the env-var fallback moved into the loader. Precedence is unchanged: `--env-file` > `COMPOSE_ENV_FILES` (stack or ambient) > default `.env`.

## Known boundary

A stack's `COMPOSE_ENV_FILES` affects **service-level interpolation** but not **project-name resolution** — the stack is located/named via a loader built before its env is applied (chicken-and-egg). Also, because `LoadStackEnv` uses `overload=true`, a stack-file value overrides an ambient `COMPOSE_ENV_FILES`.

## Tests

- Moved the env-var / flag-precedence coverage from `session_test.go` to `loader_test.go`.
- Added `TestWithEnvFilesFromEnvVar`, a regression test that loads a real project and asserts the env-var path (the stack-injection path) drives interpolation, plus flag-overrides-env-var and default-`.env`.

`go test -short ./pkg/cli/compose/... ./cmd/cli/command/...` passes; `golangci-lint` clean on the changed packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sw7j9FYnbChZJbYArxbhuo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected environment file selection during project loading.
  * `--env-file` now takes precedence over `COMPOSE_ENV_FILES`.
  * When no explicit file is provided, `COMPOSE_ENV_FILES` is correctly used as a fallback.
  * Default `.env` behavior remains available when neither option is configured.

* **Tests**
  * Added coverage for explicit, environment-based, and default environment file precedence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->