### PR TITLE
feat: publish the CLI's Nix binary cache via Cachix

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -301,10 +301,12 @@ jobs:
           - system: x86_64-linux
             runs-on: ubuntu-latest
           - system: aarch64-darwin
-            runs-on: macos-14
+            runs-on: macos-15
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false # this job never pushes back to the repo
 
       - name: Install Nix
         uses: cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342 # v31
@@ -589,7 +591,7 @@ jobs:
 
   on-failure:
     runs-on: ubuntu-latest
-    if: failure() && (github.ref == 'refs/heads/main' || startsWith(github.ref,
+    if: always() && failure() && (github.ref == 'refs/heads/main' || startsWith(github.ref,
       'refs/tags/v'))
     needs:
       [go-release, post-release, nix-shell-test, push-docker, publish-nix-cache]

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -283,6 +283,46 @@ jobs:
             }
             core.notice(`Smoketests passed: ${run.html_url}`);
 
+  # Publish the Nix binary cache for this tag, so `nix run github:DefangLabs/defang`
+  # downloads the CLI instead of compiling it. Cachix owns storage, signing, and the
+  # substituter protocol, so this pushes straight from CI with no cloud credentials
+  # and no second repo — unlike trigger-smoketests above, which has to dispatch into
+  # DefangLabs/defang-mvp because that's where the cloud credentials live.
+  publish-nix-cache:
+    name: Publish Nix binary cache (${{ matrix.system }})
+    runs-on: ${{ matrix.runs-on }}
+    needs: nix-shell-test # cache the derivation that job just proved builds
+    if: startsWith(github.ref, 'refs/tags/v') # only released versions are cached
+    environment: release # for CACHIX_AUTH_TOKEN
+    strategy:
+      fail-fast: false # a broken macOS runner should not withhold the Linux cache
+      matrix:
+        include:
+          - system: x86_64-linux
+            runs-on: ubuntu-latest
+          - system: aarch64-darwin
+            runs-on: macos-14
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342 # v31
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+
+      - name: Set up Cachix
+        uses: cachix/cachix-action@02b16339eddcf6ea27126a830c7f1992855cae13 # v17
+        with:
+          # Public cache; public key is committed in flake.nix and the README.
+          name: defanglabs
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+
+      - name: Build and push defang-cli
+        # cachix-action installs a post-build hook above, so this push is
+        # automatic: every output the build realises gets signed and uploaded.
+        run: nix build .#defang-cli --print-out-paths
+
   build-and-sign:
     name: Build app and sign files (with Trusted Signing)
     if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' # only run this step on tagged commits or the main branch
@@ -551,7 +591,8 @@ jobs:
     runs-on: ubuntu-latest
     if: failure() && (github.ref == 'refs/heads/main' || startsWith(github.ref,
       'refs/tags/v'))
-    needs: [go-release, post-release, nix-shell-test, push-docker]
+    needs:
+      [go-release, post-release, nix-shell-test, push-docker, publish-nix-cache]
     steps:
       - name: Slack Notification
         uses: rtCamp/action-slack-notify@33ca3be66c6f378fe1610fd1d5258632dbed5e58 # v2

--- a/README.md
+++ b/README.md
@@ -134,6 +134,20 @@ Install the Defang CLI from one of the following sources:
     nix profile install github:DefangLabs/defang#defang-cli --refresh
     ```
 
+  Released tags are available from our [Cachix](https://cachix.org) binary cache, so
+  you can download the CLI instead of compiling it. If you have Cachix installed, run
+  `cachix use defanglabs`; otherwise add these lines to `/etc/nix/nix.conf` (or
+  `~/.config/nix/nix.conf` if you are a [trusted user](https://nix.dev/manual/nix/stable/command-ref/conf-file#conf-trusted-users)):
+
+  ```
+  extra-substituters = https://defanglabs.cachix.org
+  extra-trusted-public-keys = defanglabs.cachix.org-1:mTXLTfYprWDrIK50Kz34fhOTreeKlQRZFQcKL7HtHx0=
+  ```
+
+  Then install a tagged version, e.g. `nix profile install github:DefangLabs/defang/v3.14.1#defang-cli`.
+  The cache holds `x86_64-linux` and `aarch64-darwin` builds. Other platforms, and
+  builds from `main`, compile from source as before.
+
 - Using [winget](https://learn.microsoft.com/en-us/windows/package-manager/winget/):
 
   ```

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Install the Defang CLI from one of the following sources:
   `cachix use defanglabs`; otherwise add these lines to `/etc/nix/nix.conf` (or
   `~/.config/nix/nix.conf` if you are a [trusted user](https://nix.dev/manual/nix/stable/command-ref/conf-file#conf-trusted-users)):
 
-  ```
+  ```nix
   extra-substituters = https://defanglabs.cachix.org
   extra-trusted-public-keys = defanglabs.cachix.org-1:mTXLTfYprWDrIK50Kz34fhOTreeKlQRZFQcKL7HtHx0=
   ```

--- a/flake.nix
+++ b/flake.nix
@@ -1,4 +1,17 @@
 {
+  # Prebuilt `defang-cli` for released tags, published by the publish-nix-cache
+  # job in go.yml straight to Cachix. Nix only honours these for trusted users
+  # (root, or a member of `trusted-users`); everyone else builds from source
+  # unless they add the same two lines to their own nix.conf — see the README.
+  nixConfig = {
+    extra-substituters = [
+      "https://defanglabs.cachix.org"
+    ];
+    extra-trusted-public-keys = [
+      "defanglabs.cachix.org-1:mTXLTfYprWDrIK50Kz34fhOTreeKlQRZFQcKL7HtHx0="
+    ];
+  };
+
   outputs =
     {
       self,


### PR DESCRIPTION
Alternative to #2234 (pairs with DefangLabs/defang-mvp#3211) — same goal, published for comparison rather than to replace it outright.

`nix run github:DefangLabs/defang` compiles the Go CLI from source, a ~100 MB build that takes minutes. For release tags, publish the prebuilt closure to a binary cache so users download ~25 MB instead.

## How this differs from #2234/#3211

The S3 design needs two repos: `defang` has no cloud credentials, so it dispatches a workflow in `defang-mvp` (via `workflow_dispatch` + polling) which owns a new OIDC-scoped IAM role, a Pulumi bucket-policy change, and a self-managed signing keypair. It's also currently blocked pre-merge on an admin creating the `nix-cache` environment and adding the signing key secret.

Cachix collapses all of that: `publish-nix-cache` here pushes straight from `defang`'s own `release` environment (which already has `CACHIX_AUTH_TOKEN`, added directly to this repo). No IAM, no Pulumi, no second repo, no dispatch/poll dance, and nothing blocked on infra changes.

The tradeoff: Cachix holds the signing key by default (self-signing is possible but adds back some of the key-management complexity this is meant to avoid), and storage is a free-tier 5 GB (LRU-evicted past that) rather than an unbounded bucket we already own — though at ~50 MB/tag that's effectively unlimited runway either way.

## Which platforms

`x86_64-linux` and `aarch64-darwin`, matching #3211. Other platforms, and builds from `main`, compile from source exactly as they do now.

## Cache

Public Cachix cache `defanglabs` (https://defanglabs.cachix.org). Public key, also in `flake.nix` and the README:

```
defanglabs.cachix.org-1:mTXLTfYprWDrIK50Kz34fhOTreeKlQRZFQcKL7HtHx0=
```

## `nixConfig` is not enough on its own

Nix ignores flake-provided substituters for non-trusted users, so `nixConfig` here only helps CI and users in `trusted-users`. The README documents the two `nix.conf` lines everyone else needs (or `cachix use defanglabs` if they have the Cachix CLI), next to the existing install instructions.

## Checks

`actionlint` clean; `nix flake check` and `nixfmt --check` pass on `flake.nix`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LnYjvSXXYN11xFBQquRfjn

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added binary-cache support for released CLI builds on Linux and macOS.
  * Added installation instructions for using the DefangLabs Cachix cache, including Nix setup and tagged-version installation.
  * Tagged releases can now install faster using prebuilt artifacts.
  * Other platforms and development builds continue compiling from source.
  * Added supported-platform guidance for Nix-based installations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->