### PR TITLE
fix(nix): bump nixpkgs pin so nix-shell-test builds with go >= 1.25.9

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -19,12 +19,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1767364772,
-        "narHash": "sha256-fFUnEYMla8b7UKjijLnMe+oVFOz6HjijGGNS1l7dYaQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "16c7794d0a28b5a37904d55bcca36003b9109aaa",
-        "type": "github"
+        "lastModified": 1787111413,
+        "narHash": "sha256-93GX5Q/npwBE92xpHlktxgGztuIP/2kwOMukz+qyJBk=",
+        "rev": "afe3d8ac4395617bdcdac9f188ac8717a062e014",
+        "type": "tarball",
+        "url": "https://releases.nixos.org/nixpkgs/nixpkgs-26.11pre1057999.afe3d8ac4395/nixexprs.tar.xz"
       },
       "original": {
         "id": "nixpkgs",

--- a/pkgs/defang/cli.nix
+++ b/pkgs/defang/cli.nix
@@ -7,7 +7,7 @@ buildGo125Module {
   pname = "defang-cli";
   version = "git";
   src = lib.cleanSource ../../src;
-  vendorHash = "sha256-3NYtGGBZ13Ln9sGrvJGs4l3dx7ZsNIysku9yfcVik5Q=";
+  vendorHash = "sha256-QMQ7rH76stxpN7EjY3l9HOBusOQp85dt+0Fkn9sO7Xk=";
 
   subPackages = [ "cmd/cli" ];
 


### PR DESCRIPTION
## Problem

`nix-shell-test` is failing on `main` and on every open PR (including #2225) with:

```
go: go.mod requires go >= 1.25.9 (running go 1.25.5; GOTOOLCHAIN=local)
```

## Root cause

Dependabot's `github.com/moby/buildkit` bump in #2224 pulled in buildkit v0.31.1, whose own `go.mod` requires `go 1.25.9` — this transitively raised our module's effective minimum toolchain requirement. That's unrelated to any single PR's diff; it landed on `main` itself.

`flake.lock`'s `nixpkgs` input was pinned to a January 2026 revision that only ships `go_1_25` 1.25.5. The Nix sandbox has no network access to auto-fetch a newer toolchain (`GOTOOLCHAIN=local`), so the build fails outright before it even gets to vendor-hash verification — the CI job's existing "Update vendorHash if needed" auto-fix step never even triggers, since the failure isn't a hash mismatch.

## Fix

- Bump the `nixpkgs` flake input to a current revision (`go_1_25` = 1.25.13, satisfies `>= 1.25.9`).
- Update `pkgs/defang/cli.nix`'s `vendorHash` for the `go.sum` changes from the buildkit bump (the old hash was already stale after #2224, just never surfaced because the build died on the Go version check first).

Verified locally:
```
nix build .#defang-cli   # succeeds
nix run .#defang-cli -- --version   # defang version development
```

## Test plan
- [x] `nix build .#defang-cli` succeeds locally with the updated pin
- [ ] `nix-shell-test` passes in CI on this PR