### PR TITLE
fix(debug): truncate debugger prompts on rune boundaries

### DIFF
--- a/src/pkg/debug/debug.go
+++ b/src/pkg/debug/debug.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/DefangLabs/defang/src/pkg"
@@ -258,18 +259,38 @@ const (
 )
 
 // truncateHead keeps the first max bytes of s; the start of a compose file (project and service
-// definitions) is the most useful part.
+// definitions) is the most useful part. The cut is pulled back to a rune boundary, so a multibyte
+// character straddling the limit is dropped whole rather than sent to the model as U+FFFD.
 func truncateHead(s string, maxLen int) string {
 	if len(s) <= maxLen {
 		return s
 	}
-	return s[:maxLen] + "\n... (truncated; ask the user or use your tools for the rest)"
+	return s[:runeBoundaryBefore(s, maxLen)] + "\n... (truncated; ask the user or use your tools for the rest)"
 }
 
 // truncateTail keeps the last max bytes of s; the end of an error is where the root cause lands.
+// Like truncateHead, it cuts on a rune boundary, dropping at most three extra bytes.
 func truncateTail(s string, maxLen int) string {
 	if len(s) <= maxLen {
 		return s
 	}
-	return "(truncated) ..." + s[len(s)-maxLen:]
+	return "(truncated) ..." + s[runeBoundaryAfter(s, len(s)-maxLen):]
+}
+
+// runeBoundaryBefore returns the largest index <= i that starts a rune, so s[:i] never ends
+// mid-character. A UTF-8 rune is at most 4 bytes, so this backs up at most 3.
+func runeBoundaryBefore(s string, i int) int {
+	for i > 0 && !utf8.RuneStart(s[i]) {
+		i--
+	}
+	return i
+}
+
+// runeBoundaryAfter returns the smallest index >= i that starts a rune, so s[i:] never begins
+// mid-character. Moving forward (rather than back) keeps the result within maxLen bytes.
+func runeBoundaryAfter(s string, i int) int {
+	for i < len(s) && !utf8.RuneStart(s[i]) {
+		i++
+	}
+	return i
 }

--- a/src/pkg/debug/debug_test.go
+++ b/src/pkg/debug/debug_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/DefangLabs/defang/src/pkg/cli/client"
@@ -244,11 +245,25 @@ func TestTruncatePromptPayloads(t *testing.T) {
 		{name: "tail: short string unchanged", fn: truncateTail, in: "abc", max: 5, want: "abc"},
 		{name: "tail: exact length unchanged", fn: truncateTail, in: "abcde", max: 5, want: "abcde"},
 		{name: "tail: keeps the end", fn: truncateTail, in: "abcdefgh", max: 5, want: "(truncated) ...defgh"},
+		// A multibyte character straddling the limit must be dropped whole: half a rune
+		// reaches the model as U+FFFD, and can break a strict JSON encoder on the way.
+		// "€" is 3 bytes, so limits 3, 4 and 5 each cut inside it from a different offset.
+		{name: "head: cut inside a rune drops it", fn: truncateHead, in: "ab€cd", max: 3,
+			want: "ab\n... (truncated; ask the user or use your tools for the rest)"},
+		{name: "head: cut one byte into a rune", fn: truncateHead, in: "ab€cd", max: 4,
+			want: "ab\n... (truncated; ask the user or use your tools for the rest)"},
+		{name: "head: cut on a rune boundary keeps it", fn: truncateHead, in: "ab€cd", max: 5,
+			want: "ab€\n... (truncated; ask the user or use your tools for the rest)"},
+		{name: "tail: cut inside a rune drops it", fn: truncateTail, in: "ab€cd", max: 3, want: "(truncated) ...cd"},
+		{name: "tail: cut one byte into a rune", fn: truncateTail, in: "ab€cd", max: 4, want: "(truncated) ...cd"},
+		{name: "tail: cut on a rune boundary keeps it", fn: truncateTail, in: "ab€cd", max: 5, want: "(truncated) ...€cd"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, tt.fn(tt.in, tt.max))
+			got := tt.fn(tt.in, tt.max)
+			assert.Equal(t, tt.want, got)
+			assert.True(t, utf8.ValidString(got), "truncation must not split a rune: %q", got)
 		})
 	}
 }


### PR DESCRIPTION
Confirms and fixes the CodeRabbit finding on PR 2158 ([discussion_r3786120377](https://github.com/DefangLabs/defang/pull/2158#discussion_r3786120377)) — it was right, and 2158 had already merged.

`truncateHead` and `truncateTail` sliced by byte index, so a multibyte character straddling the limit was cut in half. The model then receives U+FFFD where the character was, and a strict JSON encoder can reject the payload. The two payloads these cap are a compose file and an error message, so non-ASCII content is ordinary, not exotic.

Both helpers now move the cut to the nearest rune boundary — `truncateHead` backs up, `truncateTail` moves forward, so neither result exceeds `maxLen`. At most three bytes are dropped.

Tests: the truncation table gains a 3-byte rune ("€") cut at each offset inside it, for head and tail, and every case now also asserts `utf8.ValidString` on the result.

`go test ./pkg/debug/...` and `go vet` pass; `golangci-lint run ./pkg/debug/...` reports the same 15 pre-existing typecheck issues as `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T3WmpdY3zc555sNdkY9dzQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved debug prompt and error truncation to preserve valid UTF-8 text.
  * Prevented multibyte characters from being split when limiting text from the beginning or end.

* **Tests**
  * Added coverage for truncation at multibyte character boundaries.
  * Verified truncated output remains valid UTF-8.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->