### PR TITLE
fix(azure): drop redundant CD log timestamp

### DIFF
--- a/pkgs/defang/cli.nix
+++ b/pkgs/defang/cli.nix
@@ -7,7 +7,7 @@ buildGo125Module {
   pname = "defang-cli";
   version = "git";
   src = lib.cleanSource ../../src;
-  vendorHash = "sha256-CQD14oEPHZcRkjxrSKccPvZUeNsF25qwUI/48Y7VMZ0=";
+  vendorHash = "sha256-YYMRLT85SjuW8zv75QxJK2o8juXPfevcKIDYcjbfdOU=";
 
   subPackages = [ "cmd/cli" ];
 

--- a/src/pkg/cli/client/byoc/azure/byoc.go
+++ b/src/pkg/cli/client/byoc/azure/byoc.go
@@ -800,6 +800,26 @@ func (b *ByocAzure) PutConfig(ctx context.Context, req *defangv1.PutConfigReques
 	return nil
 }
 
+// parseCDLogLine splits a raw CD job log line into its engine timestamp and message.
+// The CD job's pulumi wrapper writes lines like
+// "2026-04-28T23:43:03.965786510Z - worker deleting (0s)" to stdout, which would
+// otherwise show up as a second, near-duplicate timestamp next to the CLI's own
+// read-time column (#2079). When the line doesn't start with a parseable
+// timestamp, ts is the zero value and message is the line unchanged.
+func parseCDLogLine(line string) (ts time.Time, message string) {
+	head, rest, ok := strings.Cut(line, " ")
+	if !ok {
+		return time.Time{}, line
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, head)
+	if err != nil {
+		return time.Time{}, line
+	}
+	rest = strings.TrimSpace(rest)
+	rest = strings.TrimPrefix(rest, "-")
+	return parsed, strings.TrimSpace(rest)
+}
+
 // QueryLogs implements client.Provider. It merges three log sources for the project:
 // CD (deployment) logs from the Container Apps Job, service logs from the project's
 // Container Apps, and build logs from ACR. When req.Follow is set each source streams
@@ -935,12 +955,16 @@ func (b *ByocAzure) QueryLogs(ctx context.Context, req *defangv1.TailRequest) (i
 					}
 					continue
 				}
