### PR TITLE
feat: download released CLIs from a Nix binary cache

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -283,6 +283,67 @@ jobs:
             }
             core.notice(`Smoketests passed: ${run.html_url}`);
 
+  # Publish the Nix binary cache for this tag, so `nix run github:DefangLabs/defang`
+  # downloads the CLI instead of compiling it. The push needs write access to the
+  # public S3 bucket and this repo has no cloud credentials, so — like the
+  # smoketests above — it runs in DefangLabs/defang-mvp via workflow dispatch.
+  trigger-nix-cache:
+    name: Publish Nix binary cache
+    runs-on: ubuntu-latest
+    needs: nix-shell-test # the cached derivation is the one that job just built
+    if: startsWith(github.ref, 'refs/tags/v') # only released versions are cached
+    concurrency:
+      group: nix-cache-${{ github.ref }}
+      cancel-in-progress: false
+    environment: smoketest # for DEFANG_MVP_ACTIONS_DISPATCH_TOKEN
+    timeout-minutes: 60
+    steps:
+      - name: Trigger the cache push and await conclusion
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          # Same token as trigger-smoketests: it already grants Actions
+          # read+write on DefangLabs/defang-mvp, which is all a dispatch needs.
+          github-token: ${{ secrets.DEFANG_MVP_ACTIONS_DISPATCH_TOKEN }}
+          script: |
+            const owner = 'DefangLabs';
+            const repo = 'defang-mvp';
+            const workflow_id = 'nix-cache-push.yml';
+            const cliVersion = context.ref.replace('refs/tags/', ''); // the flake is fetched by tag
+
+            // Same watermark trick as trigger-smoketests: createWorkflowDispatch
+            // does not return the new run's id, so we find ours by id > watermark
+            // plus the CLI version in the run name (see run-name in nix-cache-push.yml).
+            const { data: before } = await github.rest.actions.listWorkflowRuns({ owner, repo, workflow_id, per_page: 1 });
+            const watermark = before.workflow_runs[0]?.id ?? 0;
+
+            await github.rest.actions.createWorkflowDispatch({
+              owner, repo, workflow_id, ref: 'main',
+              inputs: { 'cli-version': cliVersion },
+            });
+
+            const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+            let run;
+            for (let i = 0; i < 30 && !run; i++) {
+              await sleep(10_000);
+              const { data } = await github.rest.actions.listWorkflowRuns({ owner, repo, workflow_id, event: 'workflow_dispatch', per_page: 30 });
+              // endsWith, not includes: v1.2.3 is a substring of v1.2.30.
+              run = data.workflow_runs.find((wr) => wr.id > watermark && wr.name.endsWith(`@ ${cliVersion}`));
+            }
+            if (!run) {
+              throw new Error('Timed out waiting for the dispatched cache run to appear');
+            }
+            core.notice(`Awaiting Nix cache push: ${run.html_url}`);
+
+            while (run.status !== 'completed') {
+              await sleep(30_000);
+              run = (await github.rest.actions.getWorkflowRun({ owner, repo, run_id: run.id })).data;
+            }
+            if (run.conclusion !== 'success') {
+              throw new Error(`Nix cache push concluded '${run.conclusion}': ${run.html_url}`);
+            }
+            core.notice(`Nix cache published: ${run.html_url}`);
+
   build-and-sign:
     name: Build app and sign files (with Trusted Signing)
     if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' # only run this step on tagged commits or the main branch
@@ -551,7 +612,7 @@ jobs:
     runs-on: ubuntu-latest
     if: failure() && (github.ref == 'refs/heads/main' || startsWith(github.ref,
       'refs/tags/v'))
