### PR TITLE
fix(gcp): grant the CD service account project-level storage.admin

### DIFF
--- a/src/pkg/cli/client/byoc/gcp/byoc.go
+++ b/src/pkg/cli/client/byoc/gcp/byoc.go
@@ -251,6 +251,7 @@ func (b *ByocGcp) SetUpCD(ctx context.Context, force bool) error {
 		"roles/datastore.owner",                 // For creating firestore database
 		"roles/logging.logWriter",               // For allowing cloudbuild to write logs
 		"roles/cloudscheduler.admin",            // For scheduling clean up jobs
+		"roles/storage.admin",                   // For creating the per-project build-artifacts bucket (pulumi-defang provider/defanggcp/gcp/artifact_registry.go); the bucket-scoped grant below only covers the CD's own fixed state bucket
 	}); err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary
Answers Lio's question on DefangLabs/defang-mvp#3181: yes, this needs a code fix in the CLI's GCP CD bootstrapping, not a one-off manual IAM grant.

`SetUpCD` (`byoc/gcp/byoc.go`) grants `defang-cd`'s service account a long list of project-level `*.admin` roles (one per GCP service it touches), plus a **bucket-scoped** `roles/storage.admin` on the CD's own fixed state bucket (`EnsurePrincipalHasBucketRoles(ctx, b.bucket, ...)`). That bucket-scoped grant only covers that one pre-existing bucket — it says nothing about creating a *different*, not-yet-existing bucket.

pulumi-defang's GCP provider creates exactly that: a per-project build-artifacts bucket for build-from-source deploys (`provider/defanggcp/gcp/artifact_registry.go`, `storage.NewBucket(ctx, projectName, ...)`). Git history shows that bucket-creation code has existed since 2026-07-08 — it predates the current GCP CE-secrets work by weeks, so this isn't a regression from anything currently in flight. It's a pre-existing gap in build-from-source support for GCP, and it looks like this smoketest is the first thing that's actually exercised it against live infra.

Confirmed live in defang-mvp#3181's `new-provider-sanity` run:
```
googleapi: Error 403: defang-cd@defang-playground-dev.iam.gserviceaccount.com does not have storage.buckets.create access to the Google Cloud project.
```

## Change
Add `roles/storage.admin` to the project-level role list `SetUpCD` grants — same pattern as every other resource type in that same list (each gets its own project-level `.admin`/`.owner` role).

## Why this self-heals existing customers
`SetUpCD`'s `EnsurePrincipalHasRoles` is additive/idempotent (checks-then-grants against the live project IAM policy) and isn't gated behind a persisted "already bootstrapped" flag — it runs on every deploy. Once this ships, any existing GCP customer's `defang-cd` SA picks up the new role automatically on their next `defang up`/`compose up`, no manual re-install needed.

## Test plan
- [x] `go build`/`go test -short ./pkg/cli/client/byoc/gcp/...` pass
- [x] `golangci-lint run ./pkg/cli/client/byoc/gcp/...` — 0 issues
- [ ] Re-dispatch `new-provider-sanity.yml` with `cli-version` pointed at this branch to confirm the GCP leg gets past bucket creation (next thing after that: pulumi-defang#455's firewall-name fix also needs to be in the CD image)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * GCP continuous delivery can now create and manage build-artifact storage buckets at the project level.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->