### PR TITLE
azure: fix lost customDomain binding when a service has multiple hostnames

### DIFF
--- a/pkgs/defang/cli.nix
+++ b/pkgs/defang/cli.nix
@@ -7,7 +7,7 @@ buildGo125Module {
   pname = "defang-cli";
   version = "git";
   src = lib.cleanSource ../../src;
-  vendorHash = "sha256-QMQ7rH76stxpN7EjY3l9HOBusOQp85dt+0Fkn9sO7Xk=";
+  vendorHash = "sha256-CQD14oEPHZcRkjxrSKccPvZUeNsF25qwUI/48Y7VMZ0=";
 
   subPackages = [ "cmd/cli" ];
 

--- a/src/go.mod
+++ b/src/go.mod
@@ -80,6 +80,7 @@ require (
 	go.yaml.in/yaml/v4 v4.0.0-rc.4
 	golang.org/x/crypto v0.52.0
 	golang.org/x/mod v0.36.0
+	golang.org/x/net v0.55.0
 	golang.org/x/oauth2 v0.36.0
 	golang.org/x/sys v0.45.0
 	golang.org/x/term v0.43.0
@@ -158,7 +159,6 @@ require (
 	go.opentelemetry.io/contrib/detectors/gcp v1.43.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.69.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v1.44.0 // indirect
-	golang.org/x/net v0.55.0 // indirect
 	google.golang.org/genai v1.30.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa // indirect
 	gopkg.in/ini.v1 v1.66.2 // indirect

--- a/src/pkg/cli/cert.go
+++ b/src/pkg/cli/cert.go
@@ -100,8 +100,21 @@ func newCertHTTPClient(r dns.Resolver) HTTPClient {
 // CNAME→fabric→ACME redirect dance used on AWS BYOD / Playground. Azure
 // implements this so `defang cert generate` can drive the Container Apps
 // hostname-add + managed-cert + SniEnabled-bind sequence end-to-end.
+//
+// The two methods mirror the two phases of runACMEJobs: PreflightCert only
+// probes and reports, so every domain's outstanding records can be printed in
+// one block up front, and IssueCert then does the work, routing all of its
+// user-facing output through the per-domain logger it is handed.
 type CertIssuer interface {
-	IssueCert(ctx context.Context, projectName, serviceName, hostname string, resolverAt func(string) dns.Resolver) error
+	// PreflightCert reports the DNS records hostname still needs before a cert
+	// can be issued, without provisioning anything. An empty result means
+	// there is nothing for the user to configure. Because the caller prints
+	// these, IssueCert must not print them again.
+	PreflightCert(ctx context.Context, projectName, serviceName, hostname string, resolverAt func(string) dns.Resolver) ([]dns.RequiredRecord, error)
+	// IssueCert provisions and binds the cert, emitting every user-facing
+	// progress line through log rather than printing directly, so concurrent
+	// per-domain workers don't interleave unattributed output.
+	IssueCert(ctx context.Context, projectName, serviceName, hostname string, resolverAt func(string) dns.Resolver, log func(string, ...any)) error
 }
 
 // domainJob is one (service, domain, targets) tuple processed by a worker.
@@ -191,11 +204,26 @@ func getDomainTargets(serviceInfo *defangv1.ServiceInfo, service compose.Service
 	}
 }
 
-// runIssuerJobs runs the provider-driven cert issuance in parallel. Per-domain
-// state transitions are emitted via a per-domain prefixed logger so the log
-// stream remains readable across concurrent workers.
+// runIssuerJobs runs the provider-driven cert issuance in the same two phases
+// as runACMEJobs:
+// Phase 1 — pre-flight every domain in parallel and print the union of the
+// records still missing as one block, so the user configures them all in a
+// single DNS-console sitting instead of learning about them one worker at a
+// time.
+// Phase 2 — parallel per-domain workers, each emitting state transitions
+// through a prefixed logger so the log stream stays readable.
 func runIssuerJobs(ctx context.Context, projectName string, jobs []domainJob, fab client.FabricClient, issuer CertIssuer) error {
 	pad := maxDomainLen(jobs)
+	resolverAt := dns.NewFabricResolverAt(fab)
+
+	// Phase 1: pre-flight.
+	pending := preflightIssuerDNS(ctx, projectName, jobs, issuer, resolverAt)
+	if len(pending) > 0 {
+		printGroupedRecords(jobs, pending, pad)
+		term.Infof("Awaiting DNS record setup and propagation for %d domain(s)…", len(pending))
+	}
+
+	// Phase 2: parallel workers.
 	eg, gctx := errgroup.WithContext(ctx)
 	eg.SetLimit(maxCertWorkers)
 	var (
@@ -208,7 +236,7 @@ func runIssuerJobs(ctx context.Context, projectName string, jobs []domainJob, fa
 		eg.Go(func() error {
 			start := time.Now()
 			log("issuing cert…")
-			if err := issuer.IssueCert(gctx, projectName, job.serviceName, job.domain, dns.NewFabricResolverAt(fab)); err != nil {
+			if err := issuer.IssueCert(gctx, projectName, job.serviceName, job.domain, resolverAt, log); err != nil {
 				log("failed: %v", err)
 				errMu.Lock()
 				errs = append(errs, fmt.Errorf("%v: %w", job.domain, err))
@@ -318,6 +346,69 @@ func printGroupedCNAMEs(jobs []domainJob, pad int) {
 	term.Infof("Configure the following DNS record(s) (CNAME or ALIAS; any listed target per row works):")
 	for _, j := range jobs {
 		term.Printf("  %-*s  ->  %s\n", pad, j.domain, strings.Join(j.targets, " or "))
+	}
+}
+
+// preflightIssuerDNS asks the provider, once per domain and in parallel, which
+// DNS records are still missing. A pre-flight error is not fatal: this phase is
+// purely presentational, and the domain's worker re-does the same discovery in
+// phase 2 where the failure can be attributed and reported properly.
+func preflightIssuerDNS(ctx context.Context, projectName string, jobs []domainJob, issuer CertIssuer, resolverAt func(string) dns.Resolver) map[string][]dns.RequiredRecord {
+	pending := make(map[string][]dns.RequiredRecord, len(jobs))
+	var mu sync.Mutex
+	eg, gctx := errgroup.WithContext(ctx)
+	eg.SetLimit(maxCertWorkers)
+	for _, j := range jobs {
+		job := j
+		eg.Go(func() error {
+			records, err := issuer.PreflightCert(gctx, projectName, job.serviceName, job.domain, resolverAt)
+			if err != nil {
+				term.Debugf("Pre-flight cert check for %v failed: %v", job.domain, err)
+				return nil
+			}
+			if len(records) == 0 {
+				return nil
+			}
+			mu.Lock()
+			pending[job.domain] = records
+			mu.Unlock()
+			return nil
+		})
+	}
+	if err := eg.Wait(); err != nil {
+		return nil // ignore errors, this should never happen
+	}
+	return pending
+}
+
+// printGroupedRecords prints every pending record across every domain in a
+// single block, iterating jobs (not the map) so sibling hostnames stay in a
+// stable, source order. Rows carry the same [domain] prefix the phase-2 workers
+// use, and the name column is padded across the whole block so the arrows line
+// up as one table rather than one table per domain.
+func printGroupedRecords(jobs []domainJob, pending map[string][]dns.RequiredRecord, pad int) {
+	namePad := 0
+	for _, records := range pending {
+		for _, r := range records {
+			if len(r.Name) > namePad {
+				namePad = len(r.Name)
+			}
+		}
+	}
+	term.Infof("Configure the following DNS record(s):")
+	for _, j := range jobs {
+		records, ok := pending[j.domain]
+		if !ok {
+			continue
+		}
+		log := newDomainLogger(j.domain, pad)
+		for _, r := range records {
+			note := ""
+			if r.Note != "" {
+				note = "  (" + r.Note + ")"
+			}
+			log("%-5s  %-*s  ->  %s%s", r.Type, namePad, r.Name, r.Value, note)
+		}
 	}
 }
 

--- a/src/pkg/cli/cert_test.go
+++ b/src/pkg/cli/cert_test.go
@@ -348,18 +348,40 @@ func (m *mockCertFabricClient) calls() int {
 // interface so GenerateLetsEncryptCert's `provider.(CertIssuer)` succeeds.
 // Captures every (project, service, hostname) tuple the SUT calls IssueCert
 // with, and lets the test inject an error per call. The mutex makes the call
-// log safe under the new parallel-worker dispatch.
+// log safe under the parallel-worker dispatch.
+//
+// events records both phases in call order so tests can assert the pre-flight
+// pass completes before any issuance starts without racing on terminal output.
 type mockCertIssuerProvider struct {
 	mockCertProvider
-	mu        sync.Mutex
-	issueErr  error
-	issueCall []string
+	mu           sync.Mutex
+	issueErr     error
+	issueCall    []string
+	events       []string
+	preflight    map[string][]dns.RequiredRecord // hostname -> records still missing
+	preflightErr error
+	onIssue      func(log func(string, ...any))
 }
 
-func (m *mockCertIssuerProvider) IssueCert(_ context.Context, projectName, serviceName, hostname string, _ func(string) dns.Resolver) error {
+func (m *mockCertIssuerProvider) PreflightCert(_ context.Context, _, _, hostname string, _ func(string) dns.Resolver) ([]dns.RequiredRecord, error) {
+	m.mu.Lock()
+	m.events = append(m.events, "preflight:"+hostname)
+	m.mu.Unlock()
+	if m.preflightErr != nil {
+		return nil, m.preflightErr
+	}
+	return m.preflight[hostname], nil
+}
+
+func (m *mockCertIssuerProvider) IssueCert(_ context.Context, projectName, serviceName, hostname string, _ func(string) dns.Resolver, log func(string, ...any)) error {
 	m.mu.Lock()
 	m.issueCall = append(m.issueCall, fmt.Sprintf("%s/%s/%s", projectName, serviceName, hostname))
+	m.events = append(m.events, "issue:"+hostname)
+	onIssue := m.onIssue
 	m.mu.Unlock()
+	if onIssue != nil {
+		onIssue(log)
+	}
 	return m.issueErr
 }
 
@@ -369,6 +391,12 @@ func (m *mockCertIssuerProvider) sortedCalls() []string {
 	out := slices.Clone(m.issueCall)
 	sort.Strings(out)
 	return out
+}
+
+func (m *mockCertIssuerProvider) orderedEvents() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return slices.Clone(m.events)
 }
 
 func TestGenerateLetsEncryptCert(t *testing.T) {
@@ -743,6 +771,141 @@ func TestRunIssuerJobs_ParallelMultipleDomains(t *testing.T) {
 	}
 	if got := provider.sortedCalls(); !slices.Equal(got, want) {
 		t.Errorf("issued = %v, want %v (any order)", got, want)
+	}
+}
+
+// TestRunIssuerJobs_PreflightsBeforeIssuing pins the two-phase shape: every
+// domain is pre-flighted before any domain starts issuing, so the batched DNS
+// instructions can't be printed after a worker has already begun waiting. A
+// pre-flight failure must not abort or skip issuance — phase 2 re-does the
+// discovery and reports the error against its own domain.
+func TestRunIssuerJobs_PreflightsBeforeIssuing(t *testing.T) {
+	tests := []struct {
+		name         string
+		preflightErr error
+	}{
+		{name: "preflight succeeds"},
+		{name: "preflight fails", preflightErr: errors.New("container app not found")},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			provider := &mockCertIssuerProvider{
+				mockCertProvider: mockCertProvider{
+					services: &defangv1.GetServicesResponse{
+						Services: []*defangv1.ServiceInfo{
+							{Service: &defangv1.Service{Name: "web"}, UseAcmeCert: true, Domainname: "a.example.com"},
+							{Service: &defangv1.Service{Name: "api"}, UseAcmeCert: true, Domainname: "b.example.com"},
+						},
+					},
+				},
+				preflightErr: tt.preflightErr,
+			}
+			project := &compose.Project{
+				Name: "two",
+				Services: compose.Services{
+					"web": {Name: "web", DomainName: "a.example.com"},
+					"api": {Name: "api", DomainName: "b.example.com"},
+				},
+			}
+			if err := GenerateLetsEncryptCert(t.Context(), project, &mockCertFabricClient{}, provider); err != nil {
+				t.Fatalf("unexpected err: %v", err)
+			}
+			events := provider.orderedEvents()
+			if len(events) != 4 {
+				t.Fatalf("expected 2 preflights + 2 issues, got %v", events)
+			}
+			for i, e := range events {
+				wantPrefix := "issue:"
+				if i < 2 {
+					wantPrefix = "preflight:"
+				}
+				if !strings.HasPrefix(e, wantPrefix) {
+					t.Errorf("event %d = %q, want a %q event (all preflights must precede all issues): %v", i, e, wantPrefix, events)
+				}
+			}
+		})
+	}
+}
+
+// TestRunIssuerJobs_PrefixesIssuerOutput asserts the logger handed to IssueCert
+// is the same per-domain prefixed logger the workers use, so provider-internal
+// progress lines are attributed like every other line. Single domain keeps the
+// terminal buffer single-writer.
+func TestRunIssuerJobs_PrefixesIssuerOutput(t *testing.T) {
+	stdout, _ := term.SetupTestTerm(t)
+	provider := &mockCertIssuerProvider{
+		mockCertProvider: mockCertProvider{
+			services: &defangv1.GetServicesResponse{
+				Services: []*defangv1.ServiceInfo{
+					{Service: &defangv1.Service{Name: "web"}, UseAcmeCert: true, Domainname: "a.example.com"},
+				},
+			},
+		},
+		onIssue: func(log func(string, ...any)) { log("registering custom hostname") },
+	}
+	project := &compose.Project{
+		Name:     "one",
+		Services: compose.Services{"web": {Name: "web", DomainName: "a.example.com"}},
+	}
+	if err := GenerateLetsEncryptCert(t.Context(), project, &mockCertFabricClient{}, provider); err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	got := stripANSI(stdout.String())
+	if !strings.Contains(got, "[a.example.com] registering custom hostname") {
+		t.Errorf("issuer output not domain-prefixed:\n%s", got)
+	}
+}
+
+func TestPrintGroupedRecords(t *testing.T) {
+	jobs := []domainJob{
+		{serviceName: "web", domain: "example.com"},
+		{serviceName: "api", domain: "ready.example.com"},
+		{serviceName: "web", domain: "www.example.com"},
+	}
+	pending := map[string][]dns.RequiredRecord{
+		"example.com": {
+			{Type: "TXT", Name: "asuid.example.com", Value: "VID123", Note: "add this first"},
+			{Type: "A", Name: "example.com", Value: "20.1.2.3"},
+		},
+		"www.example.com": {
+			{Type: "CNAME", Name: "www.example.com", Value: "app.westus.azurecontainerapps.io"},
+		},
+	}
+
+	stdout, _ := term.SetupTestTerm(t)
+	printGroupedRecords(jobs, pending, maxDomainLen(jobs))
+	lines := strings.Split(strings.TrimRight(stripANSI(stdout.String()), "\n"), "\n")
+
+	if len(lines) != 4 {
+		t.Fatalf("expected 1 header + 3 record lines, got %d:\n%s", len(lines), strings.Join(lines, "\n"))
+	}
+	if !strings.Contains(lines[0], "Configure the following DNS record(s):") {
+		t.Errorf("missing single grouped header, got %q", lines[0])
+	}
+	// Source order of jobs, not map order; the already-ready domain is omitted.
+	wantPrefixes := []string{" * [example.com]", " * [example.com]", " * [www.example.com]"}
+	for i, want := range wantPrefixes {
+		if !strings.HasPrefix(lines[i+1], want) {
+			t.Errorf("line %d = %q, want prefix %q", i+1, lines[i+1], want)
+		}
+	}
+	if strings.Contains(stripANSI(stdout.String()), "ready.example.com") {
+		t.Error("domain with no pending records should not appear in the block")
+	}
+	if !strings.Contains(lines[1], "(add this first)") {
+		t.Errorf("note not rendered: %q", lines[1])
+	}
+	if strings.Contains(lines[2], "(") {
+		t.Errorf("empty note should render nothing: %q", lines[2])
+	}
+	// The arrow column is padded across the whole block, not per domain, so
+	// records for different domains still line up as one table.
+	cols := make([]int, len(lines)-1)
+	for i, l := range lines[1:] {
+		cols[i] = strings.Index(l, "->")
+	}
+	if cols[0] != cols[1] || cols[1] != cols[2] {
+		t.Errorf("arrow column not aligned across domains: %v\n%s", cols, strings.Join(lines[1:], "\n"))
 	}
 }
 

--- a/src/pkg/cli/client/byoc/azure/cert.go
+++ b/src/pkg/cli/client/byoc/azure/cert.go
@@ -7,17 +7,29 @@ import (
 	"github.com/DefangLabs/defang/src/pkg/dns"
 )
 
+// PreflightCert implements the pre-flight half of the cli.CertIssuer interface:
+// it reports the DNS records the hostname still needs so the CLI can print
+// every domain's records in one block before any of them starts waiting.
+func (b *ByocAzure) PreflightCert(ctx context.Context, projectName, serviceName, hostname string, resolverAt func(string) dns.Resolver) ([]dns.RequiredRecord, error) {
+	cred, err := b.driver.NewCreds()
+	if err != nil {
+		return nil, err
+	}
+	rg := b.projectResourceGroupName(projectName)
+	return aca.PreflightCert(ctx, cred, b.driver.SubscriptionID, rg, serviceName, hostname, resolverAt)
+}
+
 // IssueCert implements the cli.CertIssuer interface for the BYOD `defang cert
 // generate` flow: it resolves the provider's subscription, credentials, and
 // project resource group, then hands off to aca.IssueCert (cloud-SDK layer).
 // The CD task also calls aca.IssueCert directly after a deploy to provision
 // delegate-domain certs without depending on the CLI staying up. See
 // pkg/clouds/azure/aca/cert.go for the shared cert flow.
-func (b *ByocAzure) IssueCert(ctx context.Context, projectName, serviceName, hostname string, resolverAt func(string) dns.Resolver) error {
+func (b *ByocAzure) IssueCert(ctx context.Context, projectName, serviceName, hostname string, resolverAt func(string) dns.Resolver, log func(string, ...any)) error {
 	cred, err := b.driver.NewCreds()
 	if err != nil {
 		return err
 	}
 	rg := b.projectResourceGroupName(projectName)
-	return aca.IssueCert(ctx, cred, b.driver.SubscriptionID, rg, serviceName, hostname, resolverAt)
+	return aca.IssueCert(ctx, cred, b.driver.SubscriptionID, rg, serviceName, hostname, resolverAt, log)
 }

--- a/src/pkg/clouds/azure/aca/cert.go
+++ b/src/pkg/clouds/azure/aca/cert.go
@@ -13,6 +13,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
@@ -43,21 +44,37 @@ const (
 // for `serviceName` in `resourceGroup`. Steps:
 //
 //  1. Find the ContainerApp by tag (defang-service: <serviceName>).
-//  2. Wait for DNS records: a routing record (subdomain → CNAME to app FQDN;
-//     apex → A record to the env IP) plus TXT asuid.<host> → verificationId.
+//  2. Wait for TXT asuid.<host> → verificationId (ownership proof only; no
+//     routing record needed for this step).
 //  3. Register the custom hostname with bindingType: Disabled (validates asuid TXT).
-//  4. Issue a managed certificate (subdomain → CNAME validation; apex → HTTP).
-//  5. Flip the customDomain to bindingType: SniEnabled, attaching the cert.
-//  6. Verify TLS is serving on https://<hostname>/.
+//  4. Wait for the routing record: subdomain → CNAME to app FQDN, apex → A
+//     record to the env IP. Only needed now, ahead of cert issuance/binding —
+//     registering the hostname (steps 2-3) does not require live routing, so a
+//     caller that adds the asuid TXT record ahead of a DNS cutover lets Azure
+//     start validating ownership immediately instead of blocking on both
+//     records together.
+//  5. Issue a managed certificate (subdomain → CNAME validation; apex → HTTP).
+//  6. Flip the customDomain to bindingType: SniEnabled, attaching the cert.
+//  7. Verify TLS is serving on https://<hostname>/.
 //
 // Apex domains (e.g. example.com) can't have a CNAME (RFC 1034), so they route
 // via an A record and validate over HTTP. Apex vs subdomain is detected from DNS
 // and from Azure's validation-method rejection — no caller hint is needed.
 //
 // Each ARM step is idempotent: re-running after a partial failure picks up
-// where it left off. resolverAt is used by step 2 to chase the DNS chain — pass
-// dns.DirectResolverAt to query authoritative servers directly (CD task) or
-// dns.NewFabricResolverAt(client) to route through Fabric (CLI).
+// where it left off. resolverAt is used by steps 2 and 4 to chase the DNS chain
+// — pass dns.DirectResolverAt to query authoritative servers directly (CD task)
+// or dns.NewFabricResolverAt(client) to route through Fabric (CLI).
+//
+// Steps 3 and 6 read-modify-write the ContainerApp's CustomDomains array via
+// ARM's JSON Merge Patch, which replaces the array wholesale. A service can
+// have multiple hostnames (e.g. an apex domain plus a www alias) processed as
+// concurrent domainJobs (see cli/cert.go runIssuerJobs) that all target the
+// same ContainerApp — without serialization, two concurrent read-modify-writes
+// race: whichever PATCH lands last, built from a Get that predates the other's
+// write, silently drops the other's just-added binding. appLock guards exactly
+// that critical section, per (resourceGroup, appName), while leaving DNS waits
+// and cert issuance (independent per hostname) fully parallel.
 func IssueCert(ctx context.Context, cred azcore.TokenCredential, subscriptionID, resourceGroup, serviceName, hostname string, resolverAt func(string) dns.Resolver) error {
 	appsClient, err := armappcontainers.NewContainerAppsClient(subscriptionID, cred, nil)
 	if err != nil {
@@ -101,12 +118,17 @@ func IssueCert(ctx context.Context, cred azcore.TokenCredential, subscriptionID,
 		return nil
 	}
 
-	if err := waitForBYODdns(ctx, envsClient, resourceGroup, envName, hostname, appFqdn, vid, resolverAt); err != nil {
+	deadline := time.Now().Add(dnsWaitTimeout)
+	if err := waitForAsuidTXT(ctx, hostname, vid, deadline, resolverAt); err != nil {
 		return err
 	}
 
 	term.Infof("Registering custom hostname %s on container app %s", hostname, appName)
 	if err := addHostnameDisabled(ctx, appsClient, resourceGroup, appName, hostname); err != nil {
+		return err
+	}
+
+	if err := waitForRoutingRecord(ctx, envsClient, resourceGroup, envName, hostname, appFqdn, deadline, resolverAt); err != nil {
 		return err
 	}
 
@@ -146,8 +168,39 @@ func findContainerAppByService(ctx context.Context, client *armappcontainers.Con
 	return nil, fmt.Errorf("no Container App in %s tagged %s=%s", rg, ServiceTagKey, serviceName)
 }
 
-// waitForBYODdns blocks until a routing record and the asuid TXT record both
-// resolve, prompting the user once with the values to add.
+// waitForAsuidTXT blocks until the asuid.<hostname> TXT record (Azure's
+// domain-ownership proof) resolves, prompting the user once with the value to
+// add. Unlike the routing record, this is required only for hostname
+// registration (addHostnameDisabled) — it does not need traffic to route to
+// Azure yet, so a caller can add just this record ahead of a DNS cutover and
+// have the hostname registered/verified in advance.
+func waitForAsuidTXT(ctx context.Context, hostname, expectedTxt string, deadline time.Time, resolverAt func(string) dns.Resolver) error {
+	asuid := "asuid." + hostname
+	promptShown := false
+
+	for {
+		if txtOK, _ := dns.LookupTXTContains(ctx, asuid, expectedTxt, resolverAt("")); txtOK {
+			return nil
+		}
+		if !promptShown {
+			term.Printf("Configure DNS record for %s:\n", hostname)
+			term.Printf("  TXT    asuid.%s        ->  %s\n", hostname, expectedTxt)
+			term.Infof("Waiting for DNS propagation (timeout %v)...", time.Until(deadline).Round(time.Second))
+			promptShown = true
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("timed out after %v waiting for the asuid TXT record on %s", dnsWaitTimeout, hostname)
+		}
+		if err := pkg.SleepWithContext(ctx, dnsPollEvery); err != nil {
+			return err
+		}
+	}
+}
+
+// waitForRoutingRecord blocks until the routing record resolves, prompting
+// the user once with the value to add. Required before cert issuance: CNAME
+// validation needs a live CNAME, and HTTP validation needs live routing to
+// reach the app for the challenge.
 //
 // The routing record is a CNAME → app FQDN for a subdomain, or an A record for
 // an apex domain (no CNAME possible at the zone apex). Both are covered by
@@ -155,29 +208,24 @@ func findContainerAppByService(ctx context.Context, client *armappcontainers.Con
 // whose addresses match those of expectedCname — which for Container Apps is the
 // managed environment's static IP, exactly what an apex A record must point at.
 // So an apex domain is validated against the intended target, not merely
-// "resolves to something". The asuid TXT is always required.
-func waitForBYODdns(ctx context.Context, envsClient *armappcontainers.ManagedEnvironmentsClient, resourceGroup, envName, hostname, expectedCname, expectedTxt string, resolverAt func(string) dns.Resolver) error {
-	asuid := "asuid." + hostname
-	deadline := time.Now().Add(dnsWaitTimeout)
+// "resolves to something".
+func waitForRoutingRecord(ctx context.Context, envsClient *armappcontainers.ManagedEnvironmentsClient, resourceGroup, envName, hostname, expectedCname string, deadline time.Time, resolverAt func(string) dns.Resolver) error {
 	promptShown := false
 
 	for {
-		routeOK := dns.CheckDomainDNSReady(ctx, hostname, []string{expectedCname}, resolverAt)
-		txtOK, _ := dns.LookupTXTContains(ctx, asuid, expectedTxt, resolverAt(""))
-		if routeOK && txtOK {
+		if dns.CheckDomainDNSReady(ctx, hostname, []string{expectedCname}, resolverAt) {
 			term.Infof("DNS records for %s verified", hostname)
 			return nil
 		}
 		if !promptShown {
-			term.Printf("Configure DNS records for %s:\n", hostname)
+			term.Printf("Configure DNS record for %s:\n", hostname)
 			term.Printf("  CNAME  %s              ->  %s   (subdomain)\n", hostname, expectedCname)
 			term.Printf("  A      %s              ->  %s   (apex)\n", hostname, fetchEnvironmentStaticIP(ctx, envsClient, resourceGroup, envName))
-			term.Printf("  TXT    asuid.%s        ->  %s\n", hostname, expectedTxt)
-			term.Infof("Waiting for DNS propagation (timeout %v)...", dnsWaitTimeout)
+			term.Infof("Waiting for DNS propagation (timeout %v)...", time.Until(deadline).Round(time.Second))
 			promptShown = true
 		}
 		if time.Now().After(deadline) {
-			return fmt.Errorf("timed out after %v waiting for DNS records on %s", dnsWaitTimeout, hostname)
+			return fmt.Errorf("timed out after %v waiting for the routing record on %s", dnsWaitTimeout, hostname)
 		}
 		if err := pkg.SleepWithContext(ctx, dnsPollEvery); err != nil {
 			return err
@@ -202,6 +250,24 @@ func fetchEnvironmentStaticIP(ctx context.Context, envsClient *armappcontainers.
 	return *env.Properties.StaticIP
 }
 
+// appLocks serializes the read-modify-write critical section in
+// addHostnameDisabled and bindHostnameSniEnabled per (resourceGroup, appName).
+// A single service can have multiple hostnames (e.g. an apex domain plus a
+// www alias) processed as concurrent domainJobs that all target the same
+// ContainerApp; without this, two concurrent Get-modify-PATCH sequences race
+// and the later PATCH — built from a Get that predates the other's write —
+// silently drops the other's just-added customDomain entry.
+var appLocks sync.Map // map[string]*sync.Mutex, keyed by rg+"/"+appName
+
+func lockForApp(rg, appName string) *sync.Mutex {
+	v, _ := appLocks.LoadOrStore(rg+"/"+appName, &sync.Mutex{})
+	mu, ok := v.(*sync.Mutex)
+	if !ok {
+		panic("appLocks: stored value is not a *sync.Mutex") // unreachable: only ever stores *sync.Mutex
+	}
+	return mu
+}
+
 // addHostnameDisabled PATCHes the ContainerApp to add (or no-op) a customDomain
 // entry with bindingType: Disabled. Disabled doesn't require a cert, but does
 // validate asuid TXT — that's why we wait for DNS first.
@@ -209,10 +275,17 @@ func fetchEnvironmentStaticIP(ctx context.Context, envsClient *armappcontainers.
 // Azure ARM uses JSON Merge Patch (RFC 7396) which replaces arrays wholesale,
 // so we must include every existing CustomDomain entry in the body or they
 // will be wiped out by the update. We re-Get the CA right before the PATCH
-// rather than reusing a snapshot from the caller: waitForBYODdns can block
-// for up to 30 minutes, during which another deploy could have added its own
-// customDomain entry, and a stale slice would silently drop that.
+// rather than reusing a snapshot from the caller: the DNS wait can block for
+// up to 30 minutes, during which another deploy could have added its own
+// customDomain entry, and a stale slice would silently drop that. The
+// Get-through-PATCH sequence is itself guarded by appLock so a concurrent
+// call for a sibling hostname on the same app can't interleave its own
+// Get-modify-PATCH in between and clobber this one.
 func addHostnameDisabled(ctx context.Context, client *armappcontainers.ContainerAppsClient, rg, appName, hostname string) error {
+	mu := lockForApp(rg, appName)
+	mu.Lock()
+	defer mu.Unlock()
+
 	cur, err := client.Get(ctx, rg, appName, nil)
 	if err != nil {
 		return fmt.Errorf("fetching app %s before hostname registration: %w", appName, err)
@@ -446,8 +519,13 @@ func isInvalidValidationMethod(err error) bool {
 // Azure ARM uses JSON Merge Patch (RFC 7396) which replaces arrays wholesale,
 // so we fetch the current state, update the matching entry in place, and send
 // the full CustomDomains array back. Otherwise every other custom domain on
-// the app would be dropped by the PATCH.
+// the app would be dropped by the PATCH. appLock guards this Get-modify-PATCH
+// the same way it does in addHostnameDisabled — see appLocks doc comment.
 func bindHostnameSniEnabled(ctx context.Context, client *armappcontainers.ContainerAppsClient, rg, appName, hostname, certID string) error {
+	mu := lockForApp(rg, appName)
+	mu.Lock()
+	defer mu.Unlock()
+
 	cur, err := client.Get(ctx, rg, appName, nil)
 	if err != nil {
 		return fmt.Errorf("fetching app %s before cert bind: %w", appName, err)

--- a/src/pkg/clouds/azure/aca/cert.go
+++ b/src/pkg/clouds/azure/aca/cert.go
@@ -58,8 +58,10 @@ const (
 //  7. Verify TLS is serving on https://<hostname>/.
 //
 // Apex domains (e.g. example.com) can't have a CNAME (RFC 1034), so they route
-// via an A record and validate over HTTP. Apex vs subdomain is detected from DNS
-// and from Azure's validation-method rejection — no caller hint is needed.
+// via an A record and validate over HTTP. The DNS-instructions print uses
+// dns.IsApexDomain (a static check on the name) to show the one relevant
+// record; the actual wait/validation logic still confirms apex-ness from live
+// DNS and from Azure's validation-method rejection — no caller hint is needed.
 //
 // Each ARM step is idempotent: re-running after a partial failure picks up
 // where it left off. resolverAt is used by steps 2 and 4 to chase the DNS chain
@@ -118,19 +120,30 @@ func IssueCert(ctx context.Context, cred azcore.TokenCredential, subscriptionID,
 		return nil
 	}
 
-	// Print every required record up front, in one block, even though TXT and
-	// the routing record are waited on separately below: the user is looking
-	// at their DNS dashboard right now, and wants to add everything needed in
+	// Print the records up front, in one block, even though TXT and the
+	// routing record are waited on separately below: the user is looking at
+	// their DNS dashboard right now, and wants to add everything needed in
 	// one sitting rather than being told about the routing record only after
 	// TXT has already propagated (lionello, PR review on #2222).
+	//
+	// Only one of CNAME/A ever applies to a given hostname — showing both, as
+	// if either could be added, misled the user into thinking they had a
+	// choice (lionello, PR review on #2222, r3816456453). dns.IsApexDomain is
+	// a static, DNS-lookup-free check on the name itself, so the right record
+	// can be picked before any DNS is configured; it's independent of the
+	// live-DNS apex detection dns.CheckDomainDNSReady and the managed-cert
+	// validation-method fallback (below) use once records exist.
 	asuid := "asuid." + hostname
 	txtOK, _ := dns.LookupTXTContains(ctx, asuid, vid, resolverAt(""))
 	routeOK := dns.CheckDomainDNSReady(ctx, hostname, []string{appFqdn}, resolverAt)
 	if !txtOK || !routeOK {
 		term.Printf("Configure DNS records for %s:\n", hostname)
-		term.Printf("  TXT    asuid.%s        ->  %s   (add this first — the hostname can register as soon as this is live)\n", hostname, vid)
-		term.Printf("  CNAME  %s              ->  %s   (subdomain; needed before the cert can be issued)\n", hostname, appFqdn)
-		term.Printf("  A      %s              ->  %s   (apex; needed before the cert can be issued)\n", hostname, fetchEnvironmentStaticIP(ctx, envsClient, resourceGroup, envName))
+		term.Printf("  TXT    asuid.%s  ->  %s   (add this first — the hostname can register as soon as this is live)\n", hostname, vid)
+		if dns.IsApexDomain(hostname) {
+			term.Printf("  A      %s  ->  %s   (needed before the cert can be issued)\n", hostname, fetchEnvironmentStaticIP(ctx, envsClient, resourceGroup, envName))
+		} else {
+			term.Printf("  CNAME  %s  ->  %s   (needed before the cert can be issued)\n", hostname, appFqdn)
+		}
 	}
 
 	deadline := time.Now().Add(dnsWaitTimeout)

--- a/src/pkg/clouds/azure/aca/cert.go
+++ b/src/pkg/clouds/azure/aca/cert.go
@@ -118,6 +118,21 @@ func IssueCert(ctx context.Context, cred azcore.TokenCredential, subscriptionID,
 		return nil
 	}
 
+	// Print every required record up front, in one block, even though TXT and
+	// the routing record are waited on separately below: the user is looking
+	// at their DNS dashboard right now, and wants to add everything needed in
+	// one sitting rather than being told about the routing record only after
+	// TXT has already propagated (lionello, PR review on #2222).
+	asuid := "asuid." + hostname
+	txtOK, _ := dns.LookupTXTContains(ctx, asuid, vid, resolverAt(""))
+	routeOK := dns.CheckDomainDNSReady(ctx, hostname, []string{appFqdn}, resolverAt)
+	if !txtOK || !routeOK {
+		term.Printf("Configure DNS records for %s:\n", hostname)
+		term.Printf("  TXT    asuid.%s        ->  %s   (add this first — the hostname can register as soon as this is live)\n", hostname, vid)
+		term.Printf("  CNAME  %s              ->  %s   (subdomain; needed before the cert can be issued)\n", hostname, appFqdn)
+		term.Printf("  A      %s              ->  %s   (apex; needed before the cert can be issued)\n", hostname, fetchEnvironmentStaticIP(ctx, envsClient, resourceGroup, envName))
+	}
+
 	deadline := time.Now().Add(dnsWaitTimeout)
 	if err := waitForAsuidTXT(ctx, hostname, vid, deadline, resolverAt); err != nil {
 		return err
@@ -128,7 +143,7 @@ func IssueCert(ctx context.Context, cred azcore.TokenCredential, subscriptionID,
 		return err
 	}
 
-	if err := waitForRoutingRecord(ctx, envsClient, resourceGroup, envName, hostname, appFqdn, deadline, resolverAt); err != nil {
+	if err := waitForRoutingRecord(ctx, hostname, appFqdn, deadline, resolverAt); err != nil {
 		return err
 	}
 
@@ -169,24 +184,23 @@ func findContainerAppByService(ctx context.Context, client *armappcontainers.Con
 }
 
 // waitForAsuidTXT blocks until the asuid.<hostname> TXT record (Azure's
-// domain-ownership proof) resolves, prompting the user once with the value to
-// add. Unlike the routing record, this is required only for hostname
-// registration (addHostnameDisabled) — it does not need traffic to route to
-// Azure yet, so a caller can add just this record ahead of a DNS cutover and
-// have the hostname registered/verified in advance.
+// domain-ownership proof) resolves. Unlike the routing record, this is
+// required only for hostname registration (addHostnameDisabled) — it does
+// not need traffic to route to Azure yet, so a caller can add just this
+// record ahead of a DNS cutover and have the hostname registered/verified in
+// advance. The record values themselves are printed once by the caller,
+// covering both this and the routing record in one block — see IssueCert.
 func waitForAsuidTXT(ctx context.Context, hostname, expectedTxt string, deadline time.Time, resolverAt func(string) dns.Resolver) error {
 	asuid := "asuid." + hostname
-	promptShown := false
+	waitingLogged := false
 
 	for {
 		if txtOK, _ := dns.LookupTXTContains(ctx, asuid, expectedTxt, resolverAt("")); txtOK {
 			return nil
 		}
-		if !promptShown {
-			term.Printf("Configure DNS record for %s:\n", hostname)
-			term.Printf("  TXT    asuid.%s        ->  %s\n", hostname, expectedTxt)
-			term.Infof("Waiting for DNS propagation (timeout %v)...", time.Until(deadline).Round(time.Second))
-			promptShown = true
+		if !waitingLogged {
+			term.Infof("Waiting for the asuid TXT record on %s to propagate (timeout %v)...", hostname, time.Until(deadline).Round(time.Second))
+			waitingLogged = true
 		}
 		if time.Now().After(deadline) {
 			return fmt.Errorf("timed out after %v waiting for the asuid TXT record on %s", dnsWaitTimeout, hostname)
@@ -197,10 +211,9 @@ func waitForAsuidTXT(ctx context.Context, hostname, expectedTxt string, deadline
 	}
 }
 
-// waitForRoutingRecord blocks until the routing record resolves, prompting
-// the user once with the value to add. Required before cert issuance: CNAME
-// validation needs a live CNAME, and HTTP validation needs live routing to
-// reach the app for the challenge.
+// waitForRoutingRecord blocks until the routing record resolves. Required
+// before cert issuance: CNAME validation needs a live CNAME, and HTTP
+// validation needs live routing to reach the app for the challenge.
 //
 // The routing record is a CNAME → app FQDN for a subdomain, or an A record for
 // an apex domain (no CNAME possible at the zone apex). Both are covered by
@@ -208,21 +221,20 @@ func waitForAsuidTXT(ctx context.Context, hostname, expectedTxt string, deadline
 // whose addresses match those of expectedCname — which for Container Apps is the
 // managed environment's static IP, exactly what an apex A record must point at.
 // So an apex domain is validated against the intended target, not merely
-// "resolves to something".
-func waitForRoutingRecord(ctx context.Context, envsClient *armappcontainers.ManagedEnvironmentsClient, resourceGroup, envName, hostname, expectedCname string, deadline time.Time, resolverAt func(string) dns.Resolver) error {
-	promptShown := false
+// "resolves to something". The record values themselves are printed once by
+// the caller, covering both this and the TXT record in one block — see
+// IssueCert.
+func waitForRoutingRecord(ctx context.Context, hostname, expectedCname string, deadline time.Time, resolverAt func(string) dns.Resolver) error {
+	waitingLogged := false
 
 	for {
 		if dns.CheckDomainDNSReady(ctx, hostname, []string{expectedCname}, resolverAt) {
 			term.Infof("DNS records for %s verified", hostname)
 			return nil
 		}
-		if !promptShown {
-			term.Printf("Configure DNS record for %s:\n", hostname)
-			term.Printf("  CNAME  %s              ->  %s   (subdomain)\n", hostname, expectedCname)
-			term.Printf("  A      %s              ->  %s   (apex)\n", hostname, fetchEnvironmentStaticIP(ctx, envsClient, resourceGroup, envName))
-			term.Infof("Waiting for DNS propagation (timeout %v)...", time.Until(deadline).Round(time.Second))
-			promptShown = true
+		if !waitingLogged {
+			term.Infof("Waiting for the routing record on %s to propagate (timeout %v)...", hostname, time.Until(deadline).Round(time.Second))
+			waitingLogged = true
 		}
 		if time.Now().After(deadline) {
 			return fmt.Errorf("timed out after %v waiting for the routing record on %s", dnsWaitTimeout, hostname)

--- a/src/pkg/clouds/azure/aca/cert.go
+++ b/src/pkg/clouds/azure/aca/cert.go
@@ -40,6 +40,140 @@ const (
 	tlsPollEvery   = 5 * time.Second
 )
 
+// certTarget is the ContainerApp-derived state both PreflightCert and
+// IssueCert need: which app to patch, the ownership token to publish, and the
+// FQDN / environment the routing record and managed cert hang off.
+type certTarget struct {
+	appsClient  *armappcontainers.ContainerAppsClient
+	certsClient *armappcontainers.ManagedCertificatesClient
+	envsClient  *armappcontainers.ManagedEnvironmentsClient
+
+	resourceGroup string
+	app           *armappcontainers.ContainerApp
+	appName       string
+	vid           string // CustomDomainVerificationID, published as the asuid TXT value
+	appFqdn       string
+	envName       string
+	certName      string
+}
+
+// resolveCertTarget locates the ContainerApp tagged for serviceName and derives
+// everything the cert flow needs from it.
+//
+// PreflightCert and IssueCert each call this rather than one passing an opaque
+// handle to the other: the two run in separate phases of a provider-generic CLI
+// flow (see cli/cert.go runIssuerJobs), and threading Azure state through that
+// flow would leak ARM types into it. The cost is one extra ContainerApps list
+// per hostname, which is negligible next to the DNS waits and the two
+// long-running ARM operations that follow.
+func resolveCertTarget(ctx context.Context, cred azcore.TokenCredential, subscriptionID, resourceGroup, serviceName, hostname string) (*certTarget, error) {
+	appsClient, err := armappcontainers.NewContainerAppsClient(subscriptionID, cred, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating container apps client: %w", err)
+	}
+	certsClient, err := armappcontainers.NewManagedCertificatesClient(subscriptionID, cred, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating managed certificates client: %w", err)
+	}
+	envsClient, err := armappcontainers.NewManagedEnvironmentsClient(subscriptionID, cred, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating managed environments client: %w", err)
+	}
+
+	app, err := findContainerAppByService(ctx, appsClient, resourceGroup, serviceName)
+	if err != nil {
+		return nil, err
+	}
+	appName := derefString(app.Name)
+	if app.Properties == nil ||
+		app.Properties.CustomDomainVerificationID == nil ||
+		app.Properties.Configuration == nil ||
+		app.Properties.Configuration.Ingress == nil ||
+		app.Properties.Configuration.Ingress.Fqdn == nil ||
+		app.Properties.ManagedEnvironmentID == nil {
+		return nil, fmt.Errorf("container app %q is missing required ingress/verificationId fields", appName)
+	}
+	envID := *app.Properties.ManagedEnvironmentID
+	envName := envID[strings.LastIndex(envID, "/")+1:]
+	return &certTarget{
+		appsClient:    appsClient,
+		certsClient:   certsClient,
+		envsClient:    envsClient,
+		resourceGroup: resourceGroup,
+		app:           app,
+		appName:       appName,
+		vid:           *app.Properties.CustomDomainVerificationID,
+		appFqdn:       *app.Properties.Configuration.Ingress.Fqdn,
+		envName:       envName,
+		certName:      managedCertName(envName, hostname),
+	}, nil
+}
+
+// PreflightCert reports the DNS records `hostname` still needs before a cert
+// can be issued for it, doing no provisioning work of its own. A nil result
+// means there is nothing for the user to do: either both records are already
+// live, or the hostname is already serving TLS.
+//
+// This exists so the caller can probe every hostname first and present all
+// pending records in one block, before any hostname starts waiting — a user
+// staring at their DNS dashboard wants the full list in one sitting, not one
+// domain's records at a time as each worker happens to reach them. IssueCert
+// therefore does *not* print the records; callers that want them shown must
+// run this first.
+func PreflightCert(ctx context.Context, cred azcore.TokenCredential, subscriptionID, resourceGroup, serviceName, hostname string, resolverAt func(string) dns.Resolver) ([]dns.RequiredRecord, error) {
+	target, err := resolveCertTarget(ctx, cred, subscriptionID, resourceGroup, serviceName, hostname)
+	if err != nil {
+		return nil, err
+	}
+	if alreadyServingTLS(ctx, target.certsClient, resourceGroup, target.envName, target.certName, target.app, hostname) {
+		return nil, nil
+	}
+	return target.pendingRecords(ctx, hostname, resolverAt), nil
+}
+
+// pendingRecords returns both records the hostname needs whenever either is
+// missing: TXT and the routing record are waited on separately, but the user
+// wants to add everything in one sitting rather than being told about the
+// routing record only after TXT has already propagated (lionello, PR review
+// on #2222).
+//
+// Only one of CNAME/A ever applies to a given hostname — showing both, as if
+// either could be added, misled the user into thinking they had a choice
+// (lionello, PR review on #2222, r3816456453). dns.IsApexDomain is a static,
+// DNS-lookup-free check on the name itself, so the right record can be picked
+// before any DNS is configured; it's independent of the live-DNS apex detection
+// dns.CheckDomainDNSReady and the managed-cert validation-method fallback use
+// once records exist.
+func (t *certTarget) pendingRecords(ctx context.Context, hostname string, resolverAt func(string) dns.Resolver) []dns.RequiredRecord {
+	txtOK, _ := dns.LookupTXTContains(ctx, "asuid."+hostname, t.vid, resolverAt(""))
+	routeOK := dns.CheckDomainDNSReady(ctx, hostname, []string{t.appFqdn}, resolverAt)
+	if txtOK && routeOK {
+		return nil
+	}
+	records := []dns.RequiredRecord{{
+		Type:  "TXT",
+		Name:  "asuid." + hostname,
+		Value: t.vid,
+		Note:  "add this first — the hostname can register as soon as this is live",
+	}}
+	if dns.IsApexDomain(hostname) {
+		records = append(records, dns.RequiredRecord{
+			Type:  "A",
+			Name:  hostname,
+			Value: fetchEnvironmentStaticIP(ctx, t.envsClient, t.resourceGroup, t.envName),
+			Note:  "needed before the cert can be issued",
+		})
+	} else {
+		records = append(records, dns.RequiredRecord{
+			Type:  "CNAME",
+			Name:  hostname,
+			Value: t.appFqdn,
+			Note:  "needed before the cert can be issued",
+		})
+	}
+	return records
+}
+
 // IssueCert provisions a TLS cert for `hostname` on the ContainerApp tagged
 // for `serviceName` in `resourceGroup`. Steps:
 //
@@ -58,10 +192,17 @@ const (
 //  7. Verify TLS is serving on https://<hostname>/.
 //
 // Apex domains (e.g. example.com) can't have a CNAME (RFC 1034), so they route
-// via an A record and validate over HTTP. The DNS-instructions print uses
-// dns.IsApexDomain (a static check on the name) to show the one relevant
-// record; the actual wait/validation logic still confirms apex-ness from live
-// DNS and from Azure's validation-method rejection — no caller hint is needed.
+// via an A record and validate over HTTP. The wait/validation logic confirms
+// apex-ness from live DNS and from Azure's validation-method rejection — no
+// caller hint is needed.
+//
+// The records the user must create are *not* printed here; call PreflightCert
+// for those, so a caller issuing for several hostnames can show them all in one
+// block before any of them starts waiting.
+//
+// Every user-facing progress line goes through log, which the CLI points at a
+// per-domain prefixed logger so concurrent hostnames stay readable; pass nil to
+// get plain term.Infof output.
 //
 // Each ARM step is idempotent: re-running after a partial failure picks up
 // where it left off. resolverAt is used by steps 2 and 4 to chase the DNS chain
@@ -77,101 +218,52 @@ const (
 // write, silently drops the other's just-added binding. appLock guards exactly
 // that critical section, per (resourceGroup, appName), while leaving DNS waits
 // and cert issuance (independent per hostname) fully parallel.
-func IssueCert(ctx context.Context, cred azcore.TokenCredential, subscriptionID, resourceGroup, serviceName, hostname string, resolverAt func(string) dns.Resolver) error {
-	appsClient, err := armappcontainers.NewContainerAppsClient(subscriptionID, cred, nil)
-	if err != nil {
-		return fmt.Errorf("creating container apps client: %w", err)
-	}
-	certsClient, err := armappcontainers.NewManagedCertificatesClient(subscriptionID, cred, nil)
-	if err != nil {
-		return fmt.Errorf("creating managed certificates client: %w", err)
-	}
-	envsClient, err := armappcontainers.NewManagedEnvironmentsClient(subscriptionID, cred, nil)
-	if err != nil {
-		return fmt.Errorf("creating managed environments client: %w", err)
+func IssueCert(ctx context.Context, cred azcore.TokenCredential, subscriptionID, resourceGroup, serviceName, hostname string, resolverAt func(string) dns.Resolver, log func(string, ...any)) error {
+	if log == nil {
+		log = func(format string, args ...any) { term.Infof(format, args...) }
 	}
 
-	app, err := findContainerAppByService(ctx, appsClient, resourceGroup, serviceName)
+	target, err := resolveCertTarget(ctx, cred, subscriptionID, resourceGroup, serviceName, hostname)
 	if err != nil {
 		return err
 	}
-	appName := derefString(app.Name)
-	if app.Properties == nil ||
-		app.Properties.CustomDomainVerificationID == nil ||
-		app.Properties.Configuration == nil ||
-		app.Properties.Configuration.Ingress == nil ||
-		app.Properties.Configuration.Ingress.Fqdn == nil ||
-		app.Properties.ManagedEnvironmentID == nil {
-		return fmt.Errorf("container app %q is missing required ingress/verificationId fields", appName)
-	}
-	vid := *app.Properties.CustomDomainVerificationID
-	appFqdn := *app.Properties.Configuration.Ingress.Fqdn
-	envID := *app.Properties.ManagedEnvironmentID
-	envName := envID[strings.LastIndex(envID, "/")+1:]
-	certName := managedCertName(envName, hostname)
 
 	// Short-circuit: if the hostname is already bound SniEnabled with a cert and
 	// that managed cert is in the Succeeded state, the host is already serving
 	// TLS — skip the DNS wait, the cert create-or-update, and the SNI re-bind.
 	// All of those are idempotent but run two long-running ARM operations per
 	// service on every deploy; this avoids that work when nothing changed.
-	if alreadyServingTLS(ctx, certsClient, resourceGroup, envName, certName, app, hostname) {
-		term.Debugf("Cert %s for %s already provisioned and bound; skipping issuance", certName, hostname)
+	if alreadyServingTLS(ctx, target.certsClient, resourceGroup, target.envName, target.certName, target.app, hostname) {
+		term.Debugf("Cert %s for %s already provisioned and bound; skipping issuance", target.certName, hostname)
 		return nil
 	}
 
-	// Print the records up front, in one block, even though TXT and the
-	// routing record are waited on separately below: the user is looking at
-	// their DNS dashboard right now, and wants to add everything needed in
-	// one sitting rather than being told about the routing record only after
-	// TXT has already propagated (lionello, PR review on #2222).
-	//
-	// Only one of CNAME/A ever applies to a given hostname — showing both, as
-	// if either could be added, misled the user into thinking they had a
-	// choice (lionello, PR review on #2222, r3816456453). dns.IsApexDomain is
-	// a static, DNS-lookup-free check on the name itself, so the right record
-	// can be picked before any DNS is configured; it's independent of the
-	// live-DNS apex detection dns.CheckDomainDNSReady and the managed-cert
-	// validation-method fallback (below) use once records exist.
-	asuid := "asuid." + hostname
-	txtOK, _ := dns.LookupTXTContains(ctx, asuid, vid, resolverAt(""))
-	routeOK := dns.CheckDomainDNSReady(ctx, hostname, []string{appFqdn}, resolverAt)
-	if !txtOK || !routeOK {
-		term.Printf("Configure DNS records for %s:\n", hostname)
-		term.Printf("  TXT    asuid.%s  ->  %s   (add this first — the hostname can register as soon as this is live)\n", hostname, vid)
-		if dns.IsApexDomain(hostname) {
-			term.Printf("  A      %s  ->  %s   (needed before the cert can be issued)\n", hostname, fetchEnvironmentStaticIP(ctx, envsClient, resourceGroup, envName))
-		} else {
-			term.Printf("  CNAME  %s  ->  %s   (needed before the cert can be issued)\n", hostname, appFqdn)
-		}
-	}
-
 	deadline := time.Now().Add(dnsWaitTimeout)
-	if err := waitForAsuidTXT(ctx, hostname, vid, deadline, resolverAt); err != nil {
+	if err := waitForAsuidTXT(ctx, hostname, target.vid, deadline, resolverAt, log); err != nil {
 		return err
 	}
 
-	term.Infof("Registering custom hostname %s on container app %s", hostname, appName)
-	if err := addHostnameDisabled(ctx, appsClient, resourceGroup, appName, hostname); err != nil {
+	log("registering custom hostname on container app %s…", target.appName)
+	if err := addHostnameDisabled(ctx, target.appsClient, resourceGroup, target.appName, hostname); err != nil {
 		return err
 	}
 
-	if err := waitForRoutingRecord(ctx, hostname, appFqdn, deadline, resolverAt); err != nil {
+	if err := waitForRoutingRecord(ctx, hostname, target.appFqdn, deadline, resolverAt, log); err != nil {
 		return err
 	}
 
-	term.Infof("Issuing managed certificate %s (this may take up to ~5 minutes)", certName)
-	issued, err := issueManagedCertificate(ctx, certsClient, resourceGroup, envName, certName, hostname, derefString(app.Location))
+	log("issuing managed certificate %s (may take up to ~5 minutes)…", target.certName)
+	issued, err := issueManagedCertificate(ctx, target.certsClient, resourceGroup, target.envName, target.certName, hostname, derefString(target.app.Location), log)
 	if err != nil {
 		return err
 	}
 
-	term.Infof("Binding cert to %s on %s", hostname, appName)
-	if err := bindHostnameSniEnabled(ctx, appsClient, resourceGroup, appName, hostname, derefString(issued.ID)); err != nil {
+	log("binding cert on container app %s…", target.appName)
+	if err := bindHostnameSniEnabled(ctx, target.appsClient, resourceGroup, target.appName, hostname, derefString(issued.ID)); err != nil {
 		return err
 	}
 
-	term.Infof("Waiting for TLS to come online on https://%s/", hostname)
+	log("waiting for TLS cert to come online…")
 	return waitForTLS(ctx, hostname, resolverAt(""))
 }
 
@@ -201,9 +293,9 @@ func findContainerAppByService(ctx context.Context, client *armappcontainers.Con
 // required only for hostname registration (addHostnameDisabled) — it does
 // not need traffic to route to Azure yet, so a caller can add just this
 // record ahead of a DNS cutover and have the hostname registered/verified in
-// advance. The record values themselves are printed once by the caller,
-// covering both this and the routing record in one block — see IssueCert.
-func waitForAsuidTXT(ctx context.Context, hostname, expectedTxt string, deadline time.Time, resolverAt func(string) dns.Resolver) error {
+// advance. The record values themselves are printed once by the caller's
+// pre-flight, covering both this and the routing record — see PreflightCert.
+func waitForAsuidTXT(ctx context.Context, hostname, expectedTxt string, deadline time.Time, resolverAt func(string) dns.Resolver, log func(string, ...any)) error {
 	asuid := "asuid." + hostname
 	waitingLogged := false
 
@@ -212,7 +304,7 @@ func waitForAsuidTXT(ctx context.Context, hostname, expectedTxt string, deadline
 			return nil
 		}
 		if !waitingLogged {
-			term.Infof("Waiting for the asuid TXT record on %s to propagate (timeout %v)...", hostname, time.Until(deadline).Round(time.Second))
+			log("waiting for the asuid TXT record to propagate (timeout %v)…", time.Until(deadline).Round(time.Second))
 			waitingLogged = true
 		}
 		if time.Now().After(deadline) {
@@ -235,18 +327,18 @@ func waitForAsuidTXT(ctx context.Context, hostname, expectedTxt string, deadline
 // managed environment's static IP, exactly what an apex A record must point at.
 // So an apex domain is validated against the intended target, not merely
 // "resolves to something". The record values themselves are printed once by
-// the caller, covering both this and the TXT record in one block — see
-// IssueCert.
-func waitForRoutingRecord(ctx context.Context, hostname, expectedCname string, deadline time.Time, resolverAt func(string) dns.Resolver) error {
+// the caller's pre-flight, covering both this and the TXT record — see
+// PreflightCert.
+func waitForRoutingRecord(ctx context.Context, hostname, expectedCname string, deadline time.Time, resolverAt func(string) dns.Resolver, log func(string, ...any)) error {
 	waitingLogged := false
 
 	for {
 		if dns.CheckDomainDNSReady(ctx, hostname, []string{expectedCname}, resolverAt) {
-			term.Infof("DNS records for %s verified", hostname)
+			log("DNS verified")
 			return nil
 		}
 		if !waitingLogged {
-			term.Infof("Waiting for the routing record on %s to propagate (timeout %v)...", hostname, time.Until(deadline).Round(time.Second))
+			log("waiting for the routing record to propagate (timeout %v)…", time.Until(deadline).Round(time.Second))
 			waitingLogged = true
 		}
 		if time.Now().After(deadline) {
@@ -412,7 +504,7 @@ func hasCustomDomain(app *armappcontainers.ContainerApp, hostname string) bool {
 // env IP and the hostname is registered (no extra DNS record needed). If HTTP
 // also fails we fall back to TXT validation (the interactive _dnsauth dance,
 // usable from the CLI).
-func issueManagedCertificate(ctx context.Context, client *armappcontainers.ManagedCertificatesClient, rg, envName, certName, hostname, location string) (*armappcontainers.ManagedCertificate, error) {
+func issueManagedCertificate(ctx context.Context, client *armappcontainers.ManagedCertificatesClient, rg, envName, certName, hostname, location string, log func(string, ...any)) (*armappcontainers.ManagedCertificate, error) {
 	resp, err := submitManagedCert(ctx, client, rg, envName, certName, hostname, location, armappcontainers.ManagedCertificateDomainControlValidationCNAME)
 	if err == nil {
 		return resp, nil
@@ -425,14 +517,14 @@ func issueManagedCertificate(ctx context.Context, client *armappcontainers.Manag
 	// DNS record (the asuid TXT + A record already in place suffice), so it works
 	// unattended in the CD task — unlike TXT, which requires an interactive
 	// _dnsauth record.
-	term.Infof("CNAME validation rejected for %s (apex domain); using HTTP validation", hostname)
+	log("CNAME validation rejected (apex domain); using HTTP validation")
 	resp, err = submitManagedCert(ctx, client, rg, envName, certName, hostname, location, armappcontainers.ManagedCertificateDomainControlValidationHTTP)
 	if err == nil {
 		return resp, nil
 	}
 
-	term.Infof("HTTP validation failed for %s (%v); falling back to TXT validation", hostname, err)
-	return submitManagedCertTXT(ctx, client, rg, envName, certName, hostname, location)
+	log("HTTP validation failed (%v); falling back to TXT validation", err)
+	return submitManagedCertTXT(ctx, client, rg, envName, certName, hostname, location, log)
 }
 
 // submitManagedCert creates the cert with the given validation method and
@@ -466,7 +558,7 @@ func submitManagedCert(ctx context.Context, client *armappcontainers.ManagedCert
 // initial PUT response includes a validationToken that we must surface
 // before Azure can complete validation; we GET the cert in a loop until the
 // token is populated, prompt once, then wait for ProvisioningState=Succeeded.
-func submitManagedCertTXT(ctx context.Context, client *armappcontainers.ManagedCertificatesClient, rg, envName, certName, hostname, location string) (*armappcontainers.ManagedCertificate, error) {
+func submitManagedCertTXT(ctx context.Context, client *armappcontainers.ManagedCertificatesClient, rg, envName, certName, hostname, location string, log func(string, ...any)) (*armappcontainers.ManagedCertificate, error) {
 	envelope := armappcontainers.ManagedCertificate{
 		Location: to.Ptr(location),
 		Properties: &armappcontainers.ManagedCertificateProperties{
@@ -510,10 +602,12 @@ func submitManagedCertTXT(ctx context.Context, client *armappcontainers.ManagedC
 		}
 	}
 
+	// Unlike the records from PreflightCert, this one can't be batched into the
+	// up-front block: Azure only mints the token once the PUT is in flight.
 	dnsauth := "_dnsauth." + hostname
-	term.Printf("Add TXT record for managed cert validation:\n")
-	term.Printf("  TXT  %s  ->  %s\n", dnsauth, token)
-	term.Infof("Waiting for %s and cert provisioning to finish (timeout ~5m)...", dnsauth)
+	log("configure one more DNS record for managed cert validation:")
+	log("  TXT    %s  ->  %s", dnsauth, token)
+	log("waiting for %s and cert provisioning to finish (timeout ~5m)…", dnsauth)
 
 	pollResp, err := poller.PollUntilDone(ctx, nil)
 	if err != nil {
@@ -590,11 +684,12 @@ func bindHostnameSniEnabled(ctx context.Context, client *armappcontainers.Contai
 	return nil
 }
 
+// waitForTLS is silent on success: the caller's "waiting for TLS cert to come
+// online…" line already framed the wait, and returning is the confirmation.
 func waitForTLS(ctx context.Context, hostname string, resolver dns.Resolver) error {
 	deadline := time.Now().Add(tlsWaitTimeout)
 	for {
 		if err := cert.CheckTLSCert(ctx, hostname, resolver); err == nil {
-			term.Infof("TLS cert for %s is online", hostname)
 			return nil
 		}
 		if time.Now().After(deadline) {

--- a/src/pkg/clouds/azure/aca/cert_test.go
+++ b/src/pkg/clouds/azure/aca/cert_test.go
@@ -5,12 +5,15 @@ import (
 	"encoding/hex"
 	"errors"
 	"net/http"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	armappcontainers "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appcontainers/armappcontainers/v3"
+
+	"github.com/DefangLabs/defang/src/pkg/dns"
 )
 
 func ptr[T any](v T) *T { return &v }
@@ -31,6 +34,64 @@ func appWithCustomDomains(names []string) *armappcontainers.ContainerApp {
 				},
 			},
 		},
+	}
+}
+
+// TestPendingRecords covers the non-apex branch and the nothing-to-do branch.
+// The apex branch needs a live ManagedEnvironments client to look up the env's
+// static IP; the apex-vs-subdomain decision itself is dns.IsApexDomain, which
+// is unit-tested in pkg/dns.
+func TestPendingRecords(t *testing.T) {
+	const (
+		hostname = "www.example.com"
+		appFqdn  = "app.westus.azurecontainerapps.io"
+		vid      = "VID123"
+	)
+	nsRecords := dns.DNSResponse{Records: []string{"ns1.example.com", "ns2.example.com"}}
+
+	tests := []struct {
+		name     string
+		resolver dns.MockResolver
+		want     []dns.RequiredRecord
+	}{
+		{
+			name:     "nothing configured yet",
+			resolver: dns.MockResolver{}, // every lookup fails: neither record exists
+			want: []dns.RequiredRecord{
+				{Type: "TXT", Name: "asuid." + hostname, Value: vid, Note: "add this first — the hostname can register as soon as this is live"},
+				{Type: "CNAME", Name: hostname, Value: appFqdn, Note: "needed before the cert can be issued"},
+			},
+		},
+		{
+			name: "routing record live but ownership TXT missing",
+			resolver: dns.MockResolver{Records: map[dns.DNSRequest]dns.DNSResponse{
+				{Type: "NS", Domain: hostname}:    nsRecords,
+				{Type: "CNAME", Domain: hostname}: {Records: []string{appFqdn}},
+			}},
+			want: []dns.RequiredRecord{
+				{Type: "TXT", Name: "asuid." + hostname, Value: vid, Note: "add this first — the hostname can register as soon as this is live"},
+				{Type: "CNAME", Name: hostname, Value: appFqdn, Note: "needed before the cert can be issued"},
+			},
+		},
+		{
+			name: "both records live",
+			resolver: dns.MockResolver{Records: map[dns.DNSRequest]dns.DNSResponse{
+				{Type: "TXT", Domain: "asuid." + hostname}: {Records: []string{vid}},
+				{Type: "NS", Domain: hostname}:             nsRecords,
+				{Type: "CNAME", Domain: hostname}:          {Records: []string{appFqdn}},
+			}},
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			target := &certTarget{vid: vid, appFqdn: appFqdn}
+			got := target.pendingRecords(t.Context(), hostname, func(string) dns.Resolver { return tt.resolver })
+			if !slices.Equal(got, tt.want) {
+				t.Errorf("pendingRecords = %+v, want %+v", got, tt.want)
+			}
+		})
 	}
 }
 

--- a/src/pkg/clouds/azure/aca/cert_test.go
+++ b/src/pkg/clouds/azure/aca/cert_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"net/http"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
@@ -30,6 +31,56 @@ func appWithCustomDomains(names []string) *armappcontainers.ContainerApp {
 				},
 			},
 		},
+	}
+}
+
+func TestLockForAppSameKeySameMutex(t *testing.T) {
+	a := lockForApp("rg", "app")
+	b := lockForApp("rg", "app")
+	if a != b {
+		t.Error("lockForApp returned different mutexes for the same (rg, appName)")
+	}
+}
+
+func TestLockForAppDifferentKeysDifferentMutex(t *testing.T) {
+	if lockForApp("rg", "app1") == lockForApp("rg", "app2") {
+		t.Error("lockForApp returned the same mutex for different appNames")
+	}
+	if lockForApp("rg1", "app") == lockForApp("rg2", "app") {
+		t.Error("lockForApp returned the same mutex for different resource groups")
+	}
+}
+
+// TestLockForAppSerializesSameApp guards against the regression that caused
+// the 2026-08-19 defang.io outage: two hostnames on the same ContainerApp
+// (e.g. an apex domain and its www alias) are processed as concurrent
+// domainJobs (cli/cert.go runIssuerJobs), each calling addHostnameDisabled /
+// bindHostnameSniEnabled, which Get-modify-PATCH the same CustomDomains array.
+// Without appLock serializing that critical section per app, two concurrent
+// non-atomic increments on a value guarded by "the same lock" would race and
+// lose updates — exactly mirroring how a losing PATCH silently dropped a
+// sibling hostname's binding. This test asserts the lock actually provides
+// exclusion, not just that it returns a mutex.
+func TestLockForAppSerializesSameApp(t *testing.T) {
+	const goroutines = 50
+	counter := 0
+	var wg sync.WaitGroup
+	for range goroutines {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			mu := lockForApp("rg", "shared-app")
+			mu.Lock()
+			defer mu.Unlock()
+			// A non-atomic read-modify-write: only safe under mutual exclusion.
+			cur := counter
+			cur++
+			counter = cur
+		}()
+	}
+	wg.Wait()
+	if counter != goroutines {
+		t.Errorf("counter = %d, want %d (lost updates under concurrent access)", counter, goroutines)
 	}
 }
 

--- a/src/pkg/clouds/azure/aca/cert_test.go
+++ b/src/pkg/clouds/azure/aca/cert_test.go
@@ -74,6 +74,16 @@ func TestPendingRecords(t *testing.T) {
 			},
 		},
 		{
+			name: "ownership TXT live but routing record missing",
+			resolver: dns.MockResolver{Records: map[dns.DNSRequest]dns.DNSResponse{
+				{Type: "TXT", Domain: "asuid." + hostname}: {Records: []string{vid}},
+			}},
+			want: []dns.RequiredRecord{
+				{Type: "TXT", Name: "asuid." + hostname, Value: vid, Note: "add this first — the hostname can register as soon as this is live"},
+				{Type: "CNAME", Name: hostname, Value: appFqdn, Note: "needed before the cert can be issued"},
+			},
+		},
+		{
 			name: "both records live",
 			resolver: dns.MockResolver{Records: map[dns.DNSRequest]dns.DNSResponse{
 				{Type: "TXT", Domain: "asuid." + hostname}: {Records: []string{vid}},

--- a/src/pkg/dns/utils.go
+++ b/src/pkg/dns/utils.go
@@ -1,6 +1,10 @@
 package dns
 
-import "strings"
+import (
+	"strings"
+
+	"golang.org/x/net/publicsuffix"
+)
 
 func SafeLabel(fqn string) string {
 	return strings.ReplaceAll(strings.ToLower(fqn), ".", "-")
@@ -8,4 +12,20 @@ func SafeLabel(fqn string) string {
 
 func Normalize(domain string) string {
 	return strings.ToLower(strings.TrimSuffix(domain, "."))
+}
+
+// IsApexDomain reports whether hostname is a registrable domain's apex/root
+// (e.g. "example.com", "example.co.uk") rather than a subdomain of one (e.g.
+// "www.example.com"). It's a static property of the name — no DNS lookup
+// involved — so callers can use it to pick CNAME vs A record instructions
+// before any DNS is configured. A hostname that isn't a valid registrable
+// domain (e.g. a bare public suffix) is treated as non-apex: it can't be
+// bound as a custom domain anyway.
+func IsApexDomain(hostname string) bool {
+	hostname = Normalize(hostname)
+	etld1, err := publicsuffix.EffectiveTLDPlusOne(hostname)
+	if err != nil {
+		return false
+	}
+	return etld1 == hostname
 }

--- a/src/pkg/dns/utils.go
+++ b/src/pkg/dns/utils.go
@@ -6,6 +6,17 @@ import (
 	"golang.org/x/net/publicsuffix"
 )
 
+// RequiredRecord is one DNS record the user must create before a provider can
+// issue a certificate for a hostname. It lives here rather than in either the
+// CLI or a provider package so a provider's cert pre-flight can hand records
+// back to provider-generic CLI code without either side importing the other.
+type RequiredRecord struct {
+	Type  string // record type, e.g. "TXT", "CNAME", "A"
+	Name  string // fully-qualified record name
+	Value string // record value / target
+	Note  string // optional one-line hint on why or when the record is needed
+}
+
 func SafeLabel(fqn string) string {
 	return strings.ReplaceAll(strings.ToLower(fqn), ".", "-")
 }

--- a/src/pkg/dns/utils_test.go
+++ b/src/pkg/dns/utils_test.go
@@ -37,3 +37,26 @@ func TestNormalize(t *testing.T) {
 		}
 	}
 }
+
+func TestIsApexDomain(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected bool
+	}{
+		{"example.com", true},
+		{"EXAMPLE.COM", true},
+		{"example.com.", true},
+		{"example.co.uk", true},
+		{"www.example.com", false},
+		{"shop.example.co.uk", false},
+		{"a.b.example.com", false},
+		{"com", false},
+	}
+
+	for _, test := range tests {
+		result := IsApexDomain(test.input)
+		if result != test.expected {
+			t.Errorf("IsApexDomain(%q) = %v; want %v", test.input, result, test.expected)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- `defang.io` went down on 2026-08-19 right after `defang cert gen` reported `cert issued ✓` for it. Root cause: `addHostnameDisabled`/`bindHostnameSniEnabled` each Get the ContainerApp, modify `CustomDomains` in memory, and PATCH the whole array back (ARM JSON Merge Patch replaces arrays wholesale). `runIssuerJobs` processes every hostname on a service as a concurrent `domainJob`, so `defang.io` (apex) and `www.defang.io` — both on the `website` ContainerApp — raced: `www`'s PATCH landed last, built from a Get that predated `defang.io`'s own PATCH, and silently dropped the apex binding even though Azure had already issued its cert and the CLI's own live-TLS check had passed moments earlier.
- Fix: serialize the Get-modify-PATCH critical section per `(resourceGroup, appName)` via a package-level lock map, so sibling hostnames on the same app can't interleave. Hostnames on different apps stay fully parallel — this only removes the unsafe overlap.
- Also splits the DNS wait: hostname registration only needs the `asuid` TXT record (ownership proof), not the routing record, so it no longer blocks on both together. A caller can now add just the TXT record ahead of a DNS cutover and have the hostname registered/verified in advance, instead of everything blocking until the routing record is flipped (which is also when downtime starts).

## Test plan
- [x] `go build ./...` (CGO_ENABLED=0; no gcc in this sandbox)
- [x] `go test -short ./pkg/clouds/azure/...` and `./pkg/cli/...`
- [x] `golangci-lint run ./pkg/clouds/azure/aca/...` — 0 issues
- [x] Added `TestLockForAppSerializesSameApp`, which reproduces the lost-update shape (concurrent non-atomic read-modify-write under the same lock key) and asserts no updates are lost
- [ ] Re-run `defang cert gen` against a service with an apex + alias hostname pair once merged, to confirm both bind cleanly in one run

Fixes the incident from today's defang.io outage (bound the cert manually via `az containerapp hostname bind` as an immediate mitigation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T3WmpdY3zc555sNdkY9dzQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved custom-domain validation by verifying ownership before routing configuration.
  * Began hostname registration earlier to reduce delays during Azure validation.
  * Ensured routing validation completes before managed-certificate issuance.
  * Prevented concurrent custom-domain updates from overwriting each other.
  * Added preflight checks that show only the DNS records still required.
  * Improved handling of apex domains and subdomains during DNS setup.
  * Added clearer, grouped DNS instructions and propagation-status updates.
  * Continued processing other domains when one certificate encounters an error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->