+				ts, message := parseCDLogLine(entry.line)
+				if ts.IsZero() {
+					ts = time.Now()
+				}
 				if !yield(&defangv1.TailResponse{
 					Entries: []*defangv1.LogEntry{{
-						Message:   entry.line,
+						Message:   message,
 						Service:   cdServiceName,
 						Etag:      etag,
-						Timestamp: timestamppb.Now(),
+						Timestamp: timestamppb.New(ts),
 					}},
 					Service: cdServiceName,
 					Etag:    etag,

--- a/src/pkg/cli/client/byoc/azure/byoc.go
+++ b/src/pkg/cli/client/byoc/azure/byoc.go
@@ -820,6 +820,24 @@ func parseCDLogLine(line string) (ts time.Time, message string) {
 	return parsed, strings.TrimSpace(rest)
 }
 
+// splitCDLogSnapshot splits a ReadJobLogs snapshot (one line per buffered CD log
+// entry, newline-separated) into individual lines, dropping blank lines. Each
+// returned line still carries its own leading engine timestamp for parseCDLogLine
+// to extract.
+func splitCDLogSnapshot(content string) []string {
+	if content == "" {
+		return nil
+	}
+	var lines []string
+	for _, line := range strings.Split(strings.TrimRight(content, "\n"), "\n") {
+		if line == "" {
+			continue
+		}
+		lines = append(lines, line)
+	}
+	return lines
+}
+
 // QueryLogs implements client.Provider. It merges three log sources for the project:
 // CD (deployment) logs from the Container Apps Job, service logs from the project's
 // Container Apps, and build logs from ACR. When req.Follow is set each source streams
@@ -888,12 +906,16 @@ func (b *ByocAzure) QueryLogs(ctx context.Context, req *defangv1.TailRequest) (i
 			}
 			go func() {
 				defer close(cdCh)
-				if content == "" {
-					return
-				}
-				select {
-				case cdCh <- cdLogEntry{line: content}:
-				case <-ctx.Done():
+				// Each buffered line carries its own engine timestamp (see
+				// parseCDLogLine), so split the snapshot before sending: a single
+				// entry for the whole content would only parse the first line's
+				// timestamp and leave the rest embedded in the message (#2079).
+				for _, line := range splitCDLogSnapshot(content) {
+					select {
+					case cdCh <- cdLogEntry{line: line}:
+					case <-ctx.Done():
+						return
+					}
 				}
 			}()
 		}

--- a/src/pkg/cli/client/byoc/azure/byoc_test.go
+++ b/src/pkg/cli/client/byoc/azure/byoc_test.go
@@ -421,6 +421,65 @@ func TestQueryLogsNonFollow(t *testing.T) {
 	}
 }
 
+func TestParseCDLogLine(t *testing.T) {
+	tests := []struct {
+		name        string
+		line        string
+		wantTs      string // RFC3339Nano, empty means zero time
+		wantMessage string
+	}{
+		{
+			name:        "timestamp with dash separator",
+			line:        "2026-04-28T23:43:03.965786510Z - worker deleting (0s)",
+			wantTs:      "2026-04-28T23:43:03.965786510Z",
+			wantMessage: "worker deleting (0s)",
+		},
+		{
+			name:        "timestamp with extra spaces around dash",
+			line:        "2026-04-28T23:43:03.965786510Z  -  worker deleting (0s)",
+			wantTs:      "2026-04-28T23:43:03.965786510Z",
+			wantMessage: "worker deleting (0s)",
+		},
+		{
+			name:        "timestamp with no dash",
+			line:        "2026-04-28T23:43:03.965786510Z worker deleting (0s)",
+			wantTs:      "2026-04-28T23:43:03.965786510Z",
+			wantMessage: "worker deleting (0s)",
+		},
+		{
+			name:        "no leading timestamp",
+			line:        "worker deleting (0s)",
+			wantTs:      "",
+			wantMessage: "worker deleting (0s)",
+		},
+		{
+			name:        "empty line",
+			line:        "",
+			wantTs:      "",
+			wantMessage: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts, message := parseCDLogLine(tt.line)
+			var wantTs time.Time
+			if tt.wantTs != "" {
+				var err error
+				wantTs, err = time.Parse(time.RFC3339Nano, tt.wantTs)
+				if err != nil {
+					t.Fatalf("bad test fixture: %v", err)
+				}
+			}
+			if !ts.Equal(wantTs) {
+				t.Errorf("ts = %v, want %v", ts, wantTs)
+			}
+			if message != tt.wantMessage {
+				t.Errorf("message = %q, want %q", message, tt.wantMessage)
+			}
+		})
+	}
+}
+
 func TestCdCommandMissingCDImage(t *testing.T) {
 	// setUpForConfig needs to succeed for CdCommand to reach the CDImage check.
 	// Easier: exercise the setUpLocation-fails path which happens first.

--- a/src/pkg/cli/client/byoc/azure/byoc_test.go
+++ b/src/pkg/cli/client/byoc/azure/byoc_test.go
@@ -3,6 +3,7 @@ package azure
 import (
 	"context"
 	"errors"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -475,6 +476,47 @@ func TestParseCDLogLine(t *testing.T) {
 			}
 			if message != tt.wantMessage {
 				t.Errorf("message = %q, want %q", message, tt.wantMessage)
+			}
+		})
+	}
+}
+
+func TestSplitCDLogSnapshot(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    []string
+	}{
+		{
+			name:    "empty content",
+			content: "",
+			want:    nil,
+		},
+		{
+			name:    "single line no trailing newline",
+			content: "2026-04-28T23:43:03.000000000Z - worker deleting (0s)",
+			want:    []string{"2026-04-28T23:43:03.000000000Z - worker deleting (0s)"},
+		},
+		{
+			name: "multiple lines, each keeping its own timestamp",
+			content: "2026-04-28T23:43:03.000000000Z - worker deleting (0s)\n" +
+				"2026-04-28T23:43:04.000000000Z - ManagedEnvironment mastra-extended deleting (0s)\n",
+			want: []string{
+				"2026-04-28T23:43:03.000000000Z - worker deleting (0s)",
+				"2026-04-28T23:43:04.000000000Z - ManagedEnvironment mastra-extended deleting (0s)",
+			},
+		},
+		{
+			name:    "blank lines are dropped",
+			content: "line-one\n\nline-two\n",
+			want:    []string{"line-one", "line-two"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := splitCDLogSnapshot(tt.content)
+			if !slices.Equal(got, tt.want) {
+				t.Errorf("splitCDLogSnapshot(%q) = %v, want %v", tt.content, got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- Fixes #2079: `defang tail` / deploy output showed two near-identical timestamps per Azure CD log line, e.g.
  ```
  2026-04-28T16:43:03.923-07:00 defang-cd  2026-04-28T23:43:03.965786510Z  -  defang-azure:index:ACRImageBuild worker deleting (0s)
  ```
- Root cause: the CD job container's pulumi wrapper writes its own event timestamp into each stdout line. `ByocAzure.QueryLogs` forwarded that raw line verbatim as `Message` while separately stamping the entry's `Timestamp` with `time.Now()` — so the tail table's timestamp column and the engine's own timestamp (embedded in the message) both showed, a few milliseconds apart.
- Fix: `parseCDLogLine` extracts the leading RFC3339Nano timestamp from each CD log line and uses it as the entry's `Timestamp`, stripping it (and the `-` separator) from `Message`. Falls back to the original line + `time.Now()` when a line doesn't start with a parseable timestamp, so nothing is dropped.
- Scoped to the `defang-cd` log source only — Container App service logs and ACR build logs don't carry this embedded engine timestamp.

## Test plan
- [x] `go test -short ./pkg/cli/client/byoc/azure/...` — added `TestParseCDLogLine` table-driven test covering: normal separator, extra spaces around the dash, no dash, no leading timestamp, and empty line.
- [x] `go test -short ./...` — full suite passes.
- [x] `golangci-lint run ./pkg/cli/client/byoc/azure/...` — 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * CD log snapshots are now processed as separate nonblank lines.
  * Each log line preserves its embedded timestamp when available.
  * Timestamp prefixes are removed from displayed messages for clearer output.
  * Log lines without valid timestamps continue to use the current-time fallback.

* **Tests**
  * Added coverage for empty, single-line, multi-line, timestamped, and blank-line-filtered CD log snapshots.
  * Existing timestamp parsing and message extraction coverage remains in place.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->