### PR TITLE
fix: replace departed accounts in CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,11 +1,11 @@
 # Default owners for everything
-*       @jordanstephens
+*       @defangdevs
 
 # GitHub actions and repo configuration
 /.github/**       @raphaeltm
 
 # Go command line tool
-/src/**       @lionello @jordanstephens
+/src/**       @lionello @defangdevs
 
 # Packaging with Nix
 /pkgs/defang/**   @lionello


### PR DESCRIPTION
## Summary
- \`jordanstephens\` is no longer a DefangLabs org member. Replace their entries (\`*\` default owner and \`/src/**\`) with \`@defangdevs\` so PRs still get an active review request.
- No other stale accounts found in this file.

Part of DefangLabs/defang-global#128.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code ownership assignments for the repository and source files.
  * Retained existing ownership while adding the new designated maintainers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->