### PR TITLE
fix(cli): poll GetServices as a fallback when WaitServiceState reconnects

### DIFF
--- a/pkgs/defang/cli.nix
+++ b/pkgs/defang/cli.nix
@@ -7,7 +7,7 @@ buildGo125Module {
   pname = "defang-cli";
   version = "git";
   src = lib.cleanSource ../../src;
-  vendorHash = "sha256-CQD14oEPHZcRkjxrSKccPvZUeNsF25qwUI/48Y7VMZ0=";
+  vendorHash = "sha256-YYMRLT85SjuW8zv75QxJK2o8juXPfevcKIDYcjbfdOU=";
 
   subPackages = [ "cmd/cli" ];
 

--- a/src/pkg/cli/subscribe.go
+++ b/src/pkg/cli/subscribe.go
@@ -64,6 +64,20 @@ func WaitServiceState(
 				if err := provider.DelayBeforeRetry(ctx); err != nil {
 					return serviceStates, err
 				}
+
+				// A reconnected stream only observes state changes from here on; if the
+				// target transition already happened while the previous stream was stalled,
+				// no amount of reconnecting will ever see it again (#2241). Poll current
+				// state directly as a fallback so a missed transition doesn't loop until
+				// the caller's context deadline kills it.
+				done, pollErr := pollServiceStates(ctx, provider, projectName, etag, targetState, serviceStates)
+				if pollErr != nil {
+					return serviceStates, pollErr
+				}
+				if done {
+					return serviceStates, nil
+				}
+
 				stop() // stop the old iterator
 				logs, err = provider.Subscribe(ctx, &subscribeRequest)
 				if err != nil {
@@ -102,10 +116,8 @@ func WaitServiceState(
 		if serviceStates[msg.Name] != targetState {
 			serviceStates[msg.Name] = msg.State
 
-			// exit early on detecting a FAILED state
-			switch msg.State {
-			case defangv1.ServiceState_BUILD_FAILED, defangv1.ServiceState_DEPLOYMENT_FAILED:
-				return serviceStates, client.ErrDeploymentFailed{Service: msg.Name, Message: msg.Status}
+			if err := failedStateError(msg.Name, msg.State, msg.Status); err != nil {
+				return serviceStates, err
 			}
 		}
 
@@ -113,6 +125,42 @@ func WaitServiceState(
 			return serviceStates, nil // all services are in the target state
 		}
 	}
+}
+
+// pollServiceStates fetches current service state directly via GetServices, independent of
+// the log-tail stream, and merges any states for services we're tracking with a matching etag
+// into serviceStates. It returns done=true once all tracked services have reached targetState.
+// A failure to poll is not fatal: the caller falls back to reconnecting the log-tail stream.
+func pollServiceStates(ctx context.Context, provider client.Provider, projectName string, etag types.ETag, targetState defangv1.ServiceState, serviceStates ServiceStates) (done bool, err error) {
+	resp, err := provider.GetServices(ctx, &defangv1.GetServicesRequest{Project: projectName})
+	if err != nil {
+		term.Debugf("WaitServiceState: GetServices poll failed, continuing to wait for log stream: %v", err)
+		return false, nil
+	}
+
+	for _, svc := range resp.Services {
+		if svc.Service == nil || svc.Etag != etag || svc.State == defangv1.ServiceState_NOT_SPECIFIED {
+			continue
+		}
+		name := svc.Service.Name
+		if _, tracked := serviceStates[name]; !tracked {
+			continue
+		}
+		serviceStates[name] = svc.State
+		if err := failedStateError(name, svc.State, svc.Status); err != nil {
+			return false, err
+		}
+	}
+
+	return allInState(targetState, serviceStates), nil
+}
+
+func failedStateError(name string, state defangv1.ServiceState, status string) error {
+	switch state {
+	case defangv1.ServiceState_BUILD_FAILED, defangv1.ServiceState_DEPLOYMENT_FAILED:
+		return client.ErrDeploymentFailed{Service: name, Message: status}
+	}
+	return nil
 }
 
 func allInState(targetState defangv1.ServiceState, serviceStates ServiceStates) bool {

--- a/src/pkg/cli/subscribe.go
+++ b/src/pkg/cli/subscribe.go
@@ -75,6 +75,7 @@ func WaitServiceState(
 					return serviceStates, pollErr
 				}
 				if done {
+					term.Debugf("WaitServiceState: GetServices poll observed target state during reconnect; not resuming the stream")
 					return serviceStates, nil
 				}
 

--- a/src/pkg/cli/subscribe_test.go
+++ b/src/pkg/cli/subscribe_test.go
@@ -264,6 +264,12 @@ func (m *mockSubscribeProviderForReconnectTest) Subscribe(
 	}, nil
 }
 
+// GetServices returns no services, so the reconnect-time poll never short-circuits
+// these tests: they exercise the stream-reconnect path itself, not the poll fallback.
+func (m *mockSubscribeProviderForReconnectTest) GetServices(context.Context, *defangv1.GetServicesRequest) (*defangv1.GetServicesResponse, error) {
+	return &defangv1.GetServicesResponse{}, nil
+}
+
 func TestWaitServiceStateStreamReceive(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -311,4 +317,90 @@ func TestWaitServiceStateStreamReceive(t *testing.T) {
 			}
 		})
 	}
+}
+
+// mockStalledStreamProvider's Subscribe always returns a transient error, simulating a log-tail
+// stream that never delivers the health-transition event (e.g. because it happened before the
+// stream reconnected, #2241). GetServices reports the true current state, independent of the stream.
+type mockStalledStreamProvider struct {
+	client.MockProvider
+	client.RetryDelayer
+	servicesResp *defangv1.GetServicesResponse
+	getServicesN int
+}
+
+func (m *mockStalledStreamProvider) Subscribe(
+	_ context.Context,
+	_ *defangv1.SubscribeRequest,
+) (iter.Seq2[*defangv1.SubscribeResponse, error], error) {
+	return func(yield func(*defangv1.SubscribeResponse, error) bool) {
+		yield(nil, connect.NewError(connect.CodeUnavailable, errors.New("idle timeout: no data received")))
+	}, nil
+}
+
+func (m *mockStalledStreamProvider) GetServices(context.Context, *defangv1.GetServicesRequest) (*defangv1.GetServicesResponse, error) {
+	m.getServicesN++
+	return m.servicesResp, nil
+}
+
+func TestWaitServiceStatePollFallbackOnStalledStream(t *testing.T) {
+	t.Run("poll observes target state that the stream can never see again", func(t *testing.T) {
+		ctx := t.Context()
+		provider := &mockStalledStreamProvider{
+			RetryDelayer: client.RetryDelayer{Delay: 1 * time.Millisecond},
+			servicesResp: &defangv1.GetServicesResponse{
+				Services: []*defangv1.ServiceInfo{
+					{
+						Service: &defangv1.Service{Name: "service1"},
+						Etag:    "EtagSomething",
+						State:   defangv1.ServiceState_DEPLOYMENT_COMPLETED,
+					},
+				},
+			},
+		}
+		ss, err := WaitServiceState(
+			ctx, provider,
+			defangv1.ServiceState_DEPLOYMENT_COMPLETED,
+			"testproject",
+			"EtagSomething",
+			[]string{"service1"},
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := ServiceStates{"service1": defangv1.ServiceState_DEPLOYMENT_COMPLETED}
+		if !reflect.DeepEqual(ss, want) {
+			t.Errorf("expected service states %v, got: %v", want, ss)
+		}
+		if provider.getServicesN == 0 {
+			t.Error("expected GetServices to be polled at least once")
+		}
+	})
+
+	t.Run("poll ignores services with a mismatched etag", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(t.Context(), 20*time.Millisecond)
+		defer cancel()
+		provider := &mockStalledStreamProvider{
+			RetryDelayer: client.RetryDelayer{Delay: 1 * time.Millisecond},
+			servicesResp: &defangv1.GetServicesResponse{
+				Services: []*defangv1.ServiceInfo{
+					{
+						Service: &defangv1.Service{Name: "service1"},
+						Etag:    "SomeOtherEtag",
+						State:   defangv1.ServiceState_DEPLOYMENT_COMPLETED,
+					},
+				},
+			},
+		}
+		_, err := WaitServiceState(
+			ctx, provider,
+			defangv1.ServiceState_DEPLOYMENT_COMPLETED,
+			"testproject",
+			"EtagSomething",
+			[]string{"service1"},
+		)
+		if err == nil {
+			t.Fatal("expected an error once the context deadline is exceeded, got nil")
+		}
+	})
 }

