### PR TITLE
Secure agent filesystem tools

### DIFF
--- a/src/pkg/agent/fs.go
+++ b/src/pkg/agent/fs.go
@@ -3,9 +3,9 @@ package agent
 import (
 	"encoding/json"
 	"errors"
+	"io/fs"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/firebase/genkit/go/ai"
 )
@@ -23,20 +23,36 @@ type ListFilesParams struct {
 	Path string `json:"path"`
 }
 
-func isSafePath(path string) bool {
-	cleaned := filepath.Clean(path)
-
-	// Reject absolute paths
-	if filepath.IsAbs(cleaned) {
-		return false
+// openCwdRoot returns a root-constrained name for path. The returned Root, rather
+// than this path conversion, enforces that filesystem operations cannot escape cwd.
+func openCwdRoot(path string) (*os.Root, string, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return nil, "", err
 	}
 
-	// Reject paths that traverse outside the current directory
-	if cleaned == ".." || strings.HasPrefix(cleaned, "../") {
-		return false
+	root, err := os.OpenRoot(cwd)
+	if err != nil {
+		return nil, "", err
 	}
 
-	return true
+	if filepath.IsAbs(path) {
+		path, err = filepath.Rel(cwd, path)
+		if err != nil {
+			_ = root.Close()
+			return nil, "", err
+		}
+	}
+
+	return root, path, nil
+}
+
+func rootPathError(op, path string, err error) error {
+	var pathErr *os.PathError
+	if errors.As(err, &pathErr) {
+		return &os.PathError{Op: op, Path: path, Err: pathErr.Err}
+	}
+	return err
 }
 
 func CollectFsTools() []ai.Tool {
@@ -45,12 +61,15 @@ func CollectFsTools() []ai.Tool {
 			"read_file",
 			"Read the contents of a file from the local filesystem",
 			func(ctx *ai.ToolContext, params ReadFileParams) (string, error) {
-				if !isSafePath(params.Path) {
-					return "", errors.New("Accessing files outside the current working directory is not permitted")
-				}
-				bytes, err := os.ReadFile(params.Path)
+				root, path, err := openCwdRoot(params.Path)
 				if err != nil {
 					return "", err
+				}
+				defer root.Close()
+
+				bytes, err := root.ReadFile(path)
+				if err != nil {
+					return "", rootPathError("open", params.Path, err)
 				}
 				return string(bytes), nil
 			},
@@ -59,20 +78,27 @@ func CollectFsTools() []ai.Tool {
 			"find_files",
 			"Find files in a directory on the local filesystem matching a given pattern",
 			func(ctx *ai.ToolContext, params FindFilesParams) (string, error) {
-				if !isSafePath(params.Path) {
-					return "", errors.New("Accessing files outside the current working directory is not permitted")
+				root, path, err := openCwdRoot(params.Path)
+				if err != nil {
+					return "", err
 				}
+				defer root.Close()
+
 				var matches []string
-				err := filepath.Walk(params.Path, func(path string, info os.FileInfo, err error) error {
+				err = fs.WalkDir(root.FS(), filepath.ToSlash(path), func(path string, entry fs.DirEntry, err error) error {
 					if err != nil {
 						return err
 					}
-					matched, err := filepath.Match(params.Pattern, info.Name())
+					matched, err := filepath.Match(params.Pattern, entry.Name())
 					if err != nil {
 						return err
 					}
 					if matched {
-						matches = append(matches, path)
+						matchPath := filepath.FromSlash(path)
+						if filepath.IsAbs(params.Path) {
+							matchPath = filepath.Join(root.Name(), matchPath)
+						}
+						matches = append(matches, matchPath)
 					}
 					return nil
 				})
@@ -90,10 +116,13 @@ func CollectFsTools() []ai.Tool {
 			"list_files",
 			"List files in a directory on the local filesystem",
 			func(ctx *ai.ToolContext, params ListFilesParams) (string, error) {
-				if !isSafePath(params.Path) {
-					return "", errors.New("Accessing files outside the current working directory is not permitted")
+				root, path, err := openCwdRoot(params.Path)
+				if err != nil {
+					return "", err
 				}
-				entries, err := os.ReadDir(params.Path)
+				defer root.Close()
+
+				entries, err := fs.ReadDir(root.FS(), filepath.ToSlash(path))
 				if err != nil {
 					return "", err
 				}

--- a/src/pkg/agent/fs_test.go
+++ b/src/pkg/agent/fs_test.go
@@ -1,0 +1,81 @@
+package agent
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCwdRootReadFile(t *testing.T) {
+	cwd := t.TempDir()
+	t.Chdir(cwd)
+
+	require.NoError(t, os.Mkdir(filepath.Join(cwd, "app"), 0o755))
+	file := filepath.Join(cwd, "app", "Dockerfile")
+	require.NoError(t, os.WriteFile(file, []byte("FROM scratch"), 0o600))
+
+	for _, path := range []string{"app/Dockerfile", file} {
+		t.Run(path, func(t *testing.T) {
+			root, name, err := openCwdRoot(path)
+			require.NoError(t, err)
+			defer root.Close()
+
+			contents, err := root.ReadFile(name)
+			require.NoError(t, err)
+			assert.Equal(t, "FROM scratch", string(contents))
+		})
+	}
+}
+
+func TestCwdRootRejectsPathsOutsideCwd(t *testing.T) {
+	parent := t.TempDir()
+	cwd := filepath.Join(parent, "cwd")
+	require.NoError(t, os.Mkdir(cwd, 0o755))
+	t.Chdir(cwd)
+
+	outside := filepath.Join(parent, "secret")
+	require.NoError(t, os.WriteFile(outside, []byte("secret"), 0o600))
+
+	for _, path := range []string{"../secret", outside} {
+		t.Run(path, func(t *testing.T) {
+			root, name, err := openCwdRoot(path)
+			require.NoError(t, err)
+			defer root.Close()
+
+			_, err = root.ReadFile(name)
+			assert.Error(t, err)
+		})
+	}
+}
+
+func TestCwdRootRejectsSymlinkEscape(t *testing.T) {
+	parent := t.TempDir()
+	cwd := filepath.Join(parent, "cwd")
+	outside := filepath.Join(parent, "outside")
+	require.NoError(t, os.Mkdir(cwd, 0o755))
+	require.NoError(t, os.Mkdir(outside, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(outside, "secret"), []byte("secret"), 0o600))
+	if err := os.Symlink(outside, filepath.Join(cwd, "escape")); err != nil {
+		t.Skipf("symlinks are unavailable: %v", err)
+	}
+	t.Chdir(cwd)
+
+	root, name, err := openCwdRoot("escape/secret")
+	require.NoError(t, err)
+	defer root.Close()
+
+	_, err = root.ReadFile(name)
+	assert.Error(t, err)
+
+	_, err = fs.ReadDir(root.FS(), filepath.ToSlash(filepath.Dir(name)))
+	assert.Error(t, err)
+
+	err = fs.WalkDir(root.FS(), filepath.ToSlash(filepath.Dir(name)), func(_ string, _ fs.DirEntry, err error) error {
+		return err
+	})
+	assert.Error(t, err)
+}


### PR DESCRIPTION
## Description

Replace the lexical `isSafePath` check with filesystem operations constrained by `os.Root`.

- preserve relative and absolute paths within the current working directory
- prevent parent traversal and symlink escapes during read, find, and list operations
- preserve existing read error formatting
- add coverage for absolute descendants and escape attempts

## Linked Issues

None.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added appropriate tests
- [x] Documentation changes are not necessary

## Verification

- `go test -short ./pkg/agent/...`
- `golangci-lint run ./pkg/agent`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved filesystem access to prevent operations from escaping the current working directory.
  * Added protection against symlink-based access to files and directories outside the permitted location.
  * Standardized file-read errors while preserving the requested path.
  * Improved support for both relative and absolute paths within the working directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->