### PR TITLE
Add idle-read timeout to CloudWatch and GCP log tail streams

### DIFF
--- a/src/pkg/cli/tail.go
+++ b/src/pkg/cli/tail.go
@@ -226,6 +226,13 @@ func isTransientError(err error) bool {
 		return true
 	}
 
+	// A stalled stream that produced no data and no error within the idle window; reconnect
+	// so a genuinely dead connection (e.g. expired credentials) gets a chance to fail fast on
+	// the fresh call instead of hanging until the caller's own context deadline.
+	if errors.Is(err, pkg.ErrIdleTimeout) {
+		return true
+	}
+
 	// GCP grpc transient errors
 	if st, ok := status.FromError(err); ok {
 		transientCodes := []codes.Code{codes.Unavailable, codes.Internal, codes.ResourceExhausted}

--- a/src/pkg/cli/tail_test.go
+++ b/src/pkg/cli/tail_test.go
@@ -16,6 +16,7 @@ import (
 	"iter"
 
 	"connectrpc.com/connect"
+	"github.com/DefangLabs/defang/src/pkg"
 	"github.com/DefangLabs/defang/src/pkg/cli/client"
 	awscodebuild "github.com/DefangLabs/defang/src/pkg/clouds/aws/codebuild"
 	"github.com/DefangLabs/defang/src/pkg/dryrun"
@@ -38,6 +39,7 @@ func TestIsTransientError(t *testing.T) {
 	}{
 		{"nil", nil, false},
 		{"eof", io.EOF, false},
+		{"idle timeout", pkg.ErrIdleTimeout, true},
 		{"connect unavailable", connect.NewError(connect.CodeUnavailable, errors.New("unavailable")), true},
 		{"connect internal non-wire", connect.NewError(connect.CodeInternal, errors.New("internal")), true},
 		{"connect permission denied", connect.NewError(connect.CodePermissionDenied, errors.New("denied")), false},

--- a/src/pkg/clouds/aws/cw/logs.go
+++ b/src/pkg/clouds/aws/cw/logs.go
@@ -13,7 +13,16 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
 	"github.com/aws/smithy-go/ptr"
+
+	"github.com/DefangLabs/defang/src/pkg"
 )
+
+// tailIdleTimeout bounds how long TailLogGroup waits for the next Live Tail event before
+// treating the connection as stalled. CloudWatch Live Tail sessions can go quiet on a
+// half-dead connection (e.g. expired credentials) without ever closing or erroring, so
+// without this the read loop would otherwise block until the caller's own context deadline,
+// however long that is. See https://github.com/DefangLabs/defang/issues/2231.
+var tailIdleTimeout = 90 * time.Second
 
 // Task ARN						arn:aws:ecs:us-west-2:123456789012:task/CLUSTER_NAME/2cba912d5eb14ffd926f6992b054f3bf
 // Cluster ARN					arn:aws:ecs:us-west-2:123456789012:cluster/CLUSTER_NAME
@@ -72,23 +81,22 @@ func TailLogGroup(ctx context.Context, cwClient StartLiveTailAPI, input LogGroup
 	return func(yield func([]LogEvent, error) bool) {
 		defer stream.Close()
 		for {
-			select {
-			case e := <-stream.Events():
-				if err := stream.Err(); err != nil {
-					yield(nil, err)
+			e, err := pkg.RecvWithIdleTimeout(ctx, stream.Events(), tailIdleTimeout)
+			if err != nil {
+				yield(nil, err)
+				return
+			}
+			if err := stream.Err(); err != nil {
+				yield(nil, err)
+				return
+			}
+			events, err := getLogEvents(e)
+			if err != nil {
+				if !yield(nil, err) {
 					return
 				}
-				events, err := getLogEvents(e)
-				if err != nil {
-					if !yield(nil, err) {
-						return
-					}
-				}
-				if !yield(events, nil) {
-					return
-				}
-			case <-ctx.Done():
-				yield(nil, ctx.Err())
+			}
+			if !yield(events, nil) {
 				return
 			}
 		}

--- a/src/pkg/clouds/aws/cw/logs.go
+++ b/src/pkg/clouds/aws/cw/logs.go
@@ -81,13 +81,16 @@ func TailLogGroup(ctx context.Context, cwClient StartLiveTailAPI, input LogGroup
 	return func(yield func([]LogEvent, error) bool) {
 		defer stream.Close()
 		for {
-			e, err := pkg.RecvWithIdleTimeout(ctx, stream.Events(), tailIdleTimeout)
-			if err != nil {
+			e, recvErr := pkg.RecvWithIdleTimeout(ctx, stream.Events(), tailIdleTimeout)
+			// stream.Err() is the authoritative reason the channel closed (e.g. an
+			// AccessDeniedException from expired credentials); check it before trusting
+			// recvErr, which on a closed channel is just io.EOF with no detail.
+			if err := stream.Err(); err != nil {
 				yield(nil, err)
 				return
 			}
-			if err := stream.Err(); err != nil {
-				yield(nil, err)
+			if recvErr != nil {
+				yield(nil, recvErr)
 				return
 			}
 			events, err := getLogEvents(e)

--- a/src/pkg/clouds/gcp/logging.go
+++ b/src/pkg/clouds/gcp/logging.go
@@ -5,12 +5,21 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"time"
 
 	logging "cloud.google.com/go/logging/apiv2"
 	"cloud.google.com/go/logging/apiv2/loggingpb"
+	"github.com/DefangLabs/defang/src/pkg"
 	"github.com/DefangLabs/defang/src/pkg/term"
 	"google.golang.org/api/iterator"
 )
+
+// tailIdleTimeout bounds how long the tailer waits for the next TailLogEntries response
+// before treating the stream as stalled. A half-dead gRPC stream (e.g. a reconnect that
+// lands on a connection that never delivers data) can block on Recv() forever without ever
+// erroring, so without this the read loop would otherwise block until the caller's own
+// context deadline, however long that is. See https://github.com/DefangLabs/defang/issues/2231.
+var tailIdleTimeout = 90 * time.Second
 
 func (gcp Gcp) NewTailer(ctx context.Context) (Tailer, error) {
 	client, err := logging.NewClient(ctx, gcp.Options...)
@@ -56,7 +65,7 @@ func (t *gcpLoggingTailer) Start(ctx context.Context, query string) error {
 
 func (t *gcpLoggingTailer) Next(ctx context.Context) (*loggingpb.LogEntry, error) {
 	if len(t.cache) == 0 {
-		resp, err := t.tleClient.Recv()
+		resp, err := pkg.CallWithIdleTimeout(ctx, tailIdleTimeout, t.tleClient.Recv)
 		if err != nil {
 			return nil, err
 		}

--- a/src/pkg/clouds/gcp/logging_test.go
+++ b/src/pkg/clouds/gcp/logging_test.go
@@ -2,10 +2,13 @@ package gcp
 
 import (
 	"context"
+	"errors"
 	"io"
 	"testing"
+	"time"
 
 	"cloud.google.com/go/logging/apiv2/loggingpb"
+	"github.com/DefangLabs/defang/src/pkg"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 )
@@ -15,10 +18,14 @@ import (
 type mockTailLogEntriesClient struct {
 	responses []*loggingpb.TailLogEntriesResponse
 	err       error
+	block     chan struct{} // if non-nil, Recv blocks until this channel is closed
 }
 
 func (m *mockTailLogEntriesClient) Send(*loggingpb.TailLogEntriesRequest) error { return nil }
 func (m *mockTailLogEntriesClient) Recv() (*loggingpb.TailLogEntriesResponse, error) {
+	if m.block != nil {
+		<-m.block
+	}
 	if len(m.responses) == 0 {
 		if m.err != nil {
 			return nil, m.err
@@ -85,5 +92,44 @@ func TestGcpLoggingTailerNext_WithEntries(t *testing.T) {
 	}
 	if entry == nil || entry.InsertId != "entry2" {
 		t.Fatalf("Next() entry = %v, want entry2", entry)
+	}
+}
+
+func TestGcpLoggingTailerNext_IdleTimeout(t *testing.T) {
+	// A stalled stream (Recv never returns, no error, no data) must surface
+	// pkg.ErrIdleTimeout instead of blocking forever. Regression test for
+	// https://github.com/DefangLabs/defang/issues/2231.
+	orig := tailIdleTimeout
+	tailIdleTimeout = 10 * time.Millisecond
+	defer func() { tailIdleTimeout = orig }()
+
+	client := &mockTailLogEntriesClient{block: make(chan struct{})} // never closed: Recv blocks forever
+	tailer := &gcpLoggingTailer{tleClient: client}
+
+	entry, err := tailer.Next(context.Background())
+	if !errors.Is(err, pkg.ErrIdleTimeout) {
+		t.Fatalf("Next() error = %v, want ErrIdleTimeout", err)
+	}
+	if entry != nil {
+		t.Fatalf("Next() entry = %v, want nil", entry)
+	}
+}
+
+func TestGcpLoggingTailerNext_ContextCanceled(t *testing.T) {
+	// If ctx is canceled before the idle timeout, Next must return the context error, not
+	// ErrIdleTimeout.
+	orig := tailIdleTimeout
+	tailIdleTimeout = time.Minute
+	defer func() { tailIdleTimeout = orig }()
+
+	client := &mockTailLogEntriesClient{block: make(chan struct{})} // never closed: Recv blocks forever
+	tailer := &gcpLoggingTailer{tleClient: client}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := tailer.Next(ctx)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Next() error = %v, want context.Canceled", err)
 	}
 }

--- a/src/pkg/idle.go
+++ b/src/pkg/idle.go
@@ -1,0 +1,64 @@
+package pkg
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+// ErrIdleTimeout is returned when a stream read has not produced any data (and no error)
+// within the configured idle window. Long-lived server streams (e.g. CloudWatch Live Tail,
+// GCP TailLogEntries) can stall on a half-dead connection without ever closing or erroring,
+// so callers need an idle deadline distinct from the overall context deadline to detect and
+// recover from that instead of blocking indefinitely.
+var ErrIdleTimeout = errors.New("idle timeout: no data received")
+
+// RecvWithIdleTimeout receives a single value from ch, returning ErrIdleTimeout if nothing
+// arrives within d, or ctx.Err() if ctx is done first. Use this for channel-based reads
+// (e.g. an AWS SDK EventStream's Events() channel) where wrapping the read in a goroutine
+// would be wasteful.
+func RecvWithIdleTimeout[T any](ctx context.Context, ch <-chan T, d time.Duration) (T, error) {
+	var zero T
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case v := <-ch:
+		return v, nil
+	case <-ctx.Done():
+		return zero, ctx.Err()
+	case <-timer.C:
+		return zero, ErrIdleTimeout
+	}
+}
+
+type idleResult[T any] struct {
+	val T
+	err error
+}
+
+// CallWithIdleTimeout runs fn and returns its result, or ErrIdleTimeout if fn does not
+// return within d, or ctx.Err() if ctx is done first. Use this for synchronous, blocking
+// calls (e.g. a gRPC stream's Recv()) that don't expose a channel to select on.
+//
+// If the timeout (or ctx) fires first, fn keeps running in the background and its result is
+// discarded; the caller is expected to close/cancel whatever fn is blocked on so that
+// goroutine doesn't run forever.
+func CallWithIdleTimeout[T any](ctx context.Context, d time.Duration, fn func() (T, error)) (T, error) {
+	ch := make(chan idleResult[T], 1)
+	go func() {
+		v, err := fn()
+		ch <- idleResult[T]{v, err}
+	}()
+
+	var zero T
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case r := <-ch:
+		return r.val, r.err
+	case <-ctx.Done():
+		return zero, ctx.Err()
+	case <-timer.C:
+		return zero, ErrIdleTimeout
+	}
+}

--- a/src/pkg/idle.go
+++ b/src/pkg/idle.go
@@ -3,6 +3,7 @@ package pkg
 import (
 	"context"
 	"errors"
+	"io"
 	"time"
 )
 
@@ -14,15 +15,19 @@ import (
 var ErrIdleTimeout = errors.New("idle timeout: no data received")
 
 // RecvWithIdleTimeout receives a single value from ch, returning ErrIdleTimeout if nothing
-// arrives within d, or ctx.Err() if ctx is done first. Use this for channel-based reads
-// (e.g. an AWS SDK EventStream's Events() channel) where wrapping the read in a goroutine
-// would be wasteful.
+// arrives within d, or ctx.Err() if ctx is done first. If ch is closed (and drained), it
+// returns io.EOF, matching the two-value receive form's "ok" signal rather than silently
+// handing back T's zero value forever. Use this for channel-based reads (e.g. an AWS SDK
+// EventStream's Events() channel) where wrapping the read in a goroutine would be wasteful.
 func RecvWithIdleTimeout[T any](ctx context.Context, ch <-chan T, d time.Duration) (T, error) {
 	var zero T
 	timer := time.NewTimer(d)
 	defer timer.Stop()
 	select {
-	case v := <-ch:
+	case v, ok := <-ch:
+		if !ok {
+			return zero, io.EOF
+		}
 		return v, nil
 	case <-ctx.Done():
 		return zero, ctx.Err()

--- a/src/pkg/idle_test.go
+++ b/src/pkg/idle_test.go
@@ -3,86 +3,140 @@ package pkg
 import (
 	"context"
 	"errors"
+	"io"
 	"testing"
 	"time"
 )
 
-func TestRecvWithIdleTimeout_Value(t *testing.T) {
-	ch := make(chan int, 1)
-	ch <- 42
-
-	v, err := RecvWithIdleTimeout(context.Background(), ch, time.Minute)
-	if err != nil {
-		t.Fatalf("RecvWithIdleTimeout() error = %v, want nil", err)
+func TestRecvWithIdleTimeout(t *testing.T) {
+	tests := []struct {
+		name    string
+		makeCh  func() <-chan int
+		ctx     func() context.Context
+		timeout time.Duration
+		want    int
+		wantErr error
+	}{
+		{
+			name: "value",
+			makeCh: func() <-chan int {
+				ch := make(chan int, 1)
+				ch <- 42
+				return ch
+			},
+			ctx:     context.Background,
+			timeout: time.Minute,
+			want:    42,
+		},
+		{
+			name: "closed channel",
+			makeCh: func() <-chan int {
+				ch := make(chan int)
+				close(ch)
+				return ch
+			},
+			ctx:     context.Background,
+			timeout: time.Minute,
+			wantErr: io.EOF,
+		},
+		{
+			name:    "idle timeout",
+			makeCh:  func() <-chan int { return make(chan int) }, // never sent to
+			ctx:     context.Background,
+			timeout: 10 * time.Millisecond,
+			wantErr: ErrIdleTimeout,
+		},
+		{
+			name:   "context canceled",
+			makeCh: func() <-chan int { return make(chan int) },
+			ctx: func() context.Context {
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel()
+				return ctx
+			},
+			timeout: time.Minute,
+			wantErr: context.Canceled,
+		},
 	}
-	if v != 42 {
-		t.Fatalf("RecvWithIdleTimeout() = %d, want 42", v)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := RecvWithIdleTimeout(tt.ctx(), tt.makeCh(), tt.timeout)
+			if tt.wantErr != nil {
+				if !errors.Is(err, tt.wantErr) {
+					t.Fatalf("RecvWithIdleTimeout() error = %v, want %v", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("RecvWithIdleTimeout() error = %v, want nil", err)
+			}
+			if got != tt.want {
+				t.Fatalf("RecvWithIdleTimeout() = %d, want %d", got, tt.want)
+			}
+		})
 	}
 }
 
-func TestRecvWithIdleTimeout_Idle(t *testing.T) {
-	ch := make(chan int) // never sent to
-
-	_, err := RecvWithIdleTimeout(context.Background(), ch, 10*time.Millisecond)
-	if !errors.Is(err, ErrIdleTimeout) {
-		t.Fatalf("RecvWithIdleTimeout() error = %v, want ErrIdleTimeout", err)
-	}
-}
-
-func TestRecvWithIdleTimeout_ContextCanceled(t *testing.T) {
-	ch := make(chan int)
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
-
-	_, err := RecvWithIdleTimeout(ctx, ch, time.Minute)
-	if !errors.Is(err, context.Canceled) {
-		t.Fatalf("RecvWithIdleTimeout() error = %v, want context.Canceled", err)
-	}
-}
-
-func TestCallWithIdleTimeout_Value(t *testing.T) {
-	v, err := CallWithIdleTimeout(context.Background(), time.Minute, func() (int, error) {
-		return 7, nil
-	})
-	if err != nil {
-		t.Fatalf("CallWithIdleTimeout() error = %v, want nil", err)
-	}
-	if v != 7 {
-		t.Fatalf("CallWithIdleTimeout() = %d, want 7", v)
-	}
-}
-
-func TestCallWithIdleTimeout_PropagatesError(t *testing.T) {
-	wantErr := errors.New("boom")
-	_, err := CallWithIdleTimeout(context.Background(), time.Minute, func() (int, error) {
-		return 0, wantErr
-	})
-	if !errors.Is(err, wantErr) {
-		t.Fatalf("CallWithIdleTimeout() error = %v, want %v", err, wantErr)
-	}
-}
-
-func TestCallWithIdleTimeout_Idle(t *testing.T) {
+func TestCallWithIdleTimeout(t *testing.T) {
+	errBoom := errors.New("boom")
 	block := make(chan struct{}) // never closed
-	_, err := CallWithIdleTimeout(context.Background(), 10*time.Millisecond, func() (int, error) {
-		<-block
-		return 0, nil
-	})
-	if !errors.Is(err, ErrIdleTimeout) {
-		t.Fatalf("CallWithIdleTimeout() error = %v, want ErrIdleTimeout", err)
+
+	tests := []struct {
+		name    string
+		fn      func() (int, error)
+		ctx     func() context.Context
+		timeout time.Duration
+		want    int
+		wantErr error
+	}{
+		{
+			name:    "value",
+			fn:      func() (int, error) { return 7, nil },
+			ctx:     context.Background,
+			timeout: time.Minute,
+			want:    7,
+		},
+		{
+			name:    "propagated error",
+			fn:      func() (int, error) { return 0, errBoom },
+			ctx:     context.Background,
+			timeout: time.Minute,
+			wantErr: errBoom,
+		},
+		{
+			name:    "idle timeout",
+			fn:      func() (int, error) { <-block; return 0, nil },
+			ctx:     context.Background,
+			timeout: 10 * time.Millisecond,
+			wantErr: ErrIdleTimeout,
+		},
+		{
+			name: "context canceled",
+			fn:   func() (int, error) { <-block; return 0, nil },
+			ctx: func() context.Context {
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel()
+				return ctx
+			},
+			timeout: time.Minute,
+			wantErr: context.Canceled,
+		},
 	}
-}
-
-func TestCallWithIdleTimeout_ContextCanceled(t *testing.T) {
-	block := make(chan struct{}) // never closed
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
-
-	_, err := CallWithIdleTimeout(ctx, time.Minute, func() (int, error) {
-		<-block
-		return 0, nil
-	})
-	if !errors.Is(err, context.Canceled) {
-		t.Fatalf("CallWithIdleTimeout() error = %v, want context.Canceled", err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := CallWithIdleTimeout(tt.ctx(), tt.timeout, tt.fn)
+			if tt.wantErr != nil {
+				if !errors.Is(err, tt.wantErr) {
+					t.Fatalf("CallWithIdleTimeout() error = %v, want %v", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("CallWithIdleTimeout() error = %v, want nil", err)
+			}
+			if got != tt.want {
+				t.Fatalf("CallWithIdleTimeout() = %d, want %d", got, tt.want)
+			}
+		})
 	}
 }

--- a/src/pkg/idle_test.go
+++ b/src/pkg/idle_test.go
@@ -1,0 +1,88 @@
+package pkg
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestRecvWithIdleTimeout_Value(t *testing.T) {
+	ch := make(chan int, 1)
+	ch <- 42
+
+	v, err := RecvWithIdleTimeout(context.Background(), ch, time.Minute)
+	if err != nil {
+		t.Fatalf("RecvWithIdleTimeout() error = %v, want nil", err)
+	}
+	if v != 42 {
+		t.Fatalf("RecvWithIdleTimeout() = %d, want 42", v)
+	}
+}
+
+func TestRecvWithIdleTimeout_Idle(t *testing.T) {
+	ch := make(chan int) // never sent to
+
+	_, err := RecvWithIdleTimeout(context.Background(), ch, 10*time.Millisecond)
+	if !errors.Is(err, ErrIdleTimeout) {
+		t.Fatalf("RecvWithIdleTimeout() error = %v, want ErrIdleTimeout", err)
+	}
+}
+
+func TestRecvWithIdleTimeout_ContextCanceled(t *testing.T) {
+	ch := make(chan int)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := RecvWithIdleTimeout(ctx, ch, time.Minute)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("RecvWithIdleTimeout() error = %v, want context.Canceled", err)
+	}
+}
+
+func TestCallWithIdleTimeout_Value(t *testing.T) {
+	v, err := CallWithIdleTimeout(context.Background(), time.Minute, func() (int, error) {
+		return 7, nil
+	})
+	if err != nil {
+		t.Fatalf("CallWithIdleTimeout() error = %v, want nil", err)
+	}
+	if v != 7 {
+		t.Fatalf("CallWithIdleTimeout() = %d, want 7", v)
+	}
+}
+
+func TestCallWithIdleTimeout_PropagatesError(t *testing.T) {
+	wantErr := errors.New("boom")
+	_, err := CallWithIdleTimeout(context.Background(), time.Minute, func() (int, error) {
+		return 0, wantErr
+	})
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("CallWithIdleTimeout() error = %v, want %v", err, wantErr)
+	}
+}
+
+func TestCallWithIdleTimeout_Idle(t *testing.T) {
+	block := make(chan struct{}) // never closed
+	_, err := CallWithIdleTimeout(context.Background(), 10*time.Millisecond, func() (int, error) {
+		<-block
+		return 0, nil
+	})
+	if !errors.Is(err, ErrIdleTimeout) {
+		t.Fatalf("CallWithIdleTimeout() error = %v, want ErrIdleTimeout", err)
+	}
+}
+
+func TestCallWithIdleTimeout_ContextCanceled(t *testing.T) {
+	block := make(chan struct{}) // never closed
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := CallWithIdleTimeout(ctx, time.Minute, func() (int, error) {
+		<-block
+		return 0, nil
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("CallWithIdleTimeout() error = %v, want context.Canceled", err)
+	}
+}


### PR DESCRIPTION
## Summary

`defang up` could hang indefinitely in "Waiting for services to be healthy..." on both AWS and GCP when the log-tail stream backing the deployment-status wait stalls without ever closing or erroring (e.g. AWS credentials expiring mid-session, or a GCP reconnect landing on a dead connection). Root-caused and plan posted at #2231; details there.

Root cause: neither `cw.TailLogGroup` (AWS CloudWatch Live Tail) nor `gcpLoggingTailer.Next` (GCP TailLogEntries) had an idle read timeout — both block on the next frame with no data and no error, deferring entirely to the caller's own context deadline (30 min in the CI repro). The existing transient/terminal error classification (`isTransientError`) already does the right thing once an error actually surfaces; the bug is that no error ever surfaces while the connection is silently stuck.

## Changes

- `src/pkg/idle.go`: new generic `RecvWithIdleTimeout` (channel-based) and `CallWithIdleTimeout` (synchronous-call-based) helpers, plus `pkg.ErrIdleTimeout`.
- `src/pkg/clouds/aws/cw/logs.go`: `TailLogGroup` now uses `RecvWithIdleTimeout` on `stream.Events()` instead of a raw channel select.
- `src/pkg/clouds/gcp/logging.go`: `gcpLoggingTailer.Next` now wraps `tleClient.Recv()` with `CallWithIdleTimeout`.
- `src/pkg/cli/tail.go`: `isTransientError` classifies `pkg.ErrIdleTimeout` as transient, so it flows into the existing reconnect logic in `receiveLogs` and `WaitServiceState`.

Idle timeout is 90s. On reconnect, a genuinely dead credential set fails fast on the fresh `StartLiveTail`/`TailLogEntries` call (AWS SDK doesn't retry `AccessDeniedException`), so it now surfaces as a prompt, terminal error instead of a 20+ minute silent hang.

Issue #2071's "fall back to polling" suggestion is a separate, heavier change and isn't needed for this fix — this makes the existing reconnect path actually fire.

## Test plan

- [x] `go build ./...`
- [x] `go test -short ./...` (all green)
- [x] `gofmt`/`go vet` clean on changed files
- [x] New unit tests: `pkg/idle_test.go` (the generic helpers, in isolation), `pkg/clouds/gcp/logging_test.go` (`TestGcpLoggingTailerNext_IdleTimeout`, `TestGcpLoggingTailerNext_ContextCanceled`), `pkg/cli/tail_test.go` (`isTransientError` classifies `pkg.ErrIdleTimeout`)
- [ ] AWS's `TailLogGroup` idle-timeout branch isn't covered by an integration test — the existing test file notes `StartLiveTailOutput`'s `EventStream` can't be usefully mocked, which is why the timeout logic is factored into the independently-tested `RecvWithIdleTimeout` helper instead

Fixes #2231.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CssV5p1SYx6NDf9qTq7R3L

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved live log streaming reliability across AWS and GCP.
  * Stalled log streams now time out after a period of inactivity instead of hanging indefinitely.
  * CLI log tailing automatically reconnects when a transient idle timeout occurs.
  * User-requested cancellations continue to stop log streaming promptly.

* **Tests**
  * Added coverage for idle timeouts, successful reads, propagated errors, and cancellation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->