### PR TITLE
fix(compose): update tests for applied chat-large suggestions

### DIFF
--- a/src/pkg/cli/compose/fixup.go
+++ b/src/pkg/cli/compose/fixup.go
@@ -248,7 +248,8 @@ func parsePortString(port string) (uint32, error) {
 }
 
 const (
-	liteLLMPort         uint32 = 4000
+	liteLLMPort uint32 = 4000
+
 	defaultLLMCPUs             = 0.5
 	defaultLLMMemoryMiB        = 1024 // 512 MiB OOMed during AWS E2E; use the next size up.
 )

--- a/src/pkg/cli/compose/fixup.go
+++ b/src/pkg/cli/compose/fixup.go
@@ -248,9 +248,9 @@ func parsePortString(port string) (uint32, error) {
 }
 
 const (
-	liteLLMPort         = 4000
-	defaultLLMCPUs      = 0.5
-	defaultLLMMemoryMiB = 1024 // 512 MiB OOMed during AWS E2E; use the next size up.
+	liteLLMPort         uint32 = 4000
+	defaultLLMCPUs             = 0.5
+	defaultLLMMemoryMiB        = 1024 // 512 MiB OOMed during AWS E2E; use the next size up.
 )
 
 func fixupLLM(svccfg *composeTypes.ServiceConfig) {

--- a/src/pkg/cli/compose/fixup_test.go
+++ b/src/pkg/cli/compose/fixup_test.go
@@ -151,7 +151,7 @@ func TestAccessGatewayChatLarge(t *testing.T) {
 		wantModel    string
 		wantLocation string
 	}{
-		{name: "AWS", provider: client.ProviderAWS, wantModel: "bedrock/us.anthropic.claude-sonnet-5"},
+		{name: "AWS", provider: client.ProviderAWS, wantModel: "bedrock/zai.glm-5"},
 		{name: "GCP", provider: client.ProviderGCP, wantModel: "vertex_ai/gemini-3.1-pro-preview", wantLocation: "global"},
 	}
 


### PR DESCRIPTION
Fixes the failing `go-test` job on #2175 (run 29750648577).

The **Apply suggestion from @lionello** commit applied two review suggestions but the unit tests were not updated to match, so `go test ./pkg/cli/compose` fails:

- **`TestAccessGatewayChatLarge/AWS`** — the AWS `chat-large` mapping was changed to `zai.glm-5`, but the test still expected `bedrock/us.anthropic.claude-sonnet-5`. Updated the expectation to `bedrock/zai.glm-5`.
- **`TestFixupLLM`** — the same commit reformatted the `const` block, which dropped the explicit `uint32` type on `liteLLMPort`. As an untyped constant it boxes to `int`, so `assert.Equal(t, liteLLMPort, svc.Ports[0].Target)` failed against the `uint32` `Target` field (`int(4000)` vs `uint32(0xfa0)`). Restored `liteLLMPort uint32 = 4000` — it feeds a `uint32 Target` and `var port uint32 = liteLLMPort`, so typing it is the semantically correct fix and keeps the test cast-free.

## Verification

- `go test -short ./pkg/cli/compose/` passes (previously failing `TestAccessGatewayChatLarge` and `TestFixupLLM` now green)
- `go vet` and `go build ./...` clean

`make lint` could not run in this environment (toolchain download failed); flagging per repo convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)