### PR TITLE
fix: tell the AI debug agent the project name after a failed compose down

### DIFF
--- a/src/cmd/cli/command/compose.go
+++ b/src/cmd/cli/command/compose.go
@@ -534,11 +534,12 @@ func makeComposeDownCmd() *cobra.Command {
 					return deploymentErr
 				}
 				handleTailAndMonitorErr(cmd.Context(), deploymentErr, debugger, debug.DebugConfig{
-					Deployment: deployment,
-					ProviderID: &session.Stack.Provider,
-					Stack:      session.Stack.Name,
-					Since:      since,
-					Until:      time.Now(),
+					Deployment:  deployment,
+					ProviderID:  &session.Stack.Provider,
+					Stack:       session.Stack.Name,
+					ProjectName: projectName,
+					Since:       since,
+					Until:       time.Now(),
 				})
 				return deploymentErr
 			}

--- a/src/pkg/debug/debug.go
+++ b/src/pkg/debug/debug.go
@@ -27,8 +27,12 @@ type DebugConfig struct {
 	Deployment     types.ETag
 	FailedServices []string
 	Project        *compose.Project
-	Since          time.Time
-	Until          time.Time
+	// ProjectName is used when the caller only resolved a project name (e.g. `compose down`,
+	// which never loads a full compose.Project). Ignored when Project is set, which already
+	// carries the name.
+	ProjectName string
+	Since       time.Time
+	Until       time.Time
 }
 
 func (dc DebugConfig) String() string {
@@ -47,6 +51,8 @@ func (dc DebugConfig) String() string {
 		if dc.Project.WorkingDir != "" {
 			cmd += " --cwd=" + dc.Project.WorkingDir
 		}
+	} else if dc.ProjectName != "" {
+		cmd += " --project-name=" + dc.ProjectName
 	}
 	if dc.Stack != "" {
 		cmd += " --stack=" + dc.Stack
@@ -259,6 +265,13 @@ func buildDeploymentDebugPrompt(debugConfig DebugConfig) string {
 			debugConfig.Project.ComposeFiles,
 			truncateHead(string(yaml), maxPromptComposeLen),
 		)
+	} else if debugConfig.ProjectName != "" {
+		// There is no compose.Project to point the agent at (e.g. `compose down`), so state the
+		// project name explicitly: the current directory may have no compose file at all, or may
+		// contain a different project, and the account can have multiple deployed projects.
+		// Without this the agent's tool calls (e.g. logs) omit project_name and fail once more
+		// than one project exists.
+		prompt += fmt.Sprintf(" The project name is %q; pass it explicitly to your tools.", debugConfig.ProjectName)
 	}
 	return prompt
 }

--- a/src/pkg/debug/debug_test.go
+++ b/src/pkg/debug/debug_test.go
@@ -78,6 +78,18 @@ func TestDebugDeployment(t *testing.T) {
 			expectedPrompt: "An error occurred while deploying this project to AWS with Defang. Help troubleshoot and recommend a solution. Look at the logs to understand what happened. The deployment ID is \"test-deployment\". The services that failed to deploy are: [backend]. The deployment started at 2025-01-02 03:04:05 +0000 UTC. The deployment finished at 2025-01-02 04:05:06 +0000 UTC.The compose files are at []. The compose file is as follows:\n\nservices: {}\n",
 			permission:     true,
 		},
+		{
+			// compose down never loads a compose.Project, so it can only pass a resolved
+			// name (issue #2248: the agent's logs tool omitted project_name and failed
+			// once the account had more than one deployed project).
+			name: "With ProjectName but no Project",
+			debugConfig: DebugConfig{
+				Deployment:  "test-deployment",
+				ProjectName: "component-registry",
+			},
+			expectedPrompt: "An error occurred while deploying this project with Defang. Help troubleshoot and recommend a solution. Look at the logs to understand what happened. The deployment ID is \"test-deployment\". The project name is \"component-registry\"; pass it explicitly to your tools.",
+			permission:     true,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
- `compose down` never loads a `compose.Project`, so the debug prompt built for a failed destroy carried no project information at all — unlike `compose up`'s failure path, which passes the full loaded `Project`.
- The AI debug agent then had to guess the project name for its own tool calls (e.g. `logs`), and failed once the account had more than one deployed project — even though the user had already specified it via `-p`/`--project-name` on the original command.
- Adds `DebugConfig.ProjectName` for callers that only resolve a name string (not a full `compose.Project`), wires it from `compose down`'s already-resolved `projectName`, and states it explicitly in the debug prompt so the agent passes it to its tools instead of omitting it.

Fixes #2248

## Test plan
- [x] `go build ./...`
- [x] `go test -short ./pkg/debug/... ./cmd/cli/command/...` — added a table-driven case in `debug_test.go` covering the `ProjectName`-only (no `Project`) prompt path
- [x] `go test -short ./...` — one pre-existing, unrelated failure (`TestAWSEnv_ConflictingAWSCredentials`, environment-dependent on ambient AWS creds) reproduces identically on unmodified `main`
- [ ] Lint: this box's `nix profile` golangci-lint (2.12.2) is newer than CI's pin (v2.5.0) and both invents findings and misattributes them to a sibling git worktree (known issue); the CI-pinned v2.5.0 binary itself panics on this box's Go 1.26 toolchain. No findings from either run touched the changed files — CI is the real gate here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015pqSs4vzj1usWqNH1SFCU5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compose deployment troubleshooting when project details are unavailable.
  - Debug commands and prompts now retain and explicitly use the project name, helping tools target the correct compose project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->