### PR TITLE
fix: add --workspace hint to "no stack" error messages

### DIFF
--- a/src/pkg/cli/deploymentsList.go
+++ b/src/pkg/cli/deploymentsList.go
@@ -50,7 +50,7 @@ func DeploymentsList(ctx context.Context, client client.FabricClient, params Lis
 		if params.ProjectName == "" {
 			_, err = term.Warnf("No%s deployments found; use --workspace to specify a different workspace", active)
 		} else {
-			_, err = term.Warnf("No%s deployments found for project %q", active, params.ProjectName)
+			_, err = term.Warnf("No%s deployments found for project %q; use --workspace to specify a different workspace", active, params.ProjectName)
 		}
 		return err
 	}

--- a/src/pkg/cli/deploymentsList_test.go
+++ b/src/pkg/cli/deploymentsList_test.go
@@ -150,6 +150,29 @@ func TestActiveDeployments(t *testing.T) {
 		}
 	})
 
+	t.Run("no active deployments for project", func(t *testing.T) {
+		fabricServer.testDeploymentsData = nil
+		stdout, _ := term.SetupTestTerm(t)
+
+		err := DeploymentsList(ctx, grpcClient, ListDeploymentsParams{
+			ListType:    defangv1.DeploymentType_DEPLOYMENT_TYPE_ACTIVE,
+			ProjectName: "website-production",
+			Limit:       10,
+		})
+		if err != nil {
+			t.Fatalf("DeploymentsList() error = %v", err)
+		}
+
+		// The project may simply live in another workspace, so this branch needs
+		// the same --workspace hint as the workspace-wide one; see issue 2247.
+		receivedOutput := stdout.String()
+		expectedOutput := `No active deployments found for project "website-production"; use --workspace to specify a different workspace`
+
+		if !strings.Contains(receivedOutput, expectedOutput) {
+			t.Errorf("Expected %s to contain %s", receivedOutput, expectedOutput)
+		}
+	})
+
 	activeDeployments := []*defangv1.Deployment{
 		{Project: "projectAA", Provider: defangv1.Provider_AWS, Region: "us-east-1"},
 		{Project: "projectAB", Provider: defangv1.Provider_AWS, Region: "us-east-2"},

--- a/src/pkg/stacks/manager.go
+++ b/src/pkg/stacks/manager.go
@@ -282,7 +282,7 @@ type ErrNotExist struct {
 }
 
 func (e *ErrNotExist) Error() string {
-	return fmt.Sprintf("stack %q does not exist for project %q; use --workspace to specify a different workspace", e.StackName, e.ProjectName)
+	return fmt.Sprintf("stack %q does not exist for project %q in this workspace", e.StackName, e.ProjectName)
 }
 
 type ErrDefaultStackNotSet struct {

--- a/src/pkg/stacks/manager.go
+++ b/src/pkg/stacks/manager.go
@@ -282,7 +282,7 @@ type ErrNotExist struct {
 }
 
 func (e *ErrNotExist) Error() string {
-	return fmt.Sprintf("stack %q does not exist for project %q", e.StackName, e.ProjectName)
+	return fmt.Sprintf("stack %q does not exist for project %q; use --workspace to specify a different workspace", e.StackName, e.ProjectName)
 }
 
 type ErrDefaultStackNotSet struct {

--- a/src/pkg/stacks/manager_test.go
+++ b/src/pkg/stacks/manager_test.go
@@ -295,9 +295,9 @@ func TestManager_LoadNonexistentStack(t *testing.T) {
 
 func TestErrNotExist_Error(t *testing.T) {
 	// A stack can be missing simply because the wrong workspace is selected, so
-	// the message has to point at --workspace; see issue 2247.
+	// the message has to say which workspace it looked in; see issue 2247.
 	err := &ErrNotExist{ProjectName: "website-production", StackName: "beta"}
-	assert.Equal(t, `stack "beta" does not exist for project "website-production"; use --workspace to specify a different workspace`, err.Error())
+	assert.Equal(t, `stack "beta" does not exist for project "website-production" in this workspace`, err.Error())
 }
 
 func TestManager_CreateInvalidStackName(t *testing.T) {

--- a/src/pkg/stacks/manager_test.go
+++ b/src/pkg/stacks/manager_test.go
@@ -293,6 +293,13 @@ func TestManager_LoadNonexistentStack(t *testing.T) {
 	assert.Error(t, err, "Load() should return error for nonexistent stack")
 }
 
+func TestErrNotExist_Error(t *testing.T) {
+	// A stack can be missing simply because the wrong workspace is selected, so
+	// the message has to point at --workspace; see issue 2247.
+	err := &ErrNotExist{ProjectName: "website-production", StackName: "beta"}
+	assert.Equal(t, `stack "beta" does not exist for project "website-production"; use --workspace to specify a different workspace`, err.Error())
+}
+
 func TestManager_CreateInvalidStackName(t *testing.T) {
 	// Create a temporary directory for testing
 	tmpDir := t.TempDir()


### PR DESCRIPTION
Fixes #2247

A missing stack or deployment usually means the wrong workspace is selected. Of the three messages in the issue, only one said so.

| Case | Before | After |
|---|---|---|
| `defang -p X ps` (no stack) | `no stacks available to select in this workspace` | unchanged — already correct |
| `defang -p X -s beta ps` | `stack "beta" does not exist for project "X"` | `… for project "X" in this workspace` |
| `defang -p X ls` | `No active deployments found for project "X"` | `… ; use --workspace to specify a different workspace` |

The `ls` case was a plain oversight: the branch one line above, for a workspace-wide `ls`, already ends in `use --workspace to specify a different workspace`. Passing `--project` took the other branch and silently lost the hint. Both gaps now reuse that exact wording rather than introducing a third phrasing.

## Notes for the reviewer

- **The workspace is not named in the message** (`… in workspace "acme"`). Neither `stacks.ErrNotExist` nor `cli.DeploymentsList` knows the tenant — it lives in `global.TenantSelection` up in the command layer — so naming it would mean threading the workspace through both packages for an error string.
- **`ErrDefaultStackNotSet` is untouched.** Same family, but `manager.Get()` catches it and falls back to the beta stack, so it is almost never printed.
- **The two messages word the hint differently, deliberately.** Per review: no CLI flags in a library package, so `stacks.ErrNotExist` says `in this workspace` (matching `selector.go`, and the phrasing the issue called "enough to nudge"), while the `pkg/cli` warning keeps `use --workspace to specify a different workspace` to match the adjacent workspace-wide branch it sits next to.

## Test plan

- New `TestErrNotExist_Error` pins the stack message.
- New `TestActiveDeployments/no_active_deployments_for_project` subtest pins the project-scoped `ls` message; the existing workspace-wide subtest already pinned the other branch.
- `go build ./...` and `go test -short ./pkg/stacks/... ./pkg/cli/` pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0197fecoxGCAfRuqfPQfXhaC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved messaging when no deployments are found for a specified project by explaining how to select a different workspace.
  * Updated missing-stack errors to include the relevant stack and project details, along with guidance for using `--workspace`.

* **Tests**
  * Added coverage for deployment-listing and missing-stack scenarios to verify the updated guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
