### PR TITLE
fix(ci): pin protoc plugins to the versions in go.mod

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -88,13 +88,18 @@ jobs:
           git diff --exit-code go.mod go.sum || { echo "Go modules are not up to date"; exit 1; }
 
       - name: Install protoc and plugins
+        working-directory: src
         run: |
           PROTOC_VERSION=32.1
           curl -fsSL "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip" -o protoc.zip
           sudo unzip -o protoc.zip -d /usr/local bin/protoc 'include/*'
           rm protoc.zip
-          go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
-          go install connectrpc.com/connect/cmd/protoc-gen-connect-go@latest
+          # Pin the generators to the versions this module already builds against.
+          # With @latest, "Verify Proto files" breaks on every upstream release: the
+          # regenerated files carry the new generator version in their header
+          # comment while the committed ones carry go.mod's.
+          go install "google.golang.org/protobuf/cmd/protoc-gen-go@$(go list -m -f '{{.Version}}' google.golang.org/protobuf)"
+          go install "connectrpc.com/connect/cmd/protoc-gen-connect-go@$(go list -m -f '{{.Version}}' connectrpc.com/connect)"
 
       - name: Verify Proto files
         working-directory: src


### PR DESCRIPTION
## Problem

`Verify Proto files` in the Go workflow is failing on **every** open PR, including ones that touch no protos (spotted on #2156).

The step regenerates the protos and diffs against what's committed — but it installs the generators with `@latest`:

```yaml
go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
go install connectrpc.com/connect/cmd/protoc-gen-connect-go@latest
```

`google.golang.org/protobuf` in `src/go.mod` is `v1.36.11`, and the committed `.pb.go` files say `v1.36.11`. Upstream tagged **v1.36.12**, so CI now regenerates with a newer generator and the only diff is the version comment in the header:

```diff
 // Code generated by protoc-gen-go. DO NOT EDIT.
 // versions:
-// 	protoc-gen-go v1.36.11
+// 	protoc-gen-go v1.36.12
```

→ `Proto files are not up to date`, exit 1. Nothing is actually stale.

## Fix

Resolve both plugin versions from `go.mod` rather than `@latest`, so the check compares like with like:

```yaml
go install "google.golang.org/protobuf/cmd/protoc-gen-go@$(go list -m -f '{{.Version}}' google.golang.org/protobuf)"
go install "connectrpc.com/connect/cmd/protoc-gen-connect-go@$(go list -m -f '{{.Version}}' connectrpc.com/connect)"
```

(`working-directory: src` added so `go list -m` reads the right module.)

The check now fails only when the protos are genuinely out of date with `fabric.proto`, which is its point. Bumping the generator becomes a deliberate `go.mod` bump plus a regen, in one reviewable commit — instead of an unrelated PR going red the day upstream ships a release.

Verified locally from `src/`: resolves to `v1.36.11` and `v1.19.1`, matching the committed output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the build workflow to use the Go module’s declared versions of code-generation tools.
  * Improved build reproducibility while keeping the existing Protocol Buffers compiler version unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->