### PR TITLE
ci: publish aarch64-linux to the Cachix binary cache

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -11,11 +11,6 @@ on:
       - "Makefile"
       - "pkgs/**"
       - "src/**"
-  # Manual escape hatch for publish-nix-cache: re-push an existing tag's Nix
-  # closures (e.g. after adding a matrix leg) without cutting a new release.
-  # The `release` environment's deployment-branch policy (main, v*) still
-  # gates it, so this only actually reaches Cachix when dispatched on main.
-  workflow_dispatch: {}
 
 permissions:
   contents: read
@@ -293,51 +288,20 @@ jobs:
   # substituter protocol, so this pushes straight from CI with no cloud credentials
   # and no second repo — unlike trigger-smoketests above, which has to dispatch into
   # DefangLabs/defang-mvp because that's where the cloud credentials live.
+  #
+  # The actual build+push steps live in publish-nix-cache.yml (a workflow_call
+  # target) so publish-nix-cache-manual.yml can invoke the exact same job
+  # on demand — e.g. to backfill a matrix leg — WITHOUT exposing the rest of
+  # this workflow (nix-shell-test's contents:write vendorHash push, the
+  # tag-gated release jobs) to manual dispatch. A bare `workflow_dispatch:` on
+  # this file would have made ALL of that manually re-runnable against any
+  # existing tag, not just the cache publish.
   publish-nix-cache:
-    name: Publish Nix binary cache (${{ matrix.system }})
-    runs-on: ${{ matrix.runs-on }}
+    name: Publish Nix binary cache
     needs: nix-shell-test # cache the derivation that job just proved builds
-    # Released tags are cached automatically; workflow_dispatch is the manual
-    # escape hatch (only takes effect from main — see the release environment
-    # branch policy above trigger note).
-    if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
-    environment: release # for CACHIX_AUTH_TOKEN
-    strategy:
-      fail-fast: false # a broken macOS runner should not withhold the Linux cache
-      matrix:
-        include:
-          - system: x86_64-linux
-            runs-on: ubuntu-latest
-          - system: aarch64-linux
-            # GitHub-hosted arm64 runner (GA for public repos) — this is the
-            # architecture agent-box's deployed fleet actually runs (Graviton
-            # EC2, see defangdevs/agent-box#373): without this leg, Cachix
-            # never has an artifact that box's first-boot nix build can hit.
-            runs-on: ubuntu-24.04-arm
-          - system: aarch64-darwin
-            runs-on: macos-15
-    timeout-minutes: 30
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-        with:
-          persist-credentials: false # this job never pushes back to the repo
-
-      - name: Install Nix
-        uses: cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342 # v31
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable
-
-      - name: Set up Cachix
-        uses: cachix/cachix-action@02b16339eddcf6ea27126a830c7f1992855cae13 # v17
-        with:
-          # Public cache; public key is committed in flake.nix and the README.
-          name: defanglabs
-          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
-
-      - name: Build and push defang-cli
-        # cachix-action installs a post-build hook above, so this push is
-        # automatic: every output the build realises gets signed and uploaded.
-        run: nix build .#defang-cli --print-out-paths
+    if: startsWith(github.ref, 'refs/tags/v') # only released versions are cached
+    uses: ./.github/workflows/publish-nix-cache.yml
+    secrets: inherit
 
   build-and-sign:
     name: Build app and sign files (with Trusted Signing)

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -11,6 +11,11 @@ on:
       - "Makefile"
       - "pkgs/**"
       - "src/**"
+  # Manual escape hatch for publish-nix-cache: re-push an existing tag's Nix
+  # closures (e.g. after adding a matrix leg) without cutting a new release.
+  # The `release` environment's deployment-branch policy (main, v*) still
+  # gates it, so this only actually reaches Cachix when dispatched on main.
+  workflow_dispatch: {}
 
 permissions:
   contents: read
@@ -292,7 +297,10 @@ jobs:
     name: Publish Nix binary cache (${{ matrix.system }})
     runs-on: ${{ matrix.runs-on }}
     needs: nix-shell-test # cache the derivation that job just proved builds
-    if: startsWith(github.ref, 'refs/tags/v') # only released versions are cached
+    # Released tags are cached automatically; workflow_dispatch is the manual
+    # escape hatch (only takes effect from main — see the release environment
+    # branch policy above trigger note).
+    if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
     environment: release # for CACHIX_AUTH_TOKEN
     strategy:
       fail-fast: false # a broken macOS runner should not withhold the Linux cache

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -300,6 +300,12 @@ jobs:
         include:
           - system: x86_64-linux
             runs-on: ubuntu-latest
+          - system: aarch64-linux
+            # GitHub-hosted arm64 runner (GA for public repos) — this is the
+            # architecture agent-box's deployed fleet actually runs (Graviton
+            # EC2, see defangdevs/agent-box#373): without this leg, Cachix
+            # never has an artifact that box's first-boot nix build can hit.
+            runs-on: ubuntu-24.04-arm
           - system: aarch64-darwin
             runs-on: macos-15
     timeout-minutes: 30

