### PR TITLE
fix(aws): prefer AWS_REGION over AWS_DEFAULT_REGION for region resolution

### DIFF
--- a/src/pkg/clouds/aws/login.go
+++ b/src/pkg/clouds/aws/login.go
@@ -114,13 +114,21 @@ func (p *awsOAuthCredentialsProvider) toCredentials() awssdk.Credentials {
 //  3. Interactive browser-based OAuth login
 //
 // On success, a.Credentials is set so that subsequent calls to LoadConfig() use them.
+// regionFromEnv resolves the AWS region from the environment using the same
+// precedence as the AWS SDK: AWS_REGION takes priority over AWS_DEFAULT_REGION.
+// (Previously AWS_DEFAULT_REGION won, which silently ignored an AWS_REGION
+// override and made cross-region CD commands target the wrong region.)
+func regionFromEnv() string {
+	if region := os.Getenv("AWS_REGION"); region != "" {
+		return region
+	}
+	return os.Getenv("AWS_DEFAULT_REGION")
+}
+
 func (a *Aws) Authenticate(ctx context.Context, interactive bool) error {
 	// Resolve region before doing anything that requires it
 	if a.Region == "" {
-		region := os.Getenv("AWS_DEFAULT_REGION")
-		if region == "" {
-			region = os.Getenv("AWS_REGION")
-		}
+		region := regionFromEnv()
 		if region == "" {
 			return errors.New("AWS region required for login: set AWS_REGION or AWS_DEFAULT_REGION")
 		}

--- a/src/pkg/clouds/aws/login_test.go
+++ b/src/pkg/clouds/aws/login_test.go
@@ -759,3 +759,26 @@ func TestAuthenticate_AWS(t *testing.T) {
 		}
 	})
 }
+
+func TestRegionFromEnv(t *testing.T) {
+	tests := []struct {
+		name          string
+		awsRegion     string
+		defaultRegion string
+		want          string
+	}{
+		{"AWS_REGION takes precedence over AWS_DEFAULT_REGION", "us-east-1", "us-west-2", "us-east-1"},
+		{"falls back to AWS_DEFAULT_REGION when AWS_REGION unset", "", "us-west-2", "us-west-2"},
+		{"AWS_REGION only", "eu-central-1", "", "eu-central-1"},
+		{"neither set", "", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("AWS_REGION", tt.awsRegion)
+			t.Setenv("AWS_DEFAULT_REGION", tt.defaultRegion)
+			if got := regionFromEnv(); got != tt.want {
+				t.Errorf("regionFromEnv() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

`Aws.Authenticate()` (`src/pkg/clouds/aws/login.go`) resolves the region from **`AWS_DEFAULT_REGION` first**, only falling back to `AWS_REGION`:

```go
region := os.Getenv("AWS_DEFAULT_REGION")
if region == "" {
    region = os.Getenv("AWS_REGION")
}
```

This is the **reverse of the AWS SDK precedence** (SDK prefers `AWS_REGION`, then `AWS_DEFAULT_REGION`). When both are set, an `AWS_REGION` override is silently ignored. Because `a.Region` drives the CloudFormation client → the per-region `defang-cd` bucket → the Pulumi backend, `cd down`/`cd destroy`/`cd refresh` then operate against the wrong region and fail with a misleading `no stack named '<stack>'` (while `cd ls`, which scans all regions, still lists the stack).

Real-world impact: the nightly BYOC cleanup (`DefangLabs/defang-mvp` `scheduled-jobs.yml`) sets `AWS_DEFAULT_REGION=us-west-2` for the job and overrides only `AWS_REGION="$cd_region"` per stack — so every `cd down` targeted us-west-2 and the job failed on any stack in another region. See #2191 for the full trace.

## Fix

Extract `regionFromEnv()` using AWS SDK precedence (`AWS_REGION` first, then `AWS_DEFAULT_REGION`) and use it in `Authenticate()`. Add a table-driven test.

## Verification

- `CGO_ENABLED=0 go test -short ./pkg/clouds/aws/...` — passes (incl. new `TestRegionFromEnv`).
- `go vet ./pkg/clouds/aws/...` — clean.
- `golangci-lint run ./pkg/clouds/aws/...` — no new findings (identical count with/without this change; remaining gosec findings are pre-existing).

Fixes #2191

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * AWS authentication now selects the region from `AWS_REGION` before falling back to `AWS_DEFAULT_REGION`.
  * Improved region detection when no region is explicitly configured.

* **Tests**
  * Added coverage for region selection and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->