### PR TITLE
feat(compose): load .env.<provider> and .env.<stack> by convention

### DIFF
--- a/src/pkg/cli/compose/loader.go
+++ b/src/pkg/cli/compose/loader.go
@@ -40,11 +40,11 @@ type LoaderOptions struct {
 	ConfigPaths []string
 	ProjectName string
 	EnvFiles    []string
-	// EnvFileSuffixes selects env files by convention when no env file was set
-	// explicitly (via EnvFiles or COMPOSE_ENV_FILES): the default .env plus one
-	// .env.<suffix> per entry (e.g. the stack's provider and name), in order,
-	// so later files override earlier ones. Files that don't exist are skipped.
-	EnvFileSuffixes []string
+	// DefaultEnvFiles are candidate env files (names resolved against the project
+	// working directory) tried when no env file was set explicitly (via EnvFiles
+	// or COMPOSE_ENV_FILES). Files that don't exist are skipped, and later files
+	// override earlier ones. Unlike EnvFiles, these never fail on a missing file.
+	DefaultEnvFiles []string
 }
 
 type Loader struct {
@@ -172,11 +172,10 @@ func (l *Loader) newProjectOptions(suppressWarn bool) (*cli.ProjectOptions, erro
 			envFiles = strings.Split(v, ",")
 		}
 	}
-	// Only when no env file was set explicitly, fall back to the convention-based
-	// default env files (.env plus .env.<provider>/.env.<stack>).
+	// Only when no env file was set explicitly, fall back to the default env files.
 	withEnvFiles := cli.WithEnvFiles(envFiles...)
-	if len(envFiles) == 0 && len(l.options.EnvFileSuffixes) > 0 {
-		withEnvFiles = withDefaultEnvFiles(l.options.EnvFileSuffixes)
+	if len(envFiles) == 0 && len(l.options.DefaultEnvFiles) > 0 {
+		withEnvFiles = withDefaultEnvFiles(l.options.DefaultEnvFiles)
 	}
 
 	// Based on how docker compose setup its own project options
@@ -239,11 +238,11 @@ func (l *Loader) newProjectOptions(suppressWarn bool) (*cli.ProjectOptions, erro
 	)
 }
 
