### PR TITLE
fix(codeowners): route .github/** reviews to defangdevs

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,7 +2,7 @@
 *       @defangdevs
 
 # GitHub actions and repo configuration
-/.github/**       @raphaeltm
+/.github/**       @defangdevs
 
 # Go command line tool
 /src/**       @lionello @defangdevs


### PR DESCRIPTION
## Summary
- `/.github/**` in CODEOWNERS still pointed to `@raphaeltm`, a leftover from before PR #2233 moved the default owner and `/src/**` co-owner to `@defangdevs`.
- This caused dependabot PRs touching `.github/workflows/**` (e.g. #2238) to auto-request review from `raphaeltm` instead of `defangdevs`.

## Test plan
- [x] Confirmed via `gh pr view 2238` that the PR only touches `.github/workflows/go.yml` and `.github/workflows/publish-nix-cache.yml`, matching `/.github/**`.
- [ ] Next dependabot PR touching `.github/**` should request review from `defangdevs`.

Note: checked defang-mvp, portal, defang-docs, and samples for the same pattern — none have an individual-owner override on `.github/**`/dependabot paths, so no changes needed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LnYjvSXXYN11xFBQquRfjn