### PR TITLE
fix(gcp): set HOME so the CD uses the providers baked into its image

### DIFF
--- a/src/pkg/cli/client/byoc/gcp/byoc.go
+++ b/src/pkg/cli/client/byoc/gcp/byoc.go
@@ -432,6 +432,14 @@ func (b *ByocGcp) runCdCommand(ctx context.Context, cmd cdCommand) (string, erro
 		return "", err
 	}
 	env := map[string]string{
+		// Cloud Build overrides the image's own HOME for every build step, so Pulumi looks for
+		// its plugin cache somewhere other than the /root/.pulumi/plugins the CD image ships.
+		// It finds nothing, and silently downloads both providers at deploy time instead —
+		// pulumi-gcp from the CDN and defang-gcp from the pluginDownloadURL the generated SDK
+		// carries, which resolves to the latest GitHub *release*. That made every deploy depend
+		// on the public internet and, worse, meant pinning DEFANG_CD_IMAGE pinned only the cd
+		// binary while the provider silently floated to whatever was released last.
+		"HOME":                     "/root",
 		"DEFANG_CD_IMAGE":          b.CDImage,                 // used by down/destroy to schedule cleanup job with the same image
 		"DEFANG_DEBUG":             os.Getenv("DEFANG_DEBUG"), // TODO: use the global DoDebug flag
 		"DEFANG_JSON":              os.Getenv("DEFANG_JSON"),

--- a/src/pkg/cli/client/byoc/gcp/byoc_test.go
+++ b/src/pkg/cli/client/byoc/gcp/byoc_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"io"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -402,4 +403,39 @@ func TestGetServices(t *testing.T) {
 		require.NoError(t, err)
 		assert.Empty(t, res.Services)
 	})
+}
+
+// mockCdDriver captures the Cloud Build steps runCdCommand submits. The embedded interface
+// satisfies the rest of the surface, so any unexpected call panics rather than silently
+// returning a zero value.
+type mockCdDriver struct {
+	gcpDriver
+	steps string
+}
+
+func (m *mockCdDriver) GetProjectID() gcp.ProjectId { return "test-project" }
+func (m *mockCdDriver) GetRegion() string           { return "us-central1" }
+func (m *mockCdDriver) RunCloudBuild(ctx context.Context, args gcp.CloudBuildArgs) (string, error) {
+	m.steps = args.Steps
+	return "build-1", nil
+}
+
+// Cloud Build replaces the image's own HOME for every build step, which sends Pulumi looking for
+// its plugin cache outside /root/.pulumi/plugins. It then finds none of the providers the CD
+// image ships and downloads them at deploy time instead — pulumi-gcp from the CDN and defang-gcp
+// from the generated SDK's pluginDownloadURL, i.e. the latest GitHub release. Verified against a
+// real build: `pulumi plugin ls` in a Cloud Build step reports "TOTAL plugin cache size: 0 B"
+// without this, and 369 MB with it.
+func TestRunCdCommandSetsHome(t *testing.T) {
+	driver := &mockCdDriver{}
+	b := &ByocGcp{driver: driver}
+	b.ByocBaseClient = &byoc.ByocBaseClient{PulumiStack: "beta"}
+	b.bucket = "test-bucket"
+
+	if _, err := b.runCdCommand(t.Context(), cdCommand{project: "testproj", command: []string{"up"}}); err != nil {
+		t.Fatalf("runCdCommand() error = %v", err)
+	}
+	if !strings.Contains(driver.steps, "HOME=/root") {
+		t.Errorf("the CD step must pin HOME to the image's plugin cache; got steps:\n%s", driver.steps)
+	}
 }


### PR DESCRIPTION
## The bug

Cloud Build replaces a build step's `HOME`. The GCP CD image sets `ENV HOME=/root` and ships its Pulumi plugins in `/root/.pulumi/plugins`, but that env is overridden, so Pulumi looks somewhere else, finds no plugins, and downloads them at deploy time instead.

Verified against real Cloud Builds running the CD image, same image both times:

| step env | `pulumi plugin ls` |
|---|---|
| Cloud Build default | `TOTAL plugin cache size: 0 B` |
| `HOME=/root` | `369 MB` — `defang-gcp`, `gcp 9.34.1` |

The Pulumi state confirms where the provider came from instead:

```
urn:pulumi:beta::cdtest-cli::pulumi:providers:defang-gcp::default_github_/api.github.com/DefangLabs/pulumi-defang
```

That is the `pluginDownloadURL` the generated SDK carries (`sdk/v2/go/defang-gcp/internal/pulumiUtilities.go`), which resolves to the latest GitHub **release**.

## Why it matters

- **Every GCP deploy re-downloads ~370 MB of providers** and depends on github.com and the Pulumi CDN being reachable, while the copy baked into the image goes unused. In a restricted customer network it fails outright.
- **`DEFANG_CD_IMAGE` pins only the `cd` binary.** The provider floats to whatever was released last, so a deployment pinned to an older CD image silently runs newer provider code. That is a reproducibility hole in the part of the system we tell people to pin.
- It makes a custom CD image untestable, which is how this surfaced: a CD image built from a provider branch deployed released code instead, and the only visible symptom was resources named by the old code.

## The fix

Set `HOME=/root` in the Cloud Build step env, alongside the other CD variables.

## Testing

`TestRunCdCommandSetsHome` captures the submitted build steps through the existing `gcpDriver` interface and asserts the env pins `HOME`. It fails on `main` and passes with the fix.

`make lint` clean for the changed files (the gosec hits in `byoc/aws` are pre-existing on main), `go test -short ./...` green.

## Scope

GCP only. AWS runs its CD as a CodeBuild project and Azure as a container instance; neither goes through this path, and I have not checked whether they have an equivalent problem.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Google Cloud deployment commands to use the bundled provider plugins, avoiding unnecessary plugin downloads and helping deployments run more reliably.

* **Tests**
  * Added coverage to verify the deployment environment is configured correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->