### PR TITLE
fix: keep human-readable output off stdout in --json mode

### DIFF
--- a/src/pkg/cli/compose/loader.go
+++ b/src/pkg/cli/compose/loader.go
@@ -173,9 +173,9 @@ func (l *Loader) loadProject(ctx context.Context, suppressWarn bool) (*Project, 
 		return nil, err
 	}
 
-	if term.DoDebug() && !term.DoJSON() {
+	if term.DoDebug() {
 		b, _ := yaml.Marshal(project)
-		term.Println(string(b))
+		term.Println(string(b)) // term.Println routes to stderr in JSON mode, so this never corrupts --json stdout
 	}
 
 	l.cached = project

--- a/src/pkg/cli/compose/loader.go
+++ b/src/pkg/cli/compose/loader.go
@@ -173,7 +173,7 @@ func (l *Loader) loadProject(ctx context.Context, suppressWarn bool) (*Project, 
 		return nil, err
 	}
 
-	if term.DoDebug() {
+	if term.DoDebug() && !term.DoJSON() {
 		b, _ := yaml.Marshal(project)
 		term.Println(string(b))
 	}

--- a/src/pkg/cli/compose/loader_test.go
+++ b/src/pkg/cli/compose/loader_test.go
@@ -38,6 +38,40 @@ func TestResolveProjectWorkingDirDoesNotLoadOrCacheProject(t *testing.T) {
 	assert.Equal(t, dir, workingDir)
 }
 
+// TestLoadProjectSkipsDebugDumpInJSONMode is a regression test: `defang
+// services --json` with DEFANG_DEBUG=1 used to write the project's YAML dump
+// to stdout ahead of the JSON payload, corrupting it for callers like
+// `defang-github-action`'s deployment summary (jq: invalid numeric literal).
+func TestLoadProjectSkipsDebugDumpInJSONMode(t *testing.T) {
+	dir := t.TempDir()
+	composePath := filepath.Join(dir, "compose.yaml")
+	require.NoError(t, os.WriteFile(composePath, []byte("services:\n  web:\n    image: alpine\n"), 0o644))
+
+	oldTerm := term.DefaultTerm
+	t.Cleanup(func() { term.DefaultTerm = oldTerm })
+
+	t.Run("debug alone still dumps the project", func(t *testing.T) {
+		var output bytes.Buffer
+		term.DefaultTerm = term.NewTerm(os.Stdin, &output, &output)
+		term.DefaultTerm.SetDebug(true)
+
+		_, err := NewLoader(WithPath(composePath)).LoadProject(t.Context())
+		require.NoError(t, err)
+		assert.Contains(t, output.String(), "services:")
+	})
+
+	t.Run("debug plus json suppresses the dump", func(t *testing.T) {
+		var output bytes.Buffer
+		term.DefaultTerm = term.NewTerm(os.Stdin, &output, &output)
+		term.DefaultTerm.SetDebug(true)
+		term.DefaultTerm.SetJSON(true)
+
+		_, err := NewLoader(WithPath(composePath)).LoadProject(t.Context())
+		require.NoError(t, err)
+		assert.Empty(t, output.String())
+	})
+}
+
 func TestResolveProjectWorkingDirDoesNotSuppressProjectWarnings(t *testing.T) {
 	dir := t.TempDir()
 	composePath := filepath.Join(dir, "compose.yaml")

--- a/src/pkg/cli/compose/loader_test.go
+++ b/src/pkg/cli/compose/loader_test.go
@@ -38,11 +38,13 @@ func TestResolveProjectWorkingDirDoesNotLoadOrCacheProject(t *testing.T) {
 	assert.Equal(t, dir, workingDir)
 }
 
-// TestLoadProjectSkipsDebugDumpInJSONMode is a regression test: `defang
-// services --json` with DEFANG_DEBUG=1 used to write the project's YAML dump
-// to stdout ahead of the JSON payload, corrupting it for callers like
-// `defang-github-action`'s deployment summary (jq: invalid numeric literal).
-func TestLoadProjectSkipsDebugDumpInJSONMode(t *testing.T) {
+// TestLoadProjectDebugDumpNeverHitsStdoutInJSONMode is a regression test:
+// `defang services --json` with DEFANG_DEBUG=1 used to write the project's
+// YAML dump to stdout ahead of the JSON payload, corrupting it for callers
+// like `defang-github-action`'s deployment summary (jq: invalid numeric
+// literal). term.Println now routes to stderr in JSON mode, so the dump
+// must never appear on stdout, whether or not JSON mode is on.
+func TestLoadProjectDebugDumpNeverHitsStdoutInJSONMode(t *testing.T) {
 	dir := t.TempDir()
 	composePath := filepath.Join(dir, "compose.yaml")
 	require.NoError(t, os.WriteFile(composePath, []byte("services:\n  web:\n    image: alpine\n"), 0o644))
@@ -50,25 +52,27 @@ func TestLoadProjectSkipsDebugDumpInJSONMode(t *testing.T) {
 	oldTerm := term.DefaultTerm
 	t.Cleanup(func() { term.DefaultTerm = oldTerm })
 
-	t.Run("debug alone still dumps the project", func(t *testing.T) {
-		var output bytes.Buffer
-		term.DefaultTerm = term.NewTerm(os.Stdin, &output, &output)
+	t.Run("debug alone dumps the project to stdout", func(t *testing.T) {
+		var stdout, stderr bytes.Buffer
+		term.DefaultTerm = term.NewTerm(os.Stdin, &stdout, &stderr)
 		term.DefaultTerm.SetDebug(true)
 
 		_, err := NewLoader(WithPath(composePath)).LoadProject(t.Context())
 		require.NoError(t, err)
-		assert.Contains(t, output.String(), "services:")
+		assert.Contains(t, stdout.String(), "services:")
+		assert.Empty(t, stderr.String())
 	})
 
-	t.Run("debug plus json suppresses the dump", func(t *testing.T) {
-		var output bytes.Buffer
-		term.DefaultTerm = term.NewTerm(os.Stdin, &output, &output)
+	t.Run("debug plus json moves the dump to stderr", func(t *testing.T) {
+		var stdout, stderr bytes.Buffer
+		term.DefaultTerm = term.NewTerm(os.Stdin, &stdout, &stderr)
 		term.DefaultTerm.SetDebug(true)
 		term.DefaultTerm.SetJSON(true)
 
 		_, err := NewLoader(WithPath(composePath)).LoadProject(t.Context())
 		require.NoError(t, err)
-		assert.Empty(t, output.String())
+		assert.Empty(t, stdout.String())
+		assert.Contains(t, stderr.String(), "services:")
 	})
 }
 

--- a/src/pkg/term/colorizer.go
+++ b/src/pkg/term/colorizer.go
@@ -97,10 +97,6 @@ func (t *Term) DoDebug() bool {
 	return t.debug.Load()
 }
 
-func (t *Term) DoJSON() bool {
-	return t.json
-}
-
 func (t *Term) HasDarkBackground() bool {
 	return t.hasDarkBg
 }
@@ -199,20 +195,24 @@ func ensurePrefix(prefix prefixChars, s string) string {
 	return string(prefix) + s
 }
 
+// Printc, Print, Println, and Printf are for human-readable text; they write
+// to stderr instead of stdout when JSON mode is on, so they never corrupt a
+// command's --json payload. The only thing that belongs on stdout in JSON
+// mode is the JSON payload itself (see jsonTable in table.go).
 func (t *Term) Printc(c Color, v ...any) (int, error) {
-	return output(t.out, c, fmt.Sprint(v...))
+	return output(t.outOrErr(), c, fmt.Sprint(v...))
 }
 
 func (t *Term) Print(v ...any) (int, error) {
-	return fmt.Fprint(t.out, v...)
+	return fmt.Fprint(t.outOrErr(), v...)
 }
 
 func (t *Term) Println(v ...any) (int, error) {
-	return fmt.Fprintln(t.out, v...)
+	return fmt.Fprintln(t.outOrErr(), v...)
 }
 
 func (t *Term) Printf(format string, v ...any) (int, error) {
-	return fmt.Fprintf(t.out, format, v...)
+	return fmt.Fprintf(t.outOrErr(), format, v...)
 }
 
 func (t *Term) Debug(v ...any) (int, error) {
@@ -383,10 +383,6 @@ func SetJSON(json bool) {
 
 func DoDebug() bool {
 	return DefaultTerm.DoDebug()
-}
-
-func DoJSON() bool {
-	return DefaultTerm.DoJSON()
 }
 
 func HasDarkBackground() bool {

--- a/src/pkg/term/colorizer.go
+++ b/src/pkg/term/colorizer.go
@@ -97,6 +97,10 @@ func (t *Term) DoDebug() bool {
 	return t.debug.Load()
 }
 
+func (t *Term) DoJSON() bool {
+	return t.json
+}
+
 func (t *Term) HasDarkBackground() bool {
 	return t.hasDarkBg
 }
@@ -379,6 +383,10 @@ func SetJSON(json bool) {
 
 func DoDebug() bool {
 	return DefaultTerm.DoDebug()
+}
+
+func DoJSON() bool {
+	return DefaultTerm.DoJSON()
 }
 
 func HasDarkBackground() bool {

--- a/src/pkg/term/colorizer_test.go
+++ b/src/pkg/term/colorizer_test.go
@@ -162,6 +162,20 @@ func TestIsTerminal(t *testing.T) {
 		t.Error("Expected IsTerminal() to return false")
 	}
 }
+
+func TestDoJSON(t *testing.T) {
+	oldTerm := DefaultTerm
+	t.Cleanup(func() { DefaultTerm = oldTerm })
+	DefaultTerm = NewTerm(os.Stdin, &bytes.Buffer{}, &bytes.Buffer{})
+
+	if DoJSON() {
+		t.Error("Expected DoJSON() to default to false")
+	}
+	SetJSON(true)
+	if !DoJSON() {
+		t.Error("Expected DoJSON() to return true after SetJSON(true)")
+	}
+}
 func TestWarn(t *testing.T) {
 	tests := []struct {
 		msgs     []string

--- a/src/pkg/term/colorizer_test.go
+++ b/src/pkg/term/colorizer_test.go
@@ -163,17 +163,32 @@ func TestIsTerminal(t *testing.T) {
 	}
 }
 
-func TestDoJSON(t *testing.T) {
-	oldTerm := DefaultTerm
-	t.Cleanup(func() { DefaultTerm = oldTerm })
-	DefaultTerm = NewTerm(os.Stdin, &bytes.Buffer{}, &bytes.Buffer{})
+// TestPrintRoutingInJSONMode is a regression test: Print/Println/Printf/Printc
+// used to always write to stdout, so any of them reachable from a command
+// that also emits --json output (e.g. via a debug dump) would corrupt that
+// JSON payload. They must move to stderr in JSON mode, like Info/Warn do.
+func TestPrintRoutingInJSONMode(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	defaultTerm := NewTerm(os.Stdin, &stdout, &stderr)
 
-	if DoJSON() {
-		t.Error("Expected DoJSON() to default to false")
+	defaultTerm.Print("a")
+	defaultTerm.Println("b")
+	defaultTerm.Printf("%s", "c")
+	defaultTerm.Printc(InfoColor, "d")
+	if stdout.String() == "" || stderr.String() != "" {
+		t.Errorf("expected Print* to write to stdout when JSON mode is off; stdout=%q stderr=%q", stdout.String(), stderr.String())
 	}
-	SetJSON(true)
-	if !DoJSON() {
-		t.Error("Expected DoJSON() to return true after SetJSON(true)")
+
+	stdout.Reset()
+	stderr.Reset()
+	defaultTerm.SetJSON(true)
+
+	defaultTerm.Print("a")
+	defaultTerm.Println("b")
+	defaultTerm.Printf("%s", "c")
+	defaultTerm.Printc(InfoColor, "d")
+	if stdout.String() != "" || stderr.String() == "" {
+		t.Errorf("expected Print* to write to stderr when JSON mode is on; stdout=%q stderr=%q", stdout.String(), stderr.String())
 	}
 }
 func TestWarn(t *testing.T) {


### PR DESCRIPTION
## Summary

- `defang services --json` could exit 0 while printing non-JSON to stdout ahead of the actual JSON array, corrupting output for machine consumers such as `defang-github-action`'s deployment summary (`jq: parse error: Invalid numeric literal`, DefangLabs/defang-github-action#55).
- Root cause: `Loader.loadProject()` unconditionally dumped the whole compose project as YAML to stdout via `term.Println` whenever debug logging was on (`--debug` / `DEFANG_DEBUG=1`), regardless of `--json`. `services --json` hits this on the way to resolving the project name, before it ever produces its own JSON output.
- Broader issue: `term.Print`/`Println`/`Printf`/`Printc` always wrote to stdout, unlike `Info`/`Warn` which already route through `outOrErr()` to stderr under `--json`. ~40 call sites across the CLI use `Print*`; any of them reachable from a `--json`-capable command's call path was one change away from the same corruption.

## Fix

Rather than gate each call site individually, fix it at the source: `Print`/`Println`/`Printf`/`Printc` now route through `outOrErr()` too, since the only legitimate way JSON output reaches stdout is `jsonTable()`'s `json.Encoder`, which writes `t.out` directly. This closes the whole class of bug, not just the one instance in `loader.go`.

## Root cause, confirmed locally (no cloud/auth needed)

Reproduced with a small standalone program calling `compose.NewLoader(...).LoadProjectName()` directly (`term.SetDebug(true)`, `term.SetJSON(true)`, no auth, no network) against a sample `compose.yaml`. Captured stdout started with:

```
name: html-css-js
services:
    app:
...
```

Piping that into the exact `jq` line from `defang-github-action`'s summary step reproduces the CI failure byte-for-byte:

```
jq: parse error: Invalid numeric literal at line 1, column 5
exit code: 5
```

## Test plan
- [x] `CGO_ENABLED=0 go test -short ./...`
- [x] `CGO_ENABLED=0 make lint` — no new findings (20 pre-existing gosec findings, none in touched files, confirmed identical on `main`)
- [x] `gofmt -l` clean on touched files
- [ ] CI on this PR passes

Related: DefangLabs/defang-github-action#55 (defensive fallback in the action itself — still worth merging independently, but this fixes the root cause in the CLI).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Debug YAML output is now available when JSON terminal mode is enabled.
  * Human-readable debug and print output is routed to stderr in JSON mode, keeping stdout reserved for valid JSON results.
  * Preserved standard output behavior when JSON mode is disabled.

* **Tests**
  * Added coverage verifying output routing across normal and JSON terminal modes.
  * Confirmed debug output does not contaminate JSON results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->