### PR TITLE
ci: fix Dependabot auto-merge gating

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,3 @@ updates:
       github-actions:
         patterns:
           - "*"
-    ignore:
-      # Only major version bumps; security advisories always bypass ignore rules.
-      - dependency-name: "*"
-        update-types: ["version-update:semver-minor", "version-update:semver-patch"]

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -9,7 +9,7 @@ permissions:
 jobs:
   automerge:
     runs-on: ubuntu-latest
-    if: github.actor == 'dependabot[bot]'
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
     steps:
       - name: Fetch dependabot metadata
         id: metadata


### PR DESCRIPTION
## Summary

- identify Dependabot PRs by their stable pull request author
- allow patch and minor GitHub Actions updates to be opened for auto-merge
- keep major updates manual

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * GitHub Actions dependencies can now receive minor and patch updates automatically.
  * Dependency update pull requests use the pull request author for automerge authorization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->