-    needs: [go-release, post-release, nix-shell-test, push-docker]
+    needs: [go-release, post-release, nix-shell-test, push-docker, trigger-nix-cache]
     steps:
       - name: Slack Notification
         uses: rtCamp/action-slack-notify@33ca3be66c6f378fe1610fd1d5258632dbed5e58 # v2

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Install the Defang CLI from one of the following sources:
   Released tags are available from our binary cache, so you can download the CLI
   instead of compiling it. Add these lines to `/etc/nix/nix.conf` (or
   `~/.config/nix/nix.conf` if you are a [trusted user](https://nix.dev/manual/nix/stable/command-ref/conf-file#conf-trusted-users)),
-  then install a tagged version such as `github:DefangLabs/defang/v1.1.9#defang-cli`:
+  then install a tagged version such as `github:DefangLabs/defang/v3.14.1#defang-cli`:
 
   ```
   extra-substituters = https://defang-public-readonly.s3.us-west-2.amazonaws.com/nix-cache

--- a/README.md
+++ b/README.md
@@ -134,6 +134,19 @@ Install the Defang CLI from one of the following sources:
     nix profile install github:DefangLabs/defang#defang-cli --refresh
     ```
 
+  Released tags are available from our binary cache, so you can download the CLI
+  instead of compiling it. Add these lines to `/etc/nix/nix.conf` (or
+  `~/.config/nix/nix.conf` if you are a [trusted user](https://nix.dev/manual/nix/stable/command-ref/conf-file#conf-trusted-users)),
+  then install a tagged version such as `github:DefangLabs/defang/v1.1.9#defang-cli`:
+
+  ```
+  extra-substituters = https://defang-public-readonly.s3.us-west-2.amazonaws.com/nix-cache
+  extra-trusted-public-keys = defang.io-1:G9XiaHDves1Jygn9Kbj4FO6BpfuH/1eevUNiDqb6Nyw=
+  ```
+
+  The cache holds `x86_64-linux` and `aarch64-darwin` builds. Other platforms,
+  and builds from `main`, compile from source as before.
+
 - Using [winget](https://learn.microsoft.com/en-us/windows/package-manager/winget/):
 
   ```

--- a/flake.nix
+++ b/flake.nix
@@ -1,4 +1,17 @@
 {
+  # Prebuilt `defang-cli` for released tags, published by the nix-cache-push
+  # workflow in DefangLabs/defang-mvp. Nix only honours these for trusted users
+  # (root, or a member of `trusted-users`); everyone else builds from source
+  # unless they add the same two lines to their own nix.conf — see the README.
+  nixConfig = {
+    extra-substituters = [
+      "https://defang-public-readonly.s3.us-west-2.amazonaws.com/nix-cache"
+    ];
+    extra-trusted-public-keys = [
+      "defang.io-1:G9XiaHDves1Jygn9Kbj4FO6BpfuH/1eevUNiDqb6Nyw="
+    ];
+  };
+
   outputs =
     {
       self,


### PR DESCRIPTION
`nix run github:DefangLabs/defang` compiles the Go CLI from source today — a ~100 MB build that takes minutes. For release tags, publish the prebuilt closure to a binary cache so users download ~25 MB instead.

Pairs with DefangLabs/defang-mvp#3211, which owns the bucket, the IAM role, and the push workflow. **Merge that one first** — this PR only dispatches it.

## How

Same shape as `trigger-smoketests` directly above it, and for the same reason: publishing needs write access to the public S3 bucket, and this repo has no cloud credentials. So `trigger-nix-cache` dispatches `nix-cache-push.yml` in `DefangLabs/defang-mvp` and waits for its conclusion, reusing the `DEFANG_MVP_ACTIONS_DISPATCH_TOKEN` already in the `smoketest` environment (it grants Actions read+write on that repo, which is all a dispatch needs).

It runs on tags only, `needs: nix-shell-test` so the cached derivation is one that job just proved builds, and it is not in `go-release`'s `needs` — a cache failure should not withhold the release binaries. It is in `on-failure`'s list, so it still pages Slack.

## Which platforms

`x86_64-linux` and `aarch64-darwin`. Other platforms, and builds from `main`, compile from source exactly as they do now.

## `nixConfig` is not enough on its own

Nix ignores flake-provided substituters for non-trusted users, so `nixConfig` here only helps CI and users in `trusted-users`. The README documents the two `nix.conf` lines everyone else needs, next to the existing install instructions.

## Trust

The cache is signed. Public key, also in `flake.nix` and in the mvp workflow:

```
defang.io-1:G9XiaHDves1Jygn9Kbj4FO6BpfuH/1eevUNiDqb6Nyw=
```

The push workflow re-fetches each published closure from the public URL into a throwaway store trusting only that key, so a bad signature fails the release rather than the first user who runs `nix run`.

## Checks

`actionlint` clean; `nix flake check` passes and `nixfmt --check` is clean on `flake.nix`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T3WmpdY3zc555sNdkY9dzQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for installing released tags using Defang’s Nix binary cache.
  * Added guidance for configuring the cache and installing on supported architectures.
  * Builds from `main` and unsupported platforms continue compiling from source.

* **Chores**
  * Automated cache publication for tagged releases.
  * Added failure handling when cache publication does not complete successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->