-// withDefaultEnvFiles selects env files by convention: the default .env plus one
-// .env.<suffix> per suffix, in order, so later files override earlier ones.
-// Unlike explicit --env-file values, files that don't exist are skipped,
-// mirroring how compose-go treats the default .env (see cli.WithEnvFiles).
-func withDefaultEnvFiles(suffixes []string) cli.ProjectOptionsFn {
+// withDefaultEnvFiles selects the env files from the given candidate names,
+// resolved against the project working directory, so later files override
+// earlier ones. Unlike explicit --env-file values, files that don't exist are
+// skipped, mirroring how compose-go treats the default .env (see cli.WithEnvFiles).
+func withDefaultEnvFiles(names []string) cli.ProjectOptionsFn {
 	return func(o *cli.ProjectOptions) error {
 		if v, ok := os.LookupEnv(consts.ComposeDisableDefaultEnvFile); ok {
 			if disabled, err := strconv.ParseBool(v); err != nil {
@@ -257,12 +256,8 @@ func withDefaultEnvFiles(suffixes []string) cli.ProjectOptionsFn {
 		if err != nil {
 			return err
 		}
-		names := []string{".env"}
-		for _, suffix := range suffixes {
-			names = append(names, ".env."+suffix)
-		}
 		var envFiles []string
-		for _, name := range slices.Compact(names) { // dedupe e.g. a stack named after its provider
+		for _, name := range slices.Compact(slices.Clone(names)) { // dedupe e.g. a stack named after its provider
 			path := filepath.Join(wd, name)
 			if s, err := os.Stat(path); err == nil && !s.IsDir() {
 				envFiles = append(envFiles, path)

--- a/src/pkg/cli/compose/loader.go
+++ b/src/pkg/cli/compose/loader.go
@@ -8,12 +8,14 @@ import (
 	"path/filepath"
 	"regexp"
 	"slices"
+	"strconv"
 	"strings"
 
 	"github.com/DefangLabs/defang/src/pkg/logs"
 	"github.com/DefangLabs/defang/src/pkg/term"
 	"github.com/DefangLabs/defang/src/pkg/types"
 	"github.com/compose-spec/compose-go/v2/cli"
+	"github.com/compose-spec/compose-go/v2/consts"
 	"github.com/compose-spec/compose-go/v2/errdefs"
 	"github.com/compose-spec/compose-go/v2/loader"
 	"github.com/compose-spec/compose-go/v2/template"
@@ -38,6 +40,11 @@ type LoaderOptions struct {
 	ConfigPaths []string
 	ProjectName string
 	EnvFiles    []string
+	// EnvFileSuffixes selects env files by convention when no env file was set
+	// explicitly (via EnvFiles or COMPOSE_ENV_FILES): the default .env plus one
+	// .env.<suffix> per entry (e.g. the stack's provider and name), in order,
+	// so later files override earlier ones. Files that don't exist are skipped.
+	EnvFileSuffixes []string
 }
 
 type Loader struct {
@@ -165,6 +172,12 @@ func (l *Loader) newProjectOptions(suppressWarn bool) (*cli.ProjectOptions, erro
 			envFiles = strings.Split(v, ",")
 		}
 	}
+	// Only when no env file was set explicitly, fall back to the convention-based
+	// default env files (.env plus .env.<provider>/.env.<stack>).
+	withEnvFiles := cli.WithEnvFiles(envFiles...)
+	if len(envFiles) == 0 && len(l.options.EnvFileSuffixes) > 0 {
+		withEnvFiles = withDefaultEnvFiles(l.options.EnvFileSuffixes)
+	}
 
 	// Based on how docker compose setup its own project options
 	// https://github.com/docker/compose/blob/1a14fcb1e6645dd92f5a4f2da00071bd59c2e887/cmd/compose/compose.go#L326-L346
@@ -172,8 +185,8 @@ func (l *Loader) newProjectOptions(suppressWarn bool) (*cli.ProjectOptions, erro
 		// First apply os.Environment, always win
 		// -- DISABLED FOR DEFANG -- cli.WithOsEnv,
 		cli.WithEnv(onlyComposeEnv),
-		// Load the explicit --env-file(s), or PWD/.env if none were set
-		cli.WithEnvFiles(envFiles...),
+		// Load the explicit --env-file(s), or the convention-based/default .env files if none were set
+		withEnvFiles,
 		// read dot env file to populate project environment
 		cli.WithDotEnv,
 		// get compose file path set by COMPOSE_FILE
@@ -182,7 +195,7 @@ func (l *Loader) newProjectOptions(suppressWarn bool) (*cli.ProjectOptions, erro
 		cli.WithDefaultConfigPath,
 		// Calling the 2 functions below the 2nd time as the loaded env in first call modifies the behavior of the 2nd call:
 		// .. and then, a project directory != PWD maybe has been set so let's load .env file
-		cli.WithEnvFiles(envFiles...),
+		withEnvFiles,
 		cli.WithDotEnv,
 		// eventually COMPOSE_PROFILES should have been set
 		// cli.WithDefaultProfiles(c.Profiles...), TODO: Support --profile to be added as param to this call
@@ -224,6 +237,40 @@ func (l *Loader) newProjectOptions(suppressWarn bool) (*cli.ProjectOptions, erro
 			}
 		}),
 	)
+}
+
+// withDefaultEnvFiles selects env files by convention: the default .env plus one
+// .env.<suffix> per suffix, in order, so later files override earlier ones.
+// Unlike explicit --env-file values, files that don't exist are skipped,
+// mirroring how compose-go treats the default .env (see cli.WithEnvFiles).
+func withDefaultEnvFiles(suffixes []string) cli.ProjectOptionsFn {
+	return func(o *cli.ProjectOptions) error {
+		if v, ok := os.LookupEnv(consts.ComposeDisableDefaultEnvFile); ok {
+			if disabled, err := strconv.ParseBool(v); err != nil {
+				return err
+			} else if disabled {
+				return nil
+			}
+		}
+
+		wd, err := o.GetWorkingDir()
+		if err != nil {
+			return err
+		}
+		names := []string{".env"}
+		for _, suffix := range suffixes {
+			names = append(names, ".env."+suffix)
+		}
+		var envFiles []string
+		for _, name := range slices.Compact(names) { // dedupe e.g. a stack named after its provider
+			path := filepath.Join(wd, name)
+			if s, err := os.Stat(path); err == nil && !s.IsDir() {
+				envFiles = append(envFiles, path)
+			}
+		}
+		o.EnvFiles = envFiles
+		return nil
+	}
 }
 
 func hasSubstitution(s, key string) bool {

--- a/src/pkg/cli/compose/loader.go
+++ b/src/pkg/cli/compose/loader.go
@@ -259,7 +259,14 @@ func withDefaultEnvFiles(names []string) cli.ProjectOptionsFn {
 		var envFiles []string
 		for _, name := range slices.Compact(slices.Clone(names)) { // dedupe e.g. a stack named after its provider
 			path := filepath.Join(wd, name)
-			if s, err := os.Stat(path); err == nil && !s.IsDir() {
+			s, err := os.Stat(path)
+			if err != nil {
+				if errors.Is(err, os.ErrNotExist) {
+					continue // missing default env files are optional
+				}
+				return fmt.Errorf("default env file: %w", err)
+			}
+			if !s.IsDir() {
 				envFiles = append(envFiles, path)
 			}
 		}

--- a/src/pkg/cli/compose/loader_test.go
+++ b/src/pkg/cli/compose/loader_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/DefangLabs/defang/src/pkg"
+	"github.com/compose-spec/compose-go/v2/cli"
 	"github.com/compose-spec/compose-go/v2/types"
 	"github.com/stretchr/testify/assert"
 )
@@ -186,6 +187,138 @@ services:
 			}
 		})
 	}
+}
+
+// TestEnvFileSuffixes covers the convention-based env files: when no env file
+// is set explicitly (--env-file or COMPOSE_ENV_FILES), the loader layers .env
+// and one .env.<suffix> per EnvFileSuffixes entry (e.g. the stack's provider
+// and name), later files overriding earlier ones. Missing files are skipped.
+func TestEnvFileSuffixes(t *testing.T) {
+	const composeYAML = `name: envsuffixtest
+services:
+  web:
+    image: alpine
+    environment:
+      - BASE=${BASE}
+      - GREETING=${GREETING}
+      - SOURCE=${SOURCE}
+`
+	dir := t.TempDir()
+	writeFile := func(name, content string) string {
+		t.Helper()
+		p := filepath.Join(dir, name)
+		if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		return p
+	}
+
+	composePath := writeFile("compose.yaml", composeYAML)
+	writeFile(".env", "BASE=from_dotenv\nGREETING=from_dotenv\nSOURCE=from_dotenv\n")
+	writeFile(".env.aws", "GREETING=from_aws\nSOURCE=from_aws\n")
+	writeFile(".env.mystack", "SOURCE=from_mystack\n")
+	flagEnv := writeFile("flag.env", "GREETING=from_flag\n")
+
+	// A sibling project without a base .env to verify suffix files load on their own.
+	noDotenvDir := t.TempDir()
+	noDotenvCompose := filepath.Join(noDotenvDir, "compose.yaml")
+	if err := os.WriteFile(noDotenvCompose, []byte(composeYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(noDotenvDir, ".env.mystack"), []byte("SOURCE=from_mystack\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name           string
+		composePath    string   // defaults to composePath
+		envFiles       []string // explicit --env-file (LoaderOptions.EnvFiles)
+		envVar         string   // COMPOSE_ENV_FILES; "" means unset
+		suffixes       []string
+		disableEnvFile bool // COMPOSE_DISABLE_ENV_FILE
+		expected       map[string]string
+	}{
+		{
+			name:     "suffix files layer over .env, most specific wins",
+			suffixes: []string{"aws", "mystack"},
+			expected: map[string]string{"BASE": "from_dotenv", "GREETING": "from_aws", "SOURCE": "from_mystack"},
+		},
+		{
+			name:     "missing suffix files are skipped",
+			suffixes: []string{"gcp", "mystack"},
+			expected: map[string]string{"BASE": "from_dotenv", "GREETING": "from_dotenv", "SOURCE": "from_mystack"},
+		},
+		{
+			name:        "suffix files load even without a base .env",
+			composePath: noDotenvCompose,
+			suffixes:    []string{"aws", "mystack"},
+			expected:    map[string]string{"BASE": "${BASE}", "GREETING": "${GREETING}", "SOURCE": "from_mystack"},
+		},
+		{
+			name:     "explicit env-file overrides the convention",
+			envFiles: []string{flagEnv},
+			suffixes: []string{"aws", "mystack"},
+			expected: map[string]string{"BASE": "${BASE}", "GREETING": "from_flag", "SOURCE": "${SOURCE}"},
+		},
+		{
+			name:     "COMPOSE_ENV_FILES overrides the convention",
+			envVar:   flagEnv,
+			suffixes: []string{"aws", "mystack"},
+			expected: map[string]string{"BASE": "${BASE}", "GREETING": "from_flag", "SOURCE": "${SOURCE}"},
+		},
+		{
+			name:           "COMPOSE_DISABLE_ENV_FILE disables the convention",
+			suffixes:       []string{"aws", "mystack"},
+			disableEnvFile: true,
+			expected:       map[string]string{"BASE": "${BASE}", "GREETING": "${GREETING}", "SOURCE": "${SOURCE}"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.envVar != "" {
+				t.Setenv(composeEnvFilesEnvVar, tt.envVar)
+			} else {
+				os.Unsetenv(composeEnvFilesEnvVar)
+			}
+			if tt.disableEnvFile {
+				t.Setenv("COMPOSE_DISABLE_ENV_FILE", "1")
+			}
+			path := tt.composePath
+			if path == "" {
+				path = composePath
+			}
+			loader := NewLoaderFromOptions(LoaderOptions{
+				ConfigPaths:     []string{path},
+				EnvFiles:        tt.envFiles,
+				EnvFileSuffixes: tt.suffixes,
+			})
+			p, err := loader.LoadProject(t.Context())
+			if err != nil {
+				t.Fatal(err)
+			}
+			env := p.Services["web"].Environment
+			for k, want := range tt.expected {
+				got := env[k]
+				if got == nil {
+					t.Errorf("environment variable %q not found", k)
+					continue
+				}
+				assert.Equal(t, want, *got, "environment variable %q", k)
+			}
+		})
+	}
+
+	t.Run("duplicate suffixes are deduped", func(t *testing.T) {
+		// e.g. a stack named after its provider; the shared file must be loaded once
+		fn := withDefaultEnvFiles([]string{"aws", "aws"})
+		o := &cli.ProjectOptions{WorkingDir: dir}
+		if err := fn(o); err != nil {
+			t.Fatal(err)
+		}
+		expected := []string{filepath.Join(dir, ".env"), filepath.Join(dir, ".env.aws")}
+		assert.Equal(t, expected, o.EnvFiles)
+	})
 }
 
 // TestWithEnvFilesFromEnvVar covers the COMPOSE_ENV_FILES fallback. This is the

--- a/src/pkg/cli/compose/loader_test.go
+++ b/src/pkg/cli/compose/loader_test.go
@@ -189,12 +189,12 @@ services:
 	}
 }
 
-// TestEnvFileSuffixes covers the convention-based env files: when no env file
-// is set explicitly (--env-file or COMPOSE_ENV_FILES), the loader layers .env
-// and one .env.<suffix> per EnvFileSuffixes entry (e.g. the stack's provider
-// and name), later files overriding earlier ones. Missing files are skipped.
-func TestEnvFileSuffixes(t *testing.T) {
-	const composeYAML = `name: envsuffixtest
+// TestDefaultEnvFiles covers the convention-based env files: when no env file
+// is set explicitly (--env-file or COMPOSE_ENV_FILES), the loader layers the
+// DefaultEnvFiles candidates (e.g. .env, .env.<provider>, .env.<stack>), later
+// files overriding earlier ones. Missing files are skipped.
+func TestDefaultEnvFiles(t *testing.T) {
+	const composeYAML = `name: envdefaultstest
 services:
   web:
     image: alpine
@@ -219,7 +219,7 @@ services:
 	writeFile(".env.mystack", "SOURCE=from_mystack\n")
 	flagEnv := writeFile("flag.env", "GREETING=from_flag\n")
 
-	// A sibling project without a base .env to verify suffix files load on their own.
+	// A sibling project without a base .env to verify the other default env files load on their own.
 	noDotenvDir := t.TempDir()
 	noDotenvCompose := filepath.Join(noDotenvDir, "compose.yaml")
 	if err := os.WriteFile(noDotenvCompose, []byte(composeYAML), 0o644); err != nil {
@@ -234,41 +234,41 @@ services:
 		composePath    string   // defaults to composePath
 		envFiles       []string // explicit --env-file (LoaderOptions.EnvFiles)
 		envVar         string   // COMPOSE_ENV_FILES; "" means unset
-		suffixes       []string
+		defaultFiles   []string
 		disableEnvFile bool // COMPOSE_DISABLE_ENV_FILE
 		expected       map[string]string
 	}{
 		{
-			name:     "suffix files layer over .env, most specific wins",
-			suffixes: []string{"aws", "mystack"},
-			expected: map[string]string{"BASE": "from_dotenv", "GREETING": "from_aws", "SOURCE": "from_mystack"},
+			name:         "default env files layer, most specific wins",
+			defaultFiles: []string{".env", ".env.aws", ".env.mystack"},
+			expected:     map[string]string{"BASE": "from_dotenv", "GREETING": "from_aws", "SOURCE": "from_mystack"},
 		},
 		{
-			name:     "missing suffix files are skipped",
-			suffixes: []string{"gcp", "mystack"},
-			expected: map[string]string{"BASE": "from_dotenv", "GREETING": "from_dotenv", "SOURCE": "from_mystack"},
+			name:         "missing default env files are skipped",
+			defaultFiles: []string{".env", ".env.gcp", ".env.mystack"},
+			expected:     map[string]string{"BASE": "from_dotenv", "GREETING": "from_dotenv", "SOURCE": "from_mystack"},
 		},
 		{
-			name:        "suffix files load even without a base .env",
-			composePath: noDotenvCompose,
-			suffixes:    []string{"aws", "mystack"},
-			expected:    map[string]string{"BASE": "${BASE}", "GREETING": "${GREETING}", "SOURCE": "from_mystack"},
+			name:         "stack env file loads even without a base .env",
+			composePath:  noDotenvCompose,
+			defaultFiles: []string{".env", ".env.aws", ".env.mystack"},
+			expected:     map[string]string{"BASE": "${BASE}", "GREETING": "${GREETING}", "SOURCE": "from_mystack"},
 		},
 		{
-			name:     "explicit env-file overrides the convention",
-			envFiles: []string{flagEnv},
-			suffixes: []string{"aws", "mystack"},
-			expected: map[string]string{"BASE": "${BASE}", "GREETING": "from_flag", "SOURCE": "${SOURCE}"},
+			name:         "explicit env-file overrides the convention",
+			envFiles:     []string{flagEnv},
+			defaultFiles: []string{".env", ".env.aws", ".env.mystack"},
+			expected:     map[string]string{"BASE": "${BASE}", "GREETING": "from_flag", "SOURCE": "${SOURCE}"},
 		},
 		{
-			name:     "COMPOSE_ENV_FILES overrides the convention",
-			envVar:   flagEnv,
-			suffixes: []string{"aws", "mystack"},
-			expected: map[string]string{"BASE": "${BASE}", "GREETING": "from_flag", "SOURCE": "${SOURCE}"},
+			name:         "COMPOSE_ENV_FILES overrides the convention",
+			envVar:       flagEnv,
+			defaultFiles: []string{".env", ".env.aws", ".env.mystack"},
+			expected:     map[string]string{"BASE": "${BASE}", "GREETING": "from_flag", "SOURCE": "${SOURCE}"},
 		},
 		{
 			name:           "COMPOSE_DISABLE_ENV_FILE disables the convention",
-			suffixes:       []string{"aws", "mystack"},
+			defaultFiles:   []string{".env", ".env.aws", ".env.mystack"},
 			disableEnvFile: true,
 			expected:       map[string]string{"BASE": "${BASE}", "GREETING": "${GREETING}", "SOURCE": "${SOURCE}"},
 		},
@@ -291,7 +291,7 @@ services:
 			loader := NewLoaderFromOptions(LoaderOptions{
 				ConfigPaths:     []string{path},
 				EnvFiles:        tt.envFiles,
-				EnvFileSuffixes: tt.suffixes,
+				DefaultEnvFiles: tt.defaultFiles,
 			})
 			p, err := loader.LoadProject(t.Context())
 			if err != nil {
@@ -309,9 +309,9 @@ services:
 		})
 	}
 
-	t.Run("duplicate suffixes are deduped", func(t *testing.T) {
+	t.Run("duplicate names are deduped", func(t *testing.T) {
 		// e.g. a stack named after its provider; the shared file must be loaded once
-		fn := withDefaultEnvFiles([]string{"aws", "aws"})
+		fn := withDefaultEnvFiles([]string{".env", ".env.aws", ".env.aws"})
 		o := &cli.ProjectOptions{WorkingDir: dir}
 		if err := fn(o); err != nil {
 			t.Fatal(err)

--- a/src/pkg/cli/compose/loader_test.go
+++ b/src/pkg/cli/compose/loader_test.go
@@ -309,6 +309,20 @@ services:
 		})
 	}
 
+	t.Run("stat errors other than not-exist are returned", func(t *testing.T) {
+		if os.Getuid() == 0 {
+			t.Skip("root ignores directory permissions")
+		}
+		unreadable := filepath.Join(t.TempDir(), "unreadable")
+		if err := os.Mkdir(unreadable, 0o000); err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { _ = os.Chmod(unreadable, 0o755) }) // let TempDir cleanup succeed
+		fn := withDefaultEnvFiles([]string{".env"})
+		err := fn(&cli.ProjectOptions{WorkingDir: unreadable})
+		assert.ErrorContains(t, err, "default env file")
+	})
+
 	t.Run("duplicate names are deduped", func(t *testing.T) {
 		// e.g. a stack named after its provider; the shared file must be loaded once
 		fn := withDefaultEnvFiles([]string{".env", ".env.aws", ".env.aws"})

--- a/src/pkg/session/session.go
+++ b/src/pkg/session/session.go
@@ -53,7 +53,7 @@ func (sl *SessionLoader) LoadSession(ctx context.Context) (*Session, error) {
 	// load provider with selected stack
 	provider := cli.NewProvider(ctx, stack.Provider, sl.client, stack.Name)
 	loaderOptions := sl.opts.LoaderOptions
-	loaderOptions.EnvFileSuffixes = stackEnvFileSuffixes(stack)
+	loaderOptions.DefaultEnvFiles = stackEnvFiles(stack)
 	session := &Session{
 		Stack:    stack,
 		Loader:   compose.NewLoaderFromOptions(loaderOptions),
@@ -91,18 +91,18 @@ func (sl *SessionLoader) loadStack(ctx context.Context) (*stacks.Parameters, str
 	return stack, whence, nil
 }
 
-// stackEnvFileSuffixes returns the env-file suffixes for the selected stack:
-// provider first, then stack name, so the more specific .env.<stack> file
-// overrides .env.<provider> (which in turn overrides the plain .env).
-func stackEnvFileSuffixes(stack *stacks.Parameters) []string {
-	var suffixes []string
+// stackEnvFiles returns the env files loaded by convention for the selected
+// stack: .env, then .env.<provider>, then .env.<stack>, so the more specific
+// file overrides the more generic ones.
+func stackEnvFiles(stack *stacks.Parameters) []string {
+	envFiles := []string{".env"}
 	if stack.Provider != "" && stack.Provider != client.ProviderAuto {
-		suffixes = append(suffixes, stack.Provider.String())
+		envFiles = append(envFiles, ".env."+stack.Provider.String())
 	}
 	if stack.Name != "" {
-		suffixes = append(suffixes, stack.Name)
+		envFiles = append(envFiles, ".env."+stack.Name)
 	}
-	return suffixes
+	return envFiles
 }
 
 func printProviderMismatchWarnings(ctx context.Context, provider client.ProviderID) {

--- a/src/pkg/session/session.go
+++ b/src/pkg/session/session.go
@@ -52,9 +52,11 @@ func (sl *SessionLoader) LoadSession(ctx context.Context) (*Session, error) {
 	}
 	// load provider with selected stack
 	provider := cli.NewProvider(ctx, stack.Provider, sl.client, stack.Name)
+	loaderOptions := sl.opts.LoaderOptions
+	loaderOptions.EnvFileSuffixes = stackEnvFileSuffixes(stack)
 	session := &Session{
 		Stack:    stack,
-		Loader:   compose.NewLoaderFromOptions(sl.opts.LoaderOptions),
+		Loader:   compose.NewLoaderFromOptions(loaderOptions),
 		Provider: provider,
 	}
 
@@ -87,6 +89,20 @@ func (sl *SessionLoader) loadStack(ctx context.Context) (*stacks.Parameters, str
 		return nil, whence, fmt.Errorf("failed to load stack env: %w", err)
 	}
 	return stack, whence, nil
+}
+
+// stackEnvFileSuffixes returns the env-file suffixes for the selected stack:
+// provider first, then stack name, so the more specific .env.<stack> file
+// overrides .env.<provider> (which in turn overrides the plain .env).
+func stackEnvFileSuffixes(stack *stacks.Parameters) []string {
+	var suffixes []string
+	if stack.Provider != "" && stack.Provider != client.ProviderAuto {
+		suffixes = append(suffixes, stack.Provider.String())
+	}
+	if stack.Name != "" {
+		suffixes = append(suffixes, stack.Name)
+	}
+	return suffixes
 }
 
 func printProviderMismatchWarnings(ctx context.Context, provider client.ProviderID) {

--- a/src/pkg/session/session_test.go
+++ b/src/pkg/session/session_test.go
@@ -65,6 +65,26 @@ func (m *mockStacksManager) TargetDirectory() string {
 	return ""
 }
 
+func TestStackEnvFileSuffixes(t *testing.T) {
+	tests := []struct {
+		name     string
+		stack    stacks.Parameters
+		expected []string
+	}{
+		{"provider then stack name", stacks.Parameters{Name: "mystack", Provider: client.ProviderAWS}, []string{"aws", "mystack"}},
+		{"auto provider is skipped", stacks.Parameters{Name: "mystack", Provider: client.ProviderAuto}, []string{"mystack"}},
+		{"empty provider is skipped", stacks.Parameters{Name: "mystack"}, []string{"mystack"}},
+		{"empty stack name is skipped", stacks.Parameters{Provider: client.ProviderGCP}, []string{"gcp"}},
+		{"empty stack", stacks.Parameters{}, nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, stackEnvFileSuffixes(&tt.stack))
+		})
+	}
+}
+
 func TestPrintProviderMismatchWarnings(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/src/pkg/session/session_test.go
+++ b/src/pkg/session/session_test.go
@@ -65,22 +65,22 @@ func (m *mockStacksManager) TargetDirectory() string {
 	return ""
 }
 
-func TestStackEnvFileSuffixes(t *testing.T) {
+func TestStackEnvFiles(t *testing.T) {
 	tests := []struct {
 		name     string
 		stack    stacks.Parameters
 		expected []string
 	}{
-		{"provider then stack name", stacks.Parameters{Name: "mystack", Provider: client.ProviderAWS}, []string{"aws", "mystack"}},
-		{"auto provider is skipped", stacks.Parameters{Name: "mystack", Provider: client.ProviderAuto}, []string{"mystack"}},
-		{"empty provider is skipped", stacks.Parameters{Name: "mystack"}, []string{"mystack"}},
-		{"empty stack name is skipped", stacks.Parameters{Provider: client.ProviderGCP}, []string{"gcp"}},
-		{"empty stack", stacks.Parameters{}, nil},
+		{"provider then stack name", stacks.Parameters{Name: "mystack", Provider: client.ProviderAWS}, []string{".env", ".env.aws", ".env.mystack"}},
+		{"auto provider is skipped", stacks.Parameters{Name: "mystack", Provider: client.ProviderAuto}, []string{".env", ".env.mystack"}},
+		{"empty provider is skipped", stacks.Parameters{Name: "mystack"}, []string{".env", ".env.mystack"}},
+		{"empty stack name is skipped", stacks.Parameters{Provider: client.ProviderGCP}, []string{".env", ".env.gcp"}},
+		{"empty stack", stacks.Parameters{}, []string{".env"}},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.expected, stackEnvFileSuffixes(&tt.stack))
+			assert.Equal(t, tt.expected, stackEnvFiles(&tt.stack))
 		})
 	}
 }


### PR DESCRIPTION
## What

When deploying with a stack and no explicit env file, the compose loader now layers convention-based env files, later files overriding earlier ones:

1. `.env` (base, as today)
2. `.env.<provider>` — e.g. `.env.aws`, shared across all stacks on that provider
3. `.env.<stack>` — e.g. `.env.mystack`, most specific, wins

Each file is optional and silently skipped when missing (softfail), mirroring how compose-go treats the default `.env`.

## Precedence (most explicit wins)

1. `--env-file` flag(s) — replace everything, docker compose semantics
2. `COMPOSE_ENV_FILES` (incl. set via stack file) — replace everything
3. The convention chain above (only when a stack is selected)

`COMPOSE_DISABLE_ENV_FILE` disables the convention along with the default `.env`.

## Why layer instead of replace?

Prior art strongly favors layering with most-specific-wins: Vite/Next.js/Symfony/Rails all load both `.env` and `.env.[mode]` with the mode file overriding. Kamal replaces, but had to invent a separate `secrets-common` file to get sharing back — evidence that pure replace is painful. Layering means shared vars live in `.env` once, per-cloud tweaks in `.env.<provider>`, per-stack overrides in `.env.<stack>`.

## Implementation notes

- `compose.LoaderOptions.DefaultEnvFiles` takes the full candidate file names (base `.env` explicit, not implied), so the loader stays agnostic of the naming convention; the session layer builds `.env`/`.env.<provider>`/`.env.<stack>` from the resolved stack (`auto`/empty skipped). Commands orchestrate, session selects stacks, compose loads — no cross-package invariants.
- The candidates are applied as a compose-go `ProjectOptionsFn` placed exactly where `cli.WithEnvFiles` sits today (both call sites of the double-load dance), so files resolve against the project working directory the same way the default `.env` does.
- Duplicate names (a stack named after its provider, e.g. stack `aws` on AWS) are deduped so the file loads once.
- A stack named after a *different* provider (stack `aws` on GCP) would load `.env.gcp` then `.env.aws`; possible follow-up: warn on `defang stack new` when the name shadows a provider ID.

## Testing

- `go test -short ./...` passes; `golangci-lint run` reports no new issues (the 21 pre-existing ones on main are from a newer lint version than CI's pin).
- New table-driven tests: layering order, missing-file skip, convention-files-without-base-`.env`, explicit `--env-file` / `COMPOSE_ENV_FILES` bypass, `COMPOSE_DISABLE_ENV_FILE`, dedupe, and candidate-list derivation from stack parameters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sw7j9FYnbChZJbYArxbhuo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added convention-based environment file loading for stacks.
  * Automatically checks `.env`, provider-specific, and stack-specific files in precedence order.
  * Missing environment files are skipped, while explicit environment file settings continue to take priority.
  * Added support for disabling default environment file loading through configuration.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->