### PR TITLE
azure: resolve the real Container Apps environment IP for apex cert-gen instructions

### DIFF
--- a/src/pkg/clouds/azure/aca/cert.go
+++ b/src/pkg/clouds/azure/aca/cert.go
@@ -67,6 +67,10 @@ func IssueCert(ctx context.Context, cred azcore.TokenCredential, subscriptionID,
 	if err != nil {
 		return fmt.Errorf("creating managed certificates client: %w", err)
 	}
+	envsClient, err := armappcontainers.NewManagedEnvironmentsClient(subscriptionID, cred, nil)
+	if err != nil {
+		return fmt.Errorf("creating managed environments client: %w", err)
+	}
 
 	app, err := findContainerAppByService(ctx, appsClient, resourceGroup, serviceName)
 	if err != nil {
@@ -97,7 +101,7 @@ func IssueCert(ctx context.Context, cred azcore.TokenCredential, subscriptionID,
 		return nil
 	}
 
-	if err := waitForBYODdns(ctx, hostname, appFqdn, vid, resolverAt); err != nil {
+	if err := waitForBYODdns(ctx, envsClient, resourceGroup, envName, hostname, appFqdn, vid, resolverAt); err != nil {
 		return err
 	}
 
@@ -152,7 +156,7 @@ func findContainerAppByService(ctx context.Context, client *armappcontainers.Con
 // managed environment's static IP, exactly what an apex A record must point at.
 // So an apex domain is validated against the intended target, not merely
 // "resolves to something". The asuid TXT is always required.
-func waitForBYODdns(ctx context.Context, hostname, expectedCname, expectedTxt string, resolverAt func(string) dns.Resolver) error {
+func waitForBYODdns(ctx context.Context, envsClient *armappcontainers.ManagedEnvironmentsClient, resourceGroup, envName, hostname, expectedCname, expectedTxt string, resolverAt func(string) dns.Resolver) error {
 	asuid := "asuid." + hostname
 	deadline := time.Now().Add(dnsWaitTimeout)
 	promptShown := false
@@ -167,7 +171,7 @@ func waitForBYODdns(ctx context.Context, hostname, expectedCname, expectedTxt st
 		if !promptShown {
 			term.Printf("Configure DNS records for %s:\n", hostname)
 			term.Printf("  CNAME  %s              ->  %s   (subdomain)\n", hostname, expectedCname)
-			term.Printf("  A      %s              ->  <Container Apps environment IP>   (apex)\n", hostname)
+			term.Printf("  A      %s              ->  %s   (apex)\n", hostname, environmentStaticIP(ctx, envsClient, resourceGroup, envName))
 			term.Printf("  TXT    asuid.%s        ->  %s\n", hostname, expectedTxt)
 			term.Infof("Waiting for DNS propagation (timeout %v)...", dnsWaitTimeout)
 			promptShown = true
@@ -179,6 +183,21 @@ func waitForBYODdns(ctx context.Context, hostname, expectedCname, expectedTxt st
 			return err
 		}
 	}
+}
+
+// environmentStaticIP fetches the Container Apps environment's inbound static IP
+// for display in the apex A-record instructions. This is a JIT lookup done only
+// once the DNS-not-ready prompt is about to be shown, so the common case (DNS
+// already configured) never pays for it. A lookup failure falls back to a
+// placeholder rather than failing cert issuance — the value is purely
+// informational; dns.CheckDomainDNSReady validates the actual DNS state itself.
+func environmentStaticIP(ctx context.Context, envsClient *armappcontainers.ManagedEnvironmentsClient, resourceGroup, envName string) string {
+	env, err := envsClient.Get(ctx, resourceGroup, envName, nil)
+	if err != nil || env.Properties == nil || env.Properties.StaticIP == nil {
+		term.Debugf("Could not fetch static IP for environment %s: %v", envName, err)
+		return "<Container Apps environment IP; check the Azure portal>"
+	}
+	return *env.Properties.StaticIP
 }
 
 // addHostnameDisabled PATCHes the ContainerApp to add (or no-op) a customDomain

--- a/src/pkg/clouds/azure/aca/cert.go
+++ b/src/pkg/clouds/azure/aca/cert.go
@@ -189,21 +189,17 @@ func waitForBYODdns(ctx context.Context, envsClient *armappcontainers.ManagedEnv
 // static IP over ARM for display in the apex A-record instructions. This is a
 // JIT lookup done only once the DNS-not-ready prompt is about to be shown, so
 // the common case (DNS already configured) never pays for it. A lookup
-// failure, or a blank StaticIP (e.g. an environment still provisioning),
+// failure, or an empty StaticIP (e.g. an environment still provisioning),
 // falls back to a placeholder rather than failing cert issuance — the value
 // is purely informational; dns.CheckDomainDNSReady validates the actual DNS
 // state itself.
 func fetchEnvironmentStaticIP(ctx context.Context, envsClient *armappcontainers.ManagedEnvironmentsClient, resourceGroup, envName string) string {
-	const placeholder = "<Container Apps environment IP; check the Azure portal>"
 	env, err := envsClient.Get(ctx, resourceGroup, envName, nil)
-	if err != nil || env.Properties == nil || env.Properties.StaticIP == nil {
+	if err != nil || env.Properties == nil || env.Properties.StaticIP == nil || *env.Properties.StaticIP == "" {
 		term.Debugf("Could not fetch static IP for environment %s: %v", envName, err)
-		return placeholder
+		return "<Container Apps environment IP; check the Azure portal>"
 	}
-	if ip := strings.TrimSpace(*env.Properties.StaticIP); ip != "" {
-		return ip
-	}
-	return placeholder
+	return *env.Properties.StaticIP
 }
 
 // addHostnameDisabled PATCHes the ContainerApp to add (or no-op) a customDomain

--- a/src/pkg/clouds/azure/aca/cert.go
+++ b/src/pkg/clouds/azure/aca/cert.go
@@ -171,7 +171,7 @@ func waitForBYODdns(ctx context.Context, envsClient *armappcontainers.ManagedEnv
 		if !promptShown {
 			term.Printf("Configure DNS records for %s:\n", hostname)
 			term.Printf("  CNAME  %s              ->  %s   (subdomain)\n", hostname, expectedCname)
-			term.Printf("  A      %s              ->  %s   (apex)\n", hostname, environmentStaticIP(ctx, envsClient, resourceGroup, envName))
+			term.Printf("  A      %s              ->  %s   (apex)\n", hostname, fetchEnvironmentStaticIP(ctx, envsClient, resourceGroup, envName))
 			term.Printf("  TXT    asuid.%s        ->  %s\n", hostname, expectedTxt)
 			term.Infof("Waiting for DNS propagation (timeout %v)...", dnsWaitTimeout)
 			promptShown = true
@@ -185,19 +185,25 @@ func waitForBYODdns(ctx context.Context, envsClient *armappcontainers.ManagedEnv
 	}
 }
 
-// environmentStaticIP fetches the Container Apps environment's inbound static IP
-// for display in the apex A-record instructions. This is a JIT lookup done only
-// once the DNS-not-ready prompt is about to be shown, so the common case (DNS
-// already configured) never pays for it. A lookup failure falls back to a
-// placeholder rather than failing cert issuance — the value is purely
-// informational; dns.CheckDomainDNSReady validates the actual DNS state itself.
-func environmentStaticIP(ctx context.Context, envsClient *armappcontainers.ManagedEnvironmentsClient, resourceGroup, envName string) string {
+// fetchEnvironmentStaticIP fetches the Container Apps environment's inbound
+// static IP over ARM for display in the apex A-record instructions. This is a
+// JIT lookup done only once the DNS-not-ready prompt is about to be shown, so
+// the common case (DNS already configured) never pays for it. A lookup
+// failure, or a blank StaticIP (e.g. an environment still provisioning),
+// falls back to a placeholder rather than failing cert issuance — the value
+// is purely informational; dns.CheckDomainDNSReady validates the actual DNS
+// state itself.
+func fetchEnvironmentStaticIP(ctx context.Context, envsClient *armappcontainers.ManagedEnvironmentsClient, resourceGroup, envName string) string {
+	const placeholder = "<Container Apps environment IP; check the Azure portal>"
 	env, err := envsClient.Get(ctx, resourceGroup, envName, nil)
 	if err != nil || env.Properties == nil || env.Properties.StaticIP == nil {
 		term.Debugf("Could not fetch static IP for environment %s: %v", envName, err)
-		return "<Container Apps environment IP; check the Azure portal>"
+		return placeholder
 	}
-	return *env.Properties.StaticIP
+	if ip := strings.TrimSpace(*env.Properties.StaticIP); ip != "" {
+		return ip
+	}
+	return placeholder
 }
 
 // addHostnameDisabled PATCHes the ContainerApp to add (or no-op) a customDomain


### PR DESCRIPTION
## Summary
- `defang cert generate` printed a literal `<Container Apps environment IP>` placeholder for the apex A record, leaving BYOD users with no way to get the real value short of the Azure portal (issue 2216).
- Compared against AWS/GCP: both print a real, resolved target for their DNS instructions (ALB DNS name / PublicFqdn) sourced over the Fabric RPC. Azure is the only provider driving cert issuance itself (`CertIssuer`/`IssueCert`), so it never had an equivalent value to show.
- Rather than adding a new field to the Fabric protobuf and threading it through `GetServices` + the CD task, this does a just-in-time ARM lookup inside `pkg/clouds/azure/aca/cert.go`, which already builds ARM clients from `cred`/`subscriptionID` for the ContainerApps/ManagedCertificates calls. One more `ManagedEnvironmentsClient.Get` call resolves `Properties.StaticIP`.
- The lookup only runs once, right before the DNS-not-ready prompt is shown (so the common case — DNS already configured — never pays for it), and falls back to a placeholder on error rather than failing cert issuance; the value is purely informational since `dns.CheckDomainDNSReady` independently validates the actual DNS state.

## Test plan
- [x] `go build ./pkg/clouds/azure/...`
- [x] `go test -short ./pkg/cli/... ./pkg/clouds/...`
- [x] `golangci-lint run ./pkg/clouds/azure/...`
- [ ] Manual: run `defang cert generate` against an Azure BYOD apex domain and confirm a real IP prints instead of the placeholder

Fixes #2216

https://claude.ai/code/session_01T3WmpdY3zc555sNdkY9dzQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Azure certificate setup now displays the environment’s actual static IP address in apex-domain DNS instructions.
  * Added a fallback message when the static IP cannot be retrieved or is unavailable.
  * IP values are now trimmed to ensure accurate DNS instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->