### PR TITLE
fix(gcp): retry token refresh on transient 5xx from STS/token endpoint

### DIFF
--- a/src/pkg/clouds/gcp/tokensource.go
+++ b/src/pkg/clouds/gcp/tokensource.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net"
 	"net/url"
+	"strings"
 	"time"
 
 	"cloud.google.com/go/auth"
@@ -71,12 +72,53 @@ func isTransientTokenError(err error) bool {
 	if errors.As(err, &timeoutErr) && timeoutErr.Timeout() {
 		return true
 	}
+	// oauth2/google's AuthenticationError (and net errors) expose Temporary()
+	// for the retryable server-side statuses 500, 503, 408, 429.
+	var temporaryErr interface{ Temporary() bool }
+	if errors.As(err, &temporaryErr) && temporaryErr.Temporary() {
+		return true
+	}
+	// A standard OAuth2 token refresh (stored-credential path) surfaces a
+	// non-2xx from the token endpoint as a typed RetrieveError; retry the same
+	// server-side statuses.
+	var retrieveErr *oauth2.RetrieveError
+	if errors.As(err, &retrieveErr) && retrieveErr.Response != nil && isRetryableStatus(retrieveErr.Response.StatusCode) {
+		return true
+	}
 	var urlErr *url.Error
 	if errors.As(err, &urlErr) {
 		return true
 	}
 	var netOpErr *net.OpError
 	if errors.As(err, &netOpErr) {
+		return true
+	}
+	// STS / external-account token exchanges (Workload Identity Federation)
+	// report a non-2xx as a plain error ("...: status code 503: <body>") with no
+	// typed status, so match the retryable server-side codes on the message.
+	// This is the 503-from-fabric case that otherwise surfaces to in-flight RPCs
+	// as a fatal Unauthenticated during a deploy.
+	msg := err.Error()
+	for _, code := range retryableStatusMarkers {
+		if strings.Contains(msg, code) {
+			return true
+		}
+	}
+	return false
+}
+
+// retryableStatusMarkers are the message fragments the oauth2/auth libraries
+// emit for server-side statuses worth retrying (500, 503, 408, 429).
+var retryableStatusMarkers = []string{
+	"status code 500",
+	"status code 503",
+	"status code 408",
+	"status code 429",
+}
+
+func isRetryableStatus(code int) bool {
+	switch code {
+	case 500, 503, 408, 429:
 		return true
 	}
 	return false

--- a/src/pkg/clouds/gcp/tokensource_test.go
+++ b/src/pkg/clouds/gcp/tokensource_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net"
+	"net/http"
 	"net/url"
 	"testing"
 	"time"
@@ -78,6 +79,25 @@ func TestRetryingTokenSource_GivesUpAfterMaxAttempts(t *testing.T) {
 	}
 }
 
+func TestRetryingTokenSource_RetriesOnServerError503(t *testing.T) {
+	want := &oauth2.Token{AccessToken: "ok"}
+	// A transient 503 from the STS/token endpoint arrives as a plain string error.
+	transient := errors.New("credentials: status code 503: upstream connect error")
+	stub := newStub(want, transient)
+
+	r := &retryingTokenSource{inner: stub, sleep: func(time.Duration) {}}
+	got, err := r.Token()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != want {
+		t.Errorf("got %+v, want %+v", got, want)
+	}
+	if stub.calls != 2 {
+		t.Errorf("inner.Token called %d times, want 2", stub.calls)
+	}
+}
+
 func TestRetryingTokenSource_DoesNotRetryPermanent(t *testing.T) {
 	perm := errors.New("invalid_grant: refresh token expired")
 	stub := newStub(nil, perm)
@@ -106,6 +126,17 @@ func TestIsTransientTokenError(t *testing.T) {
 		{"net op error", &net.OpError{Op: "dial", Err: errors.New("connection refused")}, true},
 		{"url error wrapping plain", &url.Error{Op: "Post", URL: "https://x", Err: errors.New("EOF")}, true},
 		{"permanent oauth", errors.New("invalid_grant"), false},
+		// STS / external-account exchange (WIF) reports a plain "status code N" error.
+		{"sts 503 string", errors.New("oauth2/google: status code 503: upstream connect error"), true},
+		{"auth 503 string", errors.New("credentials: status code 503: upstream connect error or disconnect/reset before headers"), true},
+		{"sts 429 string", errors.New("oauth2/google: status code 429: rate limited"), true},
+		{"sts 408 string", errors.New("oauth2/google: status code 408: request timeout"), true},
+		{"sts 400 string not retried", errors.New("oauth2/google: status code 400: invalid_request"), false},
+		{"sts 401 string not retried", errors.New("credentials: status code 401: unauthorized"), false},
+		// Standard OAuth2 refresh surfaces non-2xx as a typed RetrieveError.
+		{"retrieve error 503", &oauth2.RetrieveError{Response: &http.Response{StatusCode: 503}}, true},
+		{"retrieve error 429", &oauth2.RetrieveError{Response: &http.Response{StatusCode: 429}}, true},
+		{"retrieve error 400", &oauth2.RetrieveError{Response: &http.Response{StatusCode: 400}}, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## What

`retryingTokenSource` (added so a slow token refresh doesn't surface to in-flight RPCs as a fatal `Unauthenticated` during long deploys) only retried context deadlines, net errors, and timeouts. A **5xx / 429 / 408 response** from the STS / OAuth2 token endpoint — e.g. a `503 upstream connect error` from the fabric front door while refreshing per-RPC credentials mid-deploy — was classified as **permanent**, so the retry loop gave up immediately and the error propagated as a fatal `Unauthenticated`. That's the exact failure mode `wrapTokenSource` exists to prevent.

## Change

`isTransientTokenError` now recognizes the retryable server-side statuses (500, 503, 408, 429) across the three shapes the oauth2/auth libraries produce:

| Path | Error shape | Caught by |
|------|-------------|-----------|
| Standard OAuth2 refresh (stored creds) | typed `*oauth2.RetrieveError` | `Response.StatusCode` check |
| `oauth2/google` AuthenticationError / net | `Temporary() bool` | interface assertion |
| STS / external-account exchange (WIF) | plain `"...: status code 503: <body>"` | message-marker match |

## Relationship to the cloudbuild poll-layer fix (#2184)

These are complementary, not duplicates:

- **CI** deploys authenticate via **ADC** (`google-github-actions/auth` sets `GOOGLE_APPLICATION_CREDENTIALS`). The gcp SDK drives ADC through its own `cloud.google.com/go/auth` credentials and **bypasses this `wrapTokenSource` wrapper entirely** — so the CI smoketest failure that started this is covered by the poll-layer retry in #2184, not here.
- **This** change covers the **local** interactive / stored-credential deploy paths, which *do* flow through `retryingTokenSource` — the scenario in the original report (#2018 was a local `defang compose up`, not CI).

## Tests

- `TestRetryingTokenSource_RetriesOnServerError503` — recovers after a 503-string retry
- `TestIsTransientTokenError` — extended: 503/429/408 strings and typed RetrieveErrors are transient; 400/401 are not

`go test -short ./pkg/clouds/gcp/`, `go vet`, `gofmt`, and `golangci-lint` (on changed files) all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sw7j9FYnbChZJbYArxbhuo