### PR TITLE
byoc: enforce the TTL minimum in the CLI, not the CD

### DIFF
--- a/src/pkg/cli/client/byoc/ttl.go
+++ b/src/pkg/cli/client/byoc/ttl.go
@@ -8,6 +8,16 @@ import (
 	"github.com/DefangLabs/defang/src/pkg/timeutils"
 )
 
+// minTTL is the shortest TTL the CLI accepts. The CD's self-destruct trigger
+// clock starts at deploy time, but resources can take 10+ minutes to finish
+// provisioning after that — a shorter TTL could tear the stack down while (or
+// right after) it comes up. This floor is enforced here, in the CLI, and
+// deliberately NOT in the CD (see parseTTL in pulumi-defang's
+// cd/program/ttl.go): the CD accepts any positive TTL so tests and manual CD
+// invocations that bypass this CLI check can use shorter durations to verify
+// the self-destruct trigger without waiting an hour.
+const minTTL = time.Hour
+
 // ParseTTL normalizes a deployment time-to-live for the CD program, which
 // reads it from the DEFANG_TTL env var of the CD run into its defang:ttl
 // stack config (see parseTTL in pulumi-defang's cd/program/ttl.go) to
@@ -19,10 +29,9 @@ import (
 //     (RFC3339, unix seconds/millis): translated to the duration from now
 //     until that moment, because the CD only accepts durations
 //
-// Only the syntax (and sign) is checked here, for fast feedback before the
-// CD task starts; the 1h..10y min/max bounds are deliberately NOT duplicated
-// on the CLI side — the CD enforces them authoritatively, so the rules
-// cannot drift.
+// The minTTL floor is enforced here; the CD's maxTTL remains the sole,
+// authoritative guard against typo'd far-future dates, so that rule cannot
+// drift between the two sides.
 func ParseTTL(value string, now time.Time) (string, error) {
 	s := strings.ToLower(strings.TrimSpace(value))
 	switch s {
@@ -30,8 +39,8 @@ func ParseTTL(value string, now time.Time) (string, error) {
 		return s, nil
 	}
 	if dur, err := timeutils.ParseDuration(s); err == nil {
-		if dur <= 0 {
-			return "", fmt.Errorf(`invalid TTL %q: must be positive (use "never" to disable)`, value)
+		if dur < minTTL {
+			return "", fmt.Errorf(`invalid TTL %q: must be at least %s (use "never" to disable)`, value, minTTL)
 		}
 		return s, nil
 	}
@@ -41,8 +50,8 @@ func ParseTTL(value string, now time.Time) (string, error) {
 		return "", fmt.Errorf(`invalid TTL %q: use a duration like "12h" or "7d", a timestamp, or "never"`, value)
 	}
 	ttl := ts.Sub(now)
-	if ttl <= 0 {
-		return "", fmt.Errorf("invalid TTL %q: timestamp is in the past", value)
+	if ttl < minTTL {
+		return "", fmt.Errorf(`invalid TTL %q: must be at least %s from now`, value, minTTL)
 	}
 	return ttl.String(), nil
 }

--- a/src/pkg/cli/client/byoc/ttl_test.go
+++ b/src/pkg/cli/client/byoc/ttl_test.go
@@ -22,13 +22,16 @@ func TestParseTTL(t *testing.T) {
 		{value: "12h", want: "12h"},
 		{value: "90m", want: "90m"},
 		{value: "1h30m", want: "1h30m"},
+		{value: "1h", want: "1h"}, // exactly the minimum
 		// whole-days prefix passes through (the CD parses the same syntax)
 		{value: "7d", want: "7d"},
 		{value: "7d12h", want: "7d12h"},
 		{value: "1d1h30m", want: "1d1h30m"},
 		{value: "7d-1h", want: "7d-1h"}, // positive total; the CD computes the same 167h
-		// out-of-bounds durations pass the syntax check; the CD enforces bounds
-		{value: "30m", want: "30m"},
+		// below the CLI's minimum
+		{value: "30m", wantErr: true},
+		{value: "5m", wantErr: true},
+		// the CLI does not enforce a maximum; the CD does, as a typo guard
 		{value: "9999d", want: "9999d"},
 		// timestamps translate to the duration from now until then
 		{value: "2026-08-17T12:00:00Z", want: "24h0m0s"},

--- a/src/pkg/cli/client/byoc/ttl_test.go
+++ b/src/pkg/cli/client/byoc/ttl_test.go
@@ -36,10 +36,12 @@ func TestParseTTL(t *testing.T) {
 		// timestamps translate to the duration from now until then
 		{value: "2026-08-17T12:00:00Z", want: "24h0m0s"},
 		{value: "2026-08-16T13:30:00Z", want: "1h30m0s"},
-		{value: "1786968000", want: "24h0m0s"},         // unix seconds for 2026-08-17T12:00:00Z
-		{value: "2026-08-16T11:00:00Z", wantErr: true}, // in the past
-		{value: "2026-08-16T12:00:00Z", wantErr: true}, // now is not in the future
-		{value: "12", wantErr: true},                   // unix seconds in 1970
+		{value: "2026-08-16T13:00:00Z", want: "1h0m0s"}, // exactly the minimum
+		{value: "2026-08-16T12:30:00Z", wantErr: true},  // below the minimum
+		{value: "1786968000", want: "24h0m0s"},          // unix seconds for 2026-08-17T12:00:00Z
+		{value: "2026-08-16T11:00:00Z", wantErr: true},  // in the past
+		{value: "2026-08-16T12:00:00Z", wantErr: true},  // now is not in the future
+		{value: "12", wantErr: true},                    // unix seconds in 1970
 		// rejected syntax
 		{value: "abc", wantErr: true},
 		{value: "1w", wantErr: true},


### PR DESCRIPTION
## Summary
- Moves the `1h` TTL floor from the CD's `parseTTL` to the CLI's `byoc.ParseTTL`.
- The CD (pulumi-defang) now accepts any positive TTL, so a test or manual CD invocation that bypasses this CLI check can use a short TTL (seconds/minutes) to verify the self-destruct trigger actually fires, instead of waiting an hour.
- Real deployments through this CLI are unaffected: they still can't set a TTL below 1h.

Companion change: DefangLabs/pulumi-defang cd/program/ttl.go (removes the CD-side `minTTL`).

## Test plan
- [x] `go test -short ./pkg/cli/client/byoc/` passes with updated cases (`30m`/`5m` now `wantErr`, `1h` at the boundary still passes)
- [x] `golangci-lint run ./pkg/cli/client/byoc/...` shows no new findings (confirmed via `git stash` diff against the pre-change baseline)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced a one-hour minimum for CLI-provided TTL values.
  * TTL durations and timestamps shorter than one hour now return clear validation errors.
  * Updated validation coverage for the exact one-hour minimum and shorter values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->