### PR TITLE
refactor: extract the stack-path naming contract into pkg/stackpath

### DIFF
--- a/pkgs/defang/cli.nix
+++ b/pkgs/defang/cli.nix
@@ -7,7 +7,7 @@ buildGo125Module {
   pname = "defang-cli";
   version = "git";
   src = lib.cleanSource ../../src;
-  vendorHash = "sha256-CQD14oEPHZcRkjxrSKccPvZUeNsF25qwUI/48Y7VMZ0=";
+  vendorHash = "sha256-YYMRLT85SjuW8zv75QxJK2o8juXPfevcKIDYcjbfdOU=";
 
   subPackages = [ "cmd/cli" ];
 

--- a/src/pkg/cli/client/byoc/aws/byoc.go
+++ b/src/pkg/cli/client/byoc/aws/byoc.go
@@ -30,6 +30,7 @@ import (
 	"github.com/DefangLabs/defang/src/pkg/dockerhub"
 	"github.com/DefangLabs/defang/src/pkg/http"
 	"github.com/DefangLabs/defang/src/pkg/logs"
+	"github.com/DefangLabs/defang/src/pkg/stackpath"
 	"github.com/DefangLabs/defang/src/pkg/term"
 	"github.com/DefangLabs/defang/src/pkg/timeutils"
 	"github.com/DefangLabs/defang/src/pkg/tokenstore"
@@ -908,16 +909,16 @@ func (b *ByocAws) getLogGroupInputs(etag types.ETag, projectName, service, filte
 		}
 	}
 	if logType.Has(logs.LogTypeBuild) && projectName != "" {
-		buildsTail := cw.LogGroupInput{LogGroupARN: b.makeLogGroupARN(b.StackDir(projectName, "builds")), LogEventFilterPattern: pattern} // must match logic in ecs/common.ts; TODO: filter by etag/service
+		buildsTail := cw.LogGroupInput{LogGroupARN: b.makeLogGroupARN(b.StackDir(projectName, stackpath.LogGroupBuilds)), LogEventFilterPattern: pattern} // must match logic in ecs/common.ts; TODO: filter by etag/service
 		term.Debug("Query builds logs", buildsTail.LogGroupARN, filter)
 		groups = append(groups, buildsTail)
-		ecsTail := cw.LogGroupInput{LogGroupARN: b.makeLogGroupARN(b.StackDir(projectName, "ecs")), LogEventFilterPattern: pattern} // must match logic in ecs/common.ts; TODO: filter by etag/service/deploymentId
+		ecsTail := cw.LogGroupInput{LogGroupARN: b.makeLogGroupARN(b.StackDir(projectName, stackpath.LogGroupECS)), LogEventFilterPattern: pattern} // must match logic in ecs/common.ts; TODO: filter by etag/service/deploymentId
 		term.Debug("Query ecs events logs", ecsTail.LogGroupARN, filter)
 		groups = append(groups, ecsTail)
 	}
 	// Tail services
 	if logType.Has(logs.LogTypeRun) && projectName != "" {
-		servicesTail := cw.LogGroupInput{LogGroupARN: b.makeLogGroupARN(b.StackDir(projectName, "logs")), LogEventFilterPattern: pattern} // must match logic in ecs/common.ts
+		servicesTail := cw.LogGroupInput{LogGroupARN: b.makeLogGroupARN(b.StackDir(projectName, stackpath.LogGroupServices)), LogEventFilterPattern: pattern} // must match logic in ecs/common.ts
 		if service != "" && etag != "" {
 			servicesTail.LogStreamNamePrefix = service + "/" + service + "_" + etag
 		}
@@ -1029,9 +1030,9 @@ func (b *ByocAws) Subscribe(ctx context.Context, req *defangv1.SubscribeRequest)
 
 func (b *ByocAws) getSubscribeLogGroupInputs(projectName string) []cw.LogGroupInput {
 	var groups []cw.LogGroupInput
-	buildsARN := b.makeLogGroupARN(b.StackDir(projectName, "builds"))
+	buildsARN := b.makeLogGroupARN(b.StackDir(projectName, stackpath.LogGroupBuilds))
 	groups = append(groups, cw.LogGroupInput{LogGroupARN: buildsARN})
-	ecsARN := b.makeLogGroupARN(b.StackDir(projectName, "ecs"))
+	ecsARN := b.makeLogGroupARN(b.StackDir(projectName, stackpath.LogGroupECS))
 	groups = append(groups, cw.LogGroupInput{LogGroupARN: ecsARN})
 	return groups
 }

--- a/src/pkg/cli/client/byoc/aws/stream.go
+++ b/src/pkg/cli/client/byoc/aws/stream.go
@@ -11,6 +11,7 @@ import (
 	"github.com/DefangLabs/defang/src/pkg/clouds/aws/cw"
 	"github.com/DefangLabs/defang/src/pkg/clouds/aws/ecs"
 	"github.com/DefangLabs/defang/src/pkg/logs"
+	"github.com/DefangLabs/defang/src/pkg/stackpath"
 	"github.com/DefangLabs/defang/src/pkg/term"
 	"github.com/DefangLabs/defang/src/pkg/types"
 	defangv1 "github.com/DefangLabs/defang/src/protos/io/defang/v1"
@@ -44,7 +45,7 @@ func (p *logEventParser) parseEvents(events []cw.LogEvent) *defangv1.TailRespons
 	case first.LogGroupIdentifier == nil || first.LogStreamName == nil:
 		response.Service = "alb"
 		// response.Host = TODO: we can get the ALB IP from the bucket object name
-	case strings.HasSuffix(*first.LogGroupIdentifier, "/ecs"):
+	case stackpath.IsLogGroup(*first.LogGroupIdentifier, stackpath.LogGroupECS):
 		// ECS lifecycle events. LogStreams: "f0b805a8-fa74-3212-b6ce-a981c011d337"
 		parseECSEventRecords = true
 	case strings.Contains(*first.LogGroupIdentifier, ":"+byoc.CdTaskPrefix):
@@ -52,7 +53,7 @@ func (p *logEventParser) parseEvents(events []cw.LogEvent) *defangv1.TailRespons
 		// LogStreams: "crun/main/0f2a8ccde0374239bdd04f5e07d8c523"
 		response.Host = "pulumi"
 		response.Service = "cd"
-	case strings.HasSuffix(*first.LogGroupIdentifier, "/builds") && codeBuildPrefixRegex.MatchString(*first.LogStreamName):
+	case stackpath.IsLogGroup(*first.LogGroupIdentifier, stackpath.LogGroupBuilds) && codeBuildPrefixRegex.MatchString(*first.LogStreamName):
 		response.Host = "codebuild"
 		response.Service = "cd"
 		parseCodeBuildRecords = true

--- a/src/pkg/cli/client/byoc/aws/subscribe.go
+++ b/src/pkg/cli/client/byoc/aws/subscribe.go
@@ -8,6 +8,7 @@ import (
 	"github.com/DefangLabs/defang/src/pkg/clouds/aws/codebuild"
 	"github.com/DefangLabs/defang/src/pkg/clouds/aws/cw"
 	"github.com/DefangLabs/defang/src/pkg/clouds/aws/ecs"
+	"github.com/DefangLabs/defang/src/pkg/stackpath"
 	"github.com/DefangLabs/defang/src/pkg/term"
 	"github.com/DefangLabs/defang/src/pkg/types"
 	defangv1 "github.com/DefangLabs/defang/src/protos/io/defang/v1"
@@ -40,9 +41,9 @@ func parseSubscribeEvent(evt cw.LogEvent, etag types.ETag, services []string) *d
 	}
 
 	switch {
-	case strings.HasSuffix(*evt.LogGroupIdentifier, "/ecs"):
+	case stackpath.IsLogGroup(*evt.LogGroupIdentifier, stackpath.LogGroupECS):
 		return parseECSSubscribeEvent(evt, etag, services)
-	case strings.HasSuffix(*evt.LogGroupIdentifier, "/builds") &&
+	case stackpath.IsLogGroup(*evt.LogGroupIdentifier, stackpath.LogGroupBuilds) &&
 		evt.LogStreamName != nil &&
 		codeBuildPrefixRegex.MatchString(*evt.LogStreamName):
 		return parseCodebuildSubscribeEvent(evt, etag, services)

--- a/src/pkg/cli/client/byoc/baseclient.go
+++ b/src/pkg/cli/client/byoc/baseclient.go
@@ -12,6 +12,7 @@ import (
 	"github.com/DefangLabs/defang/src/pkg/cli/client/byoc/state"
 	"github.com/DefangLabs/defang/src/pkg/cli/compose"
 	"github.com/DefangLabs/defang/src/pkg/dns"
+	"github.com/DefangLabs/defang/src/pkg/stackpath"
 	"github.com/DefangLabs/defang/src/pkg/stacks"
 	"github.com/DefangLabs/defang/src/pkg/term"
 	"github.com/DefangLabs/defang/src/pkg/types"
@@ -248,14 +249,11 @@ func (b *ByocBaseClient) update(ctx context.Context, projectName, delegateDomain
 	return si, nil
 }
 
-// stackDir returns a stack-qualified path, like the Pulumi TS function `stackDir`
+// StackDir returns a stack-qualified path, like the Pulumi TS function `stackDir`.
+// The path shape is shared with the Pulumi provider; see pkg/stackpath.
 func (b *ByocBaseClient) StackDir(projectName, name string) string {
 	pkg.Ensure(projectName != "", "ProjectName not set")
-	prefix := []string{""} // for leading slash
-	if b.Prefix != "" {
-		prefix = []string{"", b.Prefix}
-	}
-	return strings.Join(append(prefix, projectName, b.PulumiStack, name), "/") // same as shared/common.ts
+	return stackpath.StackDir(b.Prefix, projectName, b.PulumiStack, name)
 }
 
 // This function was copied from Fabric controller and slightly modified to work with BYOC

--- a/src/pkg/stackpath/stackpath.go
+++ b/src/pkg/stackpath/stackpath.go
@@ -39,10 +39,19 @@ func StackDir(prefix, projectName, stack, name string) string {
 	return strings.Join(append(segments, projectName, stack, name), "/")
 }
 
-// IsLogGroup reports whether logGroupIdentifier names the well-known log group
-// name, which is true when it ends in "/" + name. The identifier may be a bare
-// log group name, an ARN, or the "<account>:<name>" form CloudWatch returns in
-// a live tail, so only the trailing segment can be compared.
+// IsLogGroup reports whether logGroupIdentifier refers to the well-known log
+// group name, which is true when it ends in "/" + name.
+//
+// A CloudWatch identifier reaches this in one of three shapes, and every one of
+// them carries the full StackDir path, never a lone segment:
+//
+//	/Defang/myproject/beta/ecs                                        log group name
+//	arn:aws:logs:us-west-2:123:log-group:/Defang/myproject/beta/ecs   ARN
+//	123:/Defang/myproject/beta/ecs                                    live tail
+//
+// Only the trailing segment is comparable across the three, and the leading
+// slash is required so that a group whose name merely ends in the same letters
+// ("…/beta/notecs") does not match.
 func IsLogGroup(logGroupIdentifier, name string) bool {
 	return strings.HasSuffix(logGroupIdentifier, "/"+name)
 }

--- a/src/pkg/stackpath/stackpath.go
+++ b/src/pkg/stackpath/stackpath.go
@@ -1,0 +1,48 @@
+// Package stackpath holds the stack-qualified naming contract that the Defang
+// CLI shares with the Pulumi provider (DefangLabs/pulumi-defang) and with the
+// TypeScript stack that preceded it.
+//
+// These names are a wire contract, not labels. The provider creates the
+// CloudWatch log groups; the CLI subscribes to them by name and routes each
+// event to a parser by the group's last path segment. If the two sides
+// disagree on a single segment the CLI silently tails a log group nobody
+// writes to, and `defang compose up` never sees its services come up.
+//
+// The package deliberately depends on the standard library only, so that the
+// provider can import it without pulling in the rest of the CLI.
+package stackpath
+
+import "strings"
+
+// Well-known last path segments of the per-stack CloudWatch log groups.
+// Each names one event source the CLI tails and parses differently.
+const (
+	// LogGroupECS carries ECS lifecycle events forwarded from EventBridge.
+	// The CLI routes an event to the ECS parser only when its log group name
+	// ends in "/" + LogGroupECS.
+	LogGroupECS = "ecs"
+
+	// LogGroupBuilds carries CodeBuild output for image builds.
+	LogGroupBuilds = "builds"
+
+	// LogGroupServices carries the services' own stdout and stderr.
+	LogGroupServices = "logs"
+)
+
+// StackDir builds the stack-qualified path "/<prefix>/<project>/<stack>/<name>".
+// An empty prefix drops its segment.
+func StackDir(prefix, projectName, stack, name string) string {
+	segments := []string{""} // leading slash
+	if prefix != "" {
+		segments = append(segments, prefix)
+	}
+	return strings.Join(append(segments, projectName, stack, name), "/")
+}
+
+// IsLogGroup reports whether logGroupIdentifier names the well-known log group
+// name, which is true when it ends in "/" + name. The identifier may be a bare
+// log group name, an ARN, or the "<account>:<name>" form CloudWatch returns in
+// a live tail, so only the trailing segment can be compared.
+func IsLogGroup(logGroupIdentifier, name string) bool {
+	return strings.HasSuffix(logGroupIdentifier, "/"+name)
+}

--- a/src/pkg/stackpath/stackpath_test.go
+++ b/src/pkg/stackpath/stackpath_test.go
@@ -32,6 +32,10 @@ func TestIsLogGroup(t *testing.T) {
 		{"arn", "arn:aws:logs:us-west-2:123:log-group:/Defang/myproject/beta/ecs", LogGroupECS, true},
 		{"wrong group", "/Defang/myproject/beta/builds", LogGroupECS, false},
 		{"suffix must follow a slash", "/Defang/myproject/beta/notecs", LogGroupECS, false},
+		// A lone segment is not a log group identifier: every shape CloudWatch
+		// produces carries the full StackDir path. Matching it would weaken the
+		// slash guard above for no reachable caller.
+		{"lone segment is not an identifier", "ecs", LogGroupECS, false},
 		{"builds", "/Defang/myproject/beta/builds", LogGroupBuilds, true},
 	}
 	for _, tt := range tests {

--- a/src/pkg/stackpath/stackpath_test.go
+++ b/src/pkg/stackpath/stackpath_test.go
@@ -1,0 +1,44 @@
+package stackpath
+
+import "testing"
+
+func TestStackDir(t *testing.T) {
+	tests := []struct {
+		name                            string
+		prefix, project, stack, groupID string
+		want                            string
+	}{
+		{"with prefix", "Defang", "myproject", "beta", LogGroupECS, "/Defang/myproject/beta/ecs"},
+		{"empty prefix drops its segment", "", "myproject", "beta", LogGroupECS, "/myproject/beta/ecs"},
+		{"builds", "Defang", "myproject", "beta", LogGroupBuilds, "/Defang/myproject/beta/builds"},
+		{"services", "Defang", "myproject", "beta", LogGroupServices, "/Defang/myproject/beta/logs"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := StackDir(tt.prefix, tt.project, tt.stack, tt.groupID); got != tt.want {
+				t.Errorf("StackDir() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsLogGroup(t *testing.T) {
+	tests := []struct {
+		name, identifier, group string
+		want                    bool
+	}{
+		{"bare name", "/Defang/myproject/beta/ecs", LogGroupECS, true},
+		{"account-qualified live tail", "532501343364:/Defang/django/beta/ecs", LogGroupECS, true},
+		{"arn", "arn:aws:logs:us-west-2:123:log-group:/Defang/myproject/beta/ecs", LogGroupECS, true},
+		{"wrong group", "/Defang/myproject/beta/builds", LogGroupECS, false},
+		{"suffix must follow a slash", "/Defang/myproject/beta/notecs", LogGroupECS, false},
+		{"builds", "/Defang/myproject/beta/builds", LogGroupBuilds, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsLogGroup(tt.identifier, tt.group); got != tt.want {
+				t.Errorf("IsLogGroup(%q, %q) = %v, want %v", tt.identifier, tt.group, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Requested by @lionello in review on [pulumi-defang#522](https://github.com/DefangLabs/pulumi-defang/pull/522#discussion_r3928084461): *"Let's do your suggestion: leaf package in CLI repo in order to make the dep explicit."*

## Why

The per-stack CloudWatch log group names are a **wire contract** between this CLI and the Pulumi provider. The provider creates the groups; the CLI subscribes to them by name and picks a parser from the last path segment. Today both sides spell the contract out in literals — `"ecs"`, `"builds"`, `"logs"` here, plus a private copy of `StackDir` in the provider — so a change on one side fails silently on the other.

That is exactly how pulumi-defang#522 came about: the provider never created the `/ecs` group, the CLI tailed a group nobody wrote to, and `defang compose up` hung with no error.

## What

A new stdlib-only leaf package, `src/pkg/stackpath`:

| Symbol | Replaces |
|---|---|
| `StackDir(prefix, project, stack, name)` | the body of `ByocBaseClient.StackDir`, which now delegates and keeps its own prefix/stack state |
| `LogGroupECS` / `LogGroupBuilds` / `LogGroupServices` | the `"ecs"` / `"builds"` / `"logs"` literals at all five `StackDir` call sites |
| `IsLogGroup(identifier, name)` | the `strings.HasSuffix(..., "/ecs")` tests in `subscribe.go` and `stream.go` |

It depends on the standard library and nothing else, so the provider can import it without pulling in the rest of the CLI:

```
$ go list -deps ./pkg/stackpath | grep DefangLabs
github.com/DefangLabs/defang/src/pkg/stackpath
```

## Licensing

The dependency runs MIT → AGPL, which is the safe direction: this repo is MIT, pulumi-defang's provider is AGPL-3.0. AGPL-licensed code may import MIT code; the combined work ships under AGPL and MIT's only obligation is preserving the notice. The reverse would be the problem. `pulumi-defang/cd/` already depends on `defang/src` the same way.

## Behaviour

None changed. This is a pure extraction — the strings produced are byte-identical.

- Existing `byoc` and `byoc/aws` tests cover every touched call site and pass.
- `pkg/stackpath` adds its own table-driven tests, including the `<account>:<name>` live-tail form and the `"/notecs"` near-miss that a bare `strings.Contains` would get wrong.
- `go mod tidy` clean; darwin and windows cross-builds pass.

## Follow-up

Once this merges, pulumi-defang#522 drops its private `ECSEventsLogGroupSuffix` and `StackDir` and imports these instead. #522 does not block on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DfUAxBepE1zoX5yeSm28up

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved AWS log-group recognition for ECS, build, service, and subscription logs, including account-qualified and ARN-based identifiers.
  * Standardized stack path and log-group handling for more consistent cloud operations.

* **Tests**
  * Added coverage for stack path construction and log-group matching across supported identifier formats and invalid inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->