### PR TITLE
fix: compose up must exit non-zero when the AI debugger runs

### DIFF
--- a/src/cmd/cli/command/compose.go
+++ b/src/cmd/cli/command/compose.go
@@ -358,9 +358,16 @@ func handleComposeUpErr(ctx context.Context, debugger *debug.Debugger, project *
 	}
 
 	term.Error("Error:", client.PrettyError(originalErr))
-	return debugger.DebugDeploymentError(ctx, debug.DebugConfig{
+	// The debugger runs for its side effect only. It returns nil once it has
+	// explained the failure, so returning its error here would turn a fatal
+	// deployment error into exit code 0 — a false-green CI deploy for every
+	// account that auto-approves the debugger.
+	if debugErr := debugger.DebugDeploymentError(ctx, debug.DebugConfig{
 		Project: project,
-	}, originalErr)
+	}, originalErr); debugErr != nil {
+		term.Debug("debugger failed:", debugErr)
+	}
+	return originalErr
 }
 
 func handleTooManyProjectsError(ctx context.Context, provider client.Provider, originalErr error) error {

--- a/src/cmd/cli/command/compose_test.go
+++ b/src/cmd/cli/command/compose_test.go
@@ -3,6 +3,7 @@ package command
 import (
 	"bytes"
 	"context"
+	"errors"
 	"os"
 	"strings"
 	"testing"
@@ -10,6 +11,8 @@ import (
 
 	"connectrpc.com/connect"
 	"github.com/DefangLabs/defang/src/pkg/cli/client"
+	"github.com/DefangLabs/defang/src/pkg/cli/compose"
+	"github.com/DefangLabs/defang/src/pkg/debug"
 	"github.com/DefangLabs/defang/src/pkg/term"
 	defangv1 "github.com/DefangLabs/defang/src/protos/io/defang/v1"
 )
@@ -127,5 +130,72 @@ func TestResolveTTL(t *testing.T) {
 				t.Errorf("resolveTTL() = %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+// stubDebugAgent stands in for the AI agent: it records that it ran and returns whatever the
+// test wants the debug session to end with.
+type stubDebugAgent struct {
+	called bool
+	err    error
+}
+
+func (s *stubDebugAgent) StartWithMessage(context.Context, string) error {
+	s.called = true
+	return s.err
+}
+
+// Regression for issue 2227: handleComposeUpErr used to return the DEBUGGER's error. The
+// debugger returns nil once it has explained the failure, so a fatal compose up error exited 0
+// and CI went green on a deploy that never happened.
+func TestHandleComposeUpErrKeepsTheDeploymentError(t *testing.T) {
+	prevNonInteractive := global.NonInteractive
+	global.NonInteractive = true
+	t.Cleanup(func() { global.NonInteractive = prevNonInteractive })
+
+	originalErr := errors.New(`service "fabric": port 50051: 'target' must be an integer between 1 and 32767`)
+
+	for _, tt := range []struct {
+		name     string
+		debugErr error
+	}{
+		{name: "debugger succeeds", debugErr: nil},
+		{name: "debugger fails", debugErr: errors.New("agent unavailable")},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			agent := &stubDebugAgent{err: tt.debugErr}
+			// defaultPermission=true is the paid/auto-approve account: the only one that
+			// reaches the debugger in CI, and so the only one that hit this bug.
+			debugger := debug.NewDebuggerForTest(agent, true, false)
+
+			err := handleComposeUpErr(context.Background(), debugger, &compose.Project{}, nil, originalErr)
+
+			if !agent.called {
+				t.Error("expected the debugger to run")
+			}
+			if !errors.Is(err, originalErr) {
+				t.Errorf("expected the original deployment error, got %v", err)
+			}
+		})
+	}
+}
+
+// A free-tier CI account never reaches the debugger; it must still get the error.
+func TestHandleComposeUpErrWithoutAutoApprove(t *testing.T) {
+	prevNonInteractive := global.NonInteractive
+	global.NonInteractive = true
+	t.Cleanup(func() { global.NonInteractive = prevNonInteractive })
+
+	originalErr := errors.New("boom")
+	agent := &stubDebugAgent{}
+	debugger := debug.NewDebuggerForTest(agent, false, false)
+
+	err := handleComposeUpErr(context.Background(), debugger, &compose.Project{}, nil, originalErr)
+
+	if agent.called {
+		t.Error("the debugger must not auto-run for a free-tier account")
+	}
+	if !errors.Is(err, originalErr) {
+		t.Errorf("expected the original deployment error, got %v", err)
 	}
 }

--- a/src/pkg/debug/debug.go
+++ b/src/pkg/debug/debug.go
@@ -106,6 +106,18 @@ func NewDebugger(ctx context.Context, fabricAddr string, stack *stacks.Parameter
 	}, nil
 }
 
+// NewDebuggerForTest builds a Debugger around a stub agent. NewDebugger needs a live Fabric
+// connection, so tests in OTHER packages — the ones exercising how a caller handles what the
+// debugger returns — have no other way to get one.
+func NewDebuggerForTest(agent DebugAgent, defaultPermission, interactive bool) *Debugger {
+	return &Debugger{
+		agent:             agent,
+		surveyor:          &surveyor{},
+		defaultPermission: defaultPermission,
+		interactive:       interactive,
+	}
+}
+
 // AutoApprove reports whether the debugger will run without an interactive prompt. This is true
 // for paid accounts and lets callers decide whether to invoke the debugger in non-interactive
 // environments (CI) or just print a hint.


### PR DESCRIPTION
Fixes #2227.

## The bug

`handleComposeUpErr` returned the **debugger's** error:

```go
return debugger.DebugDeploymentError(ctx, debug.DebugConfig{Project: project}, originalErr)
```

`promptAndTrackDebugSession` returns `nil` once the debug session finishes, so a
fatal `ComposeUp` error came back as `nil` and the CLI exited 0.

It only bites accounts that auto-approve the debugger. The guard above it,
`if global.NonInteractive && !debugger.AutoApprove()`, sends free-tier CI
straight out with the error — so the false green hits exactly the paid accounts
whose CI runs the debugger unattended, including Defang's own.

## The fix

Run the debugger for its side effect and always return the deployment error.
That is the shape the neighbouring paths already use: `handleTailAndMonitorErr`
returns nothing and its caller returns `deploymentErr`, and `session.go` returns
`loadErr` after `DebugComposeLoadError`.

`handleTooManyProjectsError` still returns nil after a successful interactive
`compose down` — that one is a deliberate recovery, and it is untouched.

## Tests

`TestHandleComposeUpErrKeepsTheDeploymentError` covers the CI auto-approve path
for both a debugger that succeeds and one that fails;
`TestHandleComposeUpErrWithoutAutoApprove` covers the free-tier path. Reverting
the one-line change fails the first with `expected the original deployment
error, got <nil>` — the reported symptom exactly.

`NewDebuggerForTest` is new: `NewDebugger` needs a live Fabric connection, so
tests outside `pkg/debug` had no way to build a `Debugger`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T3WmpdY3zc555sNdkY9dzQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Deployment failures now consistently return the original error, even when automated debugging is enabled.
  - Debugger issues no longer mask failed deployments or incorrectly produce successful command exits.
  - Improved error handling across both automatic and non-automatic debugging flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->