--- a/src/pkg/cli/subscribe_test.go
+++ b/src/pkg/cli/subscribe_test.go
@@ -325,8 +325,10 @@ func TestWaitServiceStateStreamReceive(t *testing.T) {
 type mockStalledStreamProvider struct {
 	client.MockProvider
 	client.RetryDelayer
-	servicesResp *defangv1.GetServicesResponse
-	getServicesN int
+	servicesResp    *defangv1.GetServicesResponse
+	servicesErr     error
+	failFirstNPolls int
+	getServicesN    int
 }
 
 func (m *mockStalledStreamProvider) Subscribe(
@@ -340,67 +342,118 @@ func (m *mockStalledStreamProvider) Subscribe(
 
 func (m *mockStalledStreamProvider) GetServices(context.Context, *defangv1.GetServicesRequest) (*defangv1.GetServicesResponse, error) {
 	m.getServicesN++
+	if m.getServicesN <= m.failFirstNPolls {
+		return nil, m.servicesErr
+	}
 	return m.servicesResp, nil
 }
 
 func TestWaitServiceStatePollFallbackOnStalledStream(t *testing.T) {
-	t.Run("poll observes target state that the stream can never see again", func(t *testing.T) {
-		ctx := t.Context()
-		provider := &mockStalledStreamProvider{
-			RetryDelayer: client.RetryDelayer{Delay: 1 * time.Millisecond},
+	tests := []struct {
+		name                string
+		servicesResp        *defangv1.GetServicesResponse
+		servicesErr         error
+		failFirstNPolls     int
+		ctxTimeout          time.Duration // 0 means no deadline
+		wantErrDeployFailed bool
+		wantCtxErr          bool
+		wantStates          ServiceStates
+	}{
+		{
+			name: "poll observes target state that the stream can never see again",
 			servicesResp: &defangv1.GetServicesResponse{
 				Services: []*defangv1.ServiceInfo{
-					{
-						Service: &defangv1.Service{Name: "service1"},
-						Etag:    "EtagSomething",
-						State:   defangv1.ServiceState_DEPLOYMENT_COMPLETED,
-					},
+					{Service: &defangv1.Service{Name: "service1"}, Etag: "EtagSomething", State: defangv1.ServiceState_DEPLOYMENT_COMPLETED},
 				},
 			},
-		}
-		ss, err := WaitServiceState(
-			ctx, provider,
-			defangv1.ServiceState_DEPLOYMENT_COMPLETED,
-			"testproject",
-			"EtagSomething",
-			[]string{"service1"},
-		)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		want := ServiceStates{"service1": defangv1.ServiceState_DEPLOYMENT_COMPLETED}
-		if !reflect.DeepEqual(ss, want) {
-			t.Errorf("expected service states %v, got: %v", want, ss)
-		}
-		if provider.getServicesN == 0 {
-			t.Error("expected GetServices to be polled at least once")
-		}
-	})
+			wantStates: ServiceStates{"service1": defangv1.ServiceState_DEPLOYMENT_COMPLETED},
+		},
+		{
+			name: "poll ignores services with a mismatched etag",
+			servicesResp: &defangv1.GetServicesResponse{
+				Services: []*defangv1.ServiceInfo{
+					{Service: &defangv1.Service{Name: "service1"}, Etag: "SomeOtherEtag", State: defangv1.ServiceState_DEPLOYMENT_COMPLETED},
+				},
+			},
+			ctxTimeout: 20 * time.Millisecond,
+			wantCtxErr: true,
+		},
+		{
+			name:            "poll error is not fatal; polling continues on later reconnects",
+			servicesErr:     errors.New("transient GetServices failure"),
+			failFirstNPolls: 2,
+			servicesResp: &defangv1.GetServicesResponse{
+				Services: []*defangv1.ServiceInfo{
+					{Service: &defangv1.Service{Name: "service1"}, Etag: "EtagSomething", State: defangv1.ServiceState_DEPLOYMENT_COMPLETED},
+				},
+			},
+			wantStates: ServiceStates{"service1": defangv1.ServiceState_DEPLOYMENT_COMPLETED},
+		},
+		{
+			name: "poll observes a BUILD_FAILED state",
+			servicesResp: &defangv1.GetServicesResponse{
+				Services: []*defangv1.ServiceInfo{
+					{Service: &defangv1.Service{Name: "service1"}, Etag: "EtagSomething", State: defangv1.ServiceState_BUILD_FAILED, Status: "build failed"},
+				},
+			},
+			wantErrDeployFailed: true,
+			wantStates:          ServiceStates{"service1": defangv1.ServiceState_BUILD_FAILED},
+		},
+		{
+			name: "poll observes a DEPLOYMENT_FAILED state",
+			servicesResp: &defangv1.GetServicesResponse{
+				Services: []*defangv1.ServiceInfo{
+					{Service: &defangv1.Service{Name: "service1"}, Etag: "EtagSomething", State: defangv1.ServiceState_DEPLOYMENT_FAILED, Status: "deploy failed"},
+				},
+			},
+			wantErrDeployFailed: true,
+			wantStates:          ServiceStates{"service1": defangv1.ServiceState_DEPLOYMENT_FAILED},
+		},
+	}
 
-	t.Run("poll ignores services with a mismatched etag", func(t *testing.T) {
-		ctx, cancel := context.WithTimeout(t.Context(), 20*time.Millisecond)
-		defer cancel()
-		provider := &mockStalledStreamProvider{
-			RetryDelayer: client.RetryDelayer{Delay: 1 * time.Millisecond},
-			servicesResp: &defangv1.GetServicesResponse{
-				Services: []*defangv1.ServiceInfo{
-					{
-						Service: &defangv1.Service{Name: "service1"},
-						Etag:    "SomeOtherEtag",
-						State:   defangv1.ServiceState_DEPLOYMENT_COMPLETED,
-					},
-				},
-			},
-		}
-		_, err := WaitServiceState(
-			ctx, provider,
-			defangv1.ServiceState_DEPLOYMENT_COMPLETED,
-			"testproject",
-			"EtagSomething",
-			[]string{"service1"},
-		)
-		if err == nil {
-			t.Fatal("expected an error once the context deadline is exceeded, got nil")
-		}
-	})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := t.Context()
+			if tt.ctxTimeout > 0 {
+				var cancel context.CancelFunc
+				ctx, cancel = context.WithTimeout(ctx, tt.ctxTimeout)
+				defer cancel()
+			}
+			provider := &mockStalledStreamProvider{
+				RetryDelayer:    client.RetryDelayer{Delay: 1 * time.Millisecond},
+				servicesResp:    tt.servicesResp,
+				servicesErr:     tt.servicesErr,
+				failFirstNPolls: tt.failFirstNPolls,
+			}
+			ss, err := WaitServiceState(
+				ctx, provider,
+				defangv1.ServiceState_DEPLOYMENT_COMPLETED,
+				"testproject",
+				"EtagSomething",
+				[]string{"service1"},
+			)
+
+			switch {
+			case tt.wantCtxErr:
+				if err == nil {
+					t.Fatal("expected an error once the context deadline is exceeded, got nil")
+				}
+			case tt.wantErrDeployFailed:
+				if !errors.As(err, &client.ErrDeploymentFailed{}) {
+					t.Fatalf("expected ErrDeploymentFailed, got: %v", err)
+				}
+			default:
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+			}
+
+			if tt.wantStates != nil && !reflect.DeepEqual(ss, tt.wantStates) {
+				t.Errorf("expected service states %v, got: %v", tt.wantStates, ss)
+			}
+			if tt.failFirstNPolls > 0 && provider.getServicesN <= tt.failFirstNPolls {
+				t.Errorf("expected polling to continue past the initial error(s), got %d GetServices calls", provider.getServicesN)
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Summary

Root cause (from #2241): `WaitServiceState`'s reconnect-on-transient-error path opens a fresh `provider.Subscribe` stream, which on GCP starts a brand-new forward-only log query. If the one-time health-transition log entry was emitted while the previous stream was stalled, no amount of reconnecting can ever re-observe it — every reconnect behaves identically (idle, then reconnect) forever, until the caller's own context deadline kills it.

## Fix

`Provider.GetServices` already exists and, for GCP, reads current service state from a project-update object independent of the log tail. `WaitServiceState` now polls it right after the transient-error backoff and before re-subscribing:
- merges any matching (etag + tracked service) states into the tracked map
- returns immediately if that already shows the target state, or a `BUILD_FAILED`/`DEPLOYMENT_FAILED` state
- otherwise falls through to reconnecting the stream exactly as before — this is a fallback, not a replacement

This addresses the reconnect-loop for any transient error that causes a resubscribe (idle timeout, `Unavailable`, `Internal`, `ResourceExhausted`), not just the idle-timeout case from #2237.

## Testing

- `go test -short ./pkg/cli/...` — all packages pass, including new tests:
  - `TestWaitServiceStatePollFallbackOnStalledStream/poll_observes_target_state_...` — a stream that always errors transiently, paired with a `GetServices` mock returning `DEPLOYMENT_COMPLETED`, resolves successfully instead of looping.
  - `.../poll_ignores_services_with_a_mismatched_etag` — a poll response for a different etag doesn't short-circuit; the wait proceeds (and times out via context, as expected in the test).
- `make lint` — clean on the changed files (20 pre-existing `gosec` findings elsewhere on `main` are unrelated).

Fixes #2241


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved deployment monitoring after temporary connection interruptions or stalled status updates.
  - Monitoring now continues through intermittent status-check errors and unrelated service versions.
  - Deployment completion is detected more reliably during reconnection.
  - Build and deployment failures are reported correctly instead of causing monitoring to stop prematurely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->