### PR TITLE
fix(aws): route the CD deploy payload through the authenticated s3:// fetch path

### DIFF
--- a/src/pkg/cli/client/byoc/aws/byoc.go
+++ b/src/pkg/cli/client/byoc/aws/byoc.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"iter"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -202,6 +203,23 @@ func (b *ByocAws) Preview(ctx context.Context, req *client.DeployRequest) (*clie
 	return b.deploy(ctx, req, "preview")
 }
 
+// s3PayloadURI rewrites a virtual-hosted-style S3 URL (bucket.s3.region.amazonaws.com/key)
+// into s3://bucket/key. cd's fetchPayload only authenticates s3:// URIs, via the deploy
+// container's ambient AWS credentials; a bare https:// GET is unsigned, so a private bucket
+// 403s it. Mirrors the gs:// rewrite in gcp/byoc.go for the same reason. Non-S3 URLs (or ones
+// that fail to parse) pass through unchanged.
+func s3PayloadURI(rawURL string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return rawURL
+	}
+	bucket, rest, ok := strings.Cut(u.Host, ".s3.")
+	if !ok || !strings.HasSuffix(rest, "amazonaws.com") {
+		return rawURL
+	}
+	return "s3://" + bucket + u.Path
+}
+
 func (b *ByocAws) deploy(ctx context.Context, req *client.DeployRequest, cmd string) (*client.DeployResponse, error) {
 	cfg, err := b.driver.LoadConfig(ctx)
 	if err != nil {
@@ -262,7 +280,7 @@ func (b *ByocAws) deploy(ctx context.Context, req *client.DeployRequest, cmd str
 		if resp.StatusCode != 200 {
 			return nil, fmt.Errorf("unexpected status code during upload: %s", resp.Status)
 		}
-		payloadString = http.RemoveQueryParam(payloadUrl)
+		payloadString = s3PayloadURI(http.RemoveQueryParam(payloadUrl))
 	}
 
 	cdCmd := cdCommand{

--- a/src/pkg/cli/client/byoc/aws/byoc_test.go
+++ b/src/pkg/cli/client/byoc/aws/byoc_test.go
@@ -737,3 +737,38 @@ func TestDeriveBuildID(t *testing.T) {
 		})
 	}
 }
+
+func TestS3PayloadURI(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "regional virtual-hosted-style URL rewritten to s3 scheme",
+			in:   "https://defang-cd-bucket-cybpbzz8hzm7.s3.us-west-2.amazonaws.com/uploads/t7jl0wwq4cz9",
+			want: "s3://defang-cd-bucket-cybpbzz8hzm7/uploads/t7jl0wwq4cz9",
+		},
+		{
+			name: "legacy virtual-hosted-style URL (no region) rewritten to s3 scheme",
+			in:   "https://defang-cd-bucket-cybpbzz8hzm7.s3.amazonaws.com/uploads/t7jl0wwq4cz9",
+			want: "s3://defang-cd-bucket-cybpbzz8hzm7/uploads/t7jl0wwq4cz9",
+		},
+		{
+			name: "non-S3 URL passes through unchanged",
+			in:   "https://example.com/uploads/t7jl0wwq4cz9",
+			want: "https://example.com/uploads/t7jl0wwq4cz9",
+		},
+		{
+			name: "base64 payload passes through unchanged",
+			in:   "cGF5bG9hZA==",
+			want: "cGF5bG9hZA==",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, s3PayloadURI(tt.in))
+		})
+	}
+}


### PR DESCRIPTION
## Summary
`cd`'s `fetchPayload` only authenticates `s3://` URIs (via the deploy container's ambient AWS credentials, see `fetchS3` in pulumi-defang's `cd/fetch.go`). The AWS BYOC driver strips the query string off the presigned upload URL and passes the bare virtual-hosted-style `https://bucket.s3.region.amazonaws.com/key` URL to `cd up`. That routes through `fetchHTTP`, which does a plain unsigned GET — a private bucket 403s it.

This mirrors the `gs://` rewrite already done for GCP in `gcp/byoc.go` (with the same comment: "Only gs:// is supported in the payload as http get in gcpcd does not handle auth yet"). AWS never got the equivalent rewrite.

## Context
Found while re-validating DefangLabs/pulumi-defang#423 (AWS CD image shell-base fix + defang#2217's entrypoint fix) against DefangLabs/defang-mvp#3181's `new-provider-sanity` smoketest. With those two fixes in place, the AWS leg now provisions and runs the correct entrypoint, but fails on this new blocker:

```
cd pulumi failed to fetch payload: GET https://defang-cd-bucket-cybpbzz8hzm7.s3.us-west-2.amazonaws.com/uploads/t7jl0wwq4cz9 returned 403 Forbidden
```

I confirmed the CodeBuild task role (`defang-cd-TaskRole-*`) has `PowerUserAccess`, which includes `s3:GetObject` — so a signed request through `fetchS3` should succeed; the request is just never signed because it isn't recognized as an S3 URI.

## Change
Adds `s3PayloadURI`, which rewrites `bucket.s3.region.amazonaws.com/key` (with or without a region segment) into `s3://bucket/key`; non-S3 URLs and base64 payloads pass through unchanged.

## Test plan
- [x] `go test -short ./pkg/cli/client/byoc/aws/...` passes, including new `TestS3PayloadURI` cases (regional URL, legacy no-region URL, non-S3 URL, base64 payload)
- [x] `golangci-lint run ./pkg/cli/client/byoc/aws/...` — no new findings (4 pre-existing gosec findings, unrelated to this diff)
- [ ] Re-dispatch `new-provider-sanity.yml` with `aws-cli-version` pointed at this branch to confirm the AWS leg gets past the payload fetch