--- a/.github/workflows/publish-nix-cache-manual.yml
+++ b/.github/workflows/publish-nix-cache-manual.yml
@@ -1,0 +1,15 @@
+name: Publish Nix binary cache (manual)
+
+# On-demand escape hatch: re-run ONLY the Cachix build+push (e.g. to backfill
+# a newly added matrix leg) without cutting a throwaway release tag and
+# without exposing the rest of go.yml (nix-shell-test's contents:write
+# vendorHash push, the tag-gated release jobs) to manual dispatch. The
+# `release` environment's deployment-branch policy (main, v*) still applies,
+# so this only actually reaches Cachix when dispatched from main or a tag.
+on:
+  workflow_dispatch: {}
+
+jobs:
+  publish-nix-cache:
+    uses: ./.github/workflows/publish-nix-cache.yml
+    secrets: inherit

--- a/.github/workflows/publish-nix-cache-manual.yml
+++ b/.github/workflows/publish-nix-cache-manual.yml
@@ -9,6 +9,9 @@ name: Publish Nix binary cache (manual)
 on:
   workflow_dispatch: {}
 
+permissions:
+  contents: read # checkout only; this job never pushes back to the repo
+
 jobs:
   publish-nix-cache:
     uses: ./.github/workflows/publish-nix-cache.yml

--- a/.github/workflows/publish-nix-cache.yml
+++ b/.github/workflows/publish-nix-cache.yml
@@ -7,6 +7,9 @@ name: Publish Nix binary cache
 on:
   workflow_call:
 
+permissions:
+  contents: read # checkout only; this job never pushes back to the repo
+
 jobs:
   publish-nix-cache:
     name: Publish Nix binary cache (${{ matrix.system }})

--- a/.github/workflows/publish-nix-cache.yml
+++ b/.github/workflows/publish-nix-cache.yml
@@ -1,0 +1,50 @@
+name: Publish Nix binary cache
+
+# Reusable build+push job, called from go.yml on every tagged release and
+# from publish-nix-cache-manual.yml for an on-demand re-push (e.g. to
+# backfill a matrix leg without cutting a new tag). Kept in its own file so
+# manual dispatch can target ONLY this job, never the rest of go.yml.
+on:
+  workflow_call:
+
+jobs:
+  publish-nix-cache:
+    name: Publish Nix binary cache (${{ matrix.system }})
+    runs-on: ${{ matrix.runs-on }}
+    environment: release # for CACHIX_AUTH_TOKEN; also gates the ref (main, v*)
+    strategy:
+      fail-fast: false # a broken macOS runner should not withhold the Linux cache
+      matrix:
+        include:
+          - system: x86_64-linux
+            runs-on: ubuntu-latest
+          - system: aarch64-linux
+            # GitHub-hosted arm64 runner (GA for public repos) — this is the
+            # architecture agent-box's deployed fleet actually runs (Graviton
+            # EC2, see defangdevs/agent-box#373): without this leg, Cachix
+            # never has an artifact that box's first-boot nix build can hit.
+            runs-on: ubuntu-24.04-arm
+          - system: aarch64-darwin
+            runs-on: macos-15
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false # this job never pushes back to the repo
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342 # v31
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+
+      - name: Set up Cachix
+        uses: cachix/cachix-action@02b16339eddcf6ea27126a830c7f1992855cae13 # v17
+        with:
+          # Public cache; public key is committed in flake.nix and the README.
+          name: defanglabs
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+
+      - name: Build and push defang-cli
+        # cachix-action installs a post-build hook above, so this push is
+        # automatic: every output the build realises gets signed and uploaded.
+        run: nix build .#defang-cli --print-out-paths


### PR DESCRIPTION
## Summary
- `publish-nix-cache` (added in #2235) only builds and pushes `x86_64-linux` and `aarch64-darwin` to the `defanglabs` Cachix cache.
- That silently excludes `aarch64-linux` — which is the architecture [agent-box](https://github.com/defangdevs/agent-box)'s entire deployed fleet runs on (Graviton `t4g.*` EC2 instances). Every box's first-boot `nix build` for `defang-cli` (defangdevs/agent-box#373) misses the cache and compiles from source instead, which OOMs on small instances.
- Adds the missing matrix leg using GitHub's hosted `ubuntu-24.04-arm` runner (GA for public repos), so no cross-compile/QEMU emulation is needed.

## Test plan
- [x] `actionlint .github/workflows/go.yml` passes
- [ ] On merge + next tagged release, confirm `Publish Nix binary cache (aarch64-linux)` job succeeds and `nix path-info --store https://defanglabs.cachix.org <output>` resolves

Related: defangdevs/agent-box#373 (agent-box-side fix to actually consume this cache is tracked separately)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LnYjvSXXYN11xFBQquRfjn

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for manually republishing the Nix cache without creating a new release.
  * Added Linux ARM64 builds for Nix cache publishing.
  * Expanded build coverage across x86_64 Linux, ARM64 Linux, and ARM64 macOS.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->