### PR TITLE
fix(cli): address PR 2175 review — Azure managed-model support + OOM-default rationale

### DIFF
--- a/src/pkg/cli/compose/fixup.go
+++ b/src/pkg/cli/compose/fixup.go
@@ -248,9 +248,15 @@ func parsePortString(port string) (uint32, error) {
 }
 
 const (
-	liteLLMPort         uint32 = 4000
-	defaultLLMCPUs             = 0.5
-	defaultLLMMemoryMiB        = 512
+	liteLLMPort uint32 = 4000
+	// Default LiteLLM gateway reservations, applied only when the user sets none.
+	// With no reservations, GCP placed the gateway on an e2-micro (1 shared vCPU /
+	// 1 GiB burstable) where LiteLLM OOM'd during startup; 0.5 vCPU / 512 MiB is
+	// the smallest field-proven shape (selects e2-small on GCP and started/served
+	// in both GCP and AWS E2E). Explicit reservations are always preserved.
+	// Evidence: PR 2175 review discussion.
+	defaultLLMCPUs      = 0.5
+	defaultLLMMemoryMiB = 512
 )
 
 func fixupLLM(svccfg *composeTypes.ServiceConfig) {
@@ -465,6 +471,15 @@ func configureAccessGateway(svccfg *composeTypes.ServiceConfig, project *compose
 		if location != "" {
 			svccfg.Environment["VERTEXAI_LOCATION"] = &location
 		}
+	case client.ProviderAzure:
+		// Azure's managed-model provider (pulumi-defang defangazure) provisions an
+		// OpenAI-compatible AI Foundry account and creates a deployment named after
+		// the alias, picking the concrete model at deploy time from a region-aware
+		// preference list (models.go chatPreference/embeddingPreference). So unlike
+		// bedrock/vertex_ai we do NOT resolve or prefix the model here: the bare alias
+		// is wired to dependents as {SERVICE}_MODEL, which the provider uses as both
+		// the deployment name and the model routed to the OpenAI-compatible endpoint.
+		// The account key is injected as OPENAI_API_KEY by the provider.
 	}
 
 	// svccfg.HealthCheck = &composeTypes.ServiceHealthCheckConfig{} TODO: add healthcheck

--- a/src/pkg/cli/compose/fixup_test.go
+++ b/src/pkg/cli/compose/fixup_test.go
@@ -119,6 +119,31 @@ func TestMakeAccessGatewayServiceGCP(t *testing.T) {
 	})
 }
 
+func TestMakeAccessGatewayServiceAzure(t *testing.T) {
+	// Azure's managed-model provider names the deployment after the alias and
+	// selects the concrete model itself, so the CLI passes the bare alias through
+	// unchanged (no bedrock/vertex_ai-style resolution or prefix) and sets no
+	// provider-specific environment; the provider injects OPENAI_API_KEY.
+	info := &client.AccountInfo{
+		Provider:  client.ProviderAzure,
+		Region:    "eastus",
+		AccountID: "my-azure-sub",
+	}
+
+	for _, alias := range []string{"chat-default", "chat-large", "embedding-default", "some-custom-model"} {
+		t.Run(alias, func(t *testing.T) {
+			proj := &composeTypes.Project{Networks: map[string]composeTypes.NetworkConfig{}, Services: composeTypes.Services{}}
+			svccfg := newLLMService()
+			makeAccessGatewayService(&svccfg, proj, alias, info)
+
+			require.Equal(t, []string{"--drop_params", "--model", alias, "--alias", alias}, []string(svccfg.Command))
+			assert.NotContains(t, svccfg.Environment, "AWS_REGION")
+			assert.NotContains(t, svccfg.Environment, "VERTEXAI_PROJECT")
+			assert.NotContains(t, svccfg.Environment, "VERTEXAI_LOCATION")
+		})
+	}
+}
+
 func TestAccessGatewayChatLarge(t *testing.T) {
 	tests := []struct {
 		name         string


### PR DESCRIPTION
Addresses the outstanding review comments on #2175. Targets that PR's branch so it merges in rather than competing with it.

## Azure managed-model support
Follows up on the "Azure is missing" thread. Checking the `defangazure` provider (pulumi-defang) shows Azure works differently from bedrock/vertex_ai:

- the provider provisions an **OpenAI-compatible** AI Foundry account and creates a deployment **named after the alias** (`chat-default`/`chat-large`/`embedding-default`);
- it selects the **concrete model itself** at deploy time from a region-aware preference list (`models.go` `chatPreference`/`embeddingPreference`) and injects the key as `OPENAI_API_KEY`.

So the CLI should **not** hardcode Azure model IDs (that would duplicate and fight the provider's dynamic selection, and grow the independently-maintained catalog called out elsewhere in review). Instead it passes the **bare alias** through unchanged — that alias is wired to dependents as `{SERVICE}_MODEL`, which the provider uses as both the deployment name and the model routed to the OpenAI-compatible endpoint. Added as an explicit, documented `case client.ProviderAzure`.

## OOM default rationale
Documented why the default gateway reservation is 0.5 vCPU / 512 MiB (unset reservations landed on a GCP e2-micro where LiteLLM OOM'd; this is the smallest field-proven shape), per the review request for evidence.

## Tests
`TestMakeAccessGatewayServiceAzure` locks in bare-alias pass-through for all three aliases + a custom model, and asserts no AWS/GCP env leaks in.

Verified: `go build`, `go vet`, `go test ./pkg/cli/compose` (green), `gofmt` clean.

## Follow-up (not this PR)
On the provider side, `selectModelForAlias` only distinguishes chat vs embedding, so `chat-large` currently resolves to the same model as `chat-default` on Azure. Worth a separate pulumi-defang issue if distinct large/default tiers are wanted there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sw7j9FYnbChZJbYArxbhuo