### PR TITLE
ci(nightly): skip build when no changes since last nightly

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -19,13 +19,44 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Skip the build when nothing has changed since the previous nightly.
+      # The nightly release publishes a lightweight `nightly` tag at the commit
+      # it was built from (see .goreleaser.yml). If HEAD is that same commit,
+      # there are no new commits to release. Manual runs always build.
+      - name: Check for changes since last nightly
+        id: check
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "Manual run; building regardless of changes."
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if git fetch --force origin 'refs/tags/nightly:refs/tags/nightly' 2>/dev/null; then
+            last_nightly="$(git rev-parse --verify 'nightly^{commit}')"
+            head_sha="$(git rev-parse --verify HEAD)"
+            echo "Last nightly commit: $last_nightly"
+            echo "Current HEAD:        $head_sha"
+            if [ "$last_nightly" = "$head_sha" ]; then
+              echo "No new commits since the last nightly; skipping build."
+              echo "changed=false" >> "$GITHUB_OUTPUT"
+            else
+              echo "changed=true" >> "$GITHUB_OUTPUT"
+            fi
+          else
+            echo "No existing nightly tag found; proceeding with build."
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
         # Get go
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        if: steps.check.outputs.changed == 'true'
         with:
           go-version-file: src/go.mod
           cache-dependency-path: src/go.sum
         # Execute goreleaser nightly run (see .goreleaser.yml nightly for details)
       - uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29 # v7
+        if: steps.check.outputs.changed == 'true'
         with:
           distribution: goreleaser-pro
           version: latest


### PR DESCRIPTION
## Problem

The Nightly Build workflow runs goreleaser every day at 6 AM UTC unconditionally, publishing a fresh nightly release even when nothing has landed on `main` since the previous run. That burns goreleaser-pro and CI minutes and churns the `nightly` release/tag for an identical artifact.

## Change

Add a `Check for changes since last nightly` step that compares `HEAD` against the commit the previous nightly was built from — the lightweight `nightly` tag that goreleaser publishes (`tag_name: nightly`, `keep_single_release: true` in `src/.goreleaser.yml`). When they match, the `setup-go` and `goreleaser` steps are skipped and the job succeeds as a no-op.

- Scheduled run, no new commits → skipped.
- Scheduled run, new commits → builds as before.
- No `nightly` tag yet (first run) → builds.
- Manual `workflow_dispatch` → always builds, so a maintainer can force a nightly on demand.

The `nightly` tag is the reliable signal here: the GitHub release's `target_commitish` is just `"main"`, whereas the tag resolves to the exact commit the last nightly was cut from.

The failure Slack notification is unchanged — a skip is a normal success and does not notify.

## Notes

Validated with `actionlint` (including shellcheck) — clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Nightly builds now run only when changes are detected since the previous nightly release.
  * Manually triggered nightly builds continue to run regardless of changes.
  * If no previous nightly tag exists, the build proceeds as usual.
  * Scheduled runs without changes skip unnecessary build and release steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->