### PR TITLE
Error when --workspace/DEFANG_WORKSPACE conflicts with the access token's workspace

### DIFF
--- a/src/cmd/cli/command/commands.go
+++ b/src/cmd/cli/command/commands.go
@@ -27,6 +27,7 @@ import (
 	"github.com/DefangLabs/defang/src/pkg/stacks"
 	"github.com/DefangLabs/defang/src/pkg/term"
 	"github.com/DefangLabs/defang/src/pkg/track"
+	"github.com/DefangLabs/defang/src/pkg/types"
 	"github.com/spf13/cobra"
 )
 
@@ -420,7 +421,14 @@ var RootCmd = &cobra.Command{
 			}
 		}
 
-		global.Client, err = cli.ConnectWithTenant(ctx, global.FabricAddr, global.TenantSelection)
+		requestedTenant := global.TenantSelection
+		if isWorkspaceListCommand(cmd) {
+			// `workspace ls` exists to discover workspaces, including ones other than the
+			// access token's own; it reconciles the actual current workspace itself via
+			// WhoAmI, so a mismatch here must not be treated as an error.
+			requestedTenant = types.TenantUnset
+		}
+		global.Client, err = cli.ConnectWithTenant(ctx, global.FabricAddr, requestedTenant)
 		if err != nil {
 			if connect.CodeOf(err) != connect.CodeUnauthenticated {
 				return err
@@ -489,6 +497,10 @@ func isCompletionCommand(cmd *cobra.Command) bool {
 
 func isUpgradeCommand(cmd *cobra.Command) bool {
 	return cmd.Name() == "upgrade"
+}
+
+func isWorkspaceListCommand(cmd *cobra.Command) bool {
+	return cmd.Name() == "workspace" || (cmd.Parent() != nil && cmd.Parent().Name() == "workspace")
 }
 
 func canIUseProvider(ctx context.Context, provider client.Provider, projectName string, serviceCount int, allowUpgrade bool) error {

--- a/src/pkg/cli/client/cluster.go
+++ b/src/pkg/cli/client/cluster.go
@@ -38,6 +38,13 @@ func TokenStorageName(fabricAddr string) string {
 	return host
 }
 
+// UsingAccessTokenEnv reports whether DEFANG_ACCESS_TOKEN is set. Such a token is minted
+// by `defang token` for a single, fixed workspace, so unlike an interactive login it cannot
+// be redirected to a different workspace via --workspace/DEFANG_WORKSPACE.
+func UsingAccessTokenEnv() bool {
+	return os.Getenv("DEFANG_ACCESS_TOKEN") != ""
+}
+
 func GetExistingToken(fabricAddr string) string {
 	var accessToken = os.Getenv("DEFANG_ACCESS_TOKEN")
 

--- a/src/pkg/cli/connect.go
+++ b/src/pkg/cli/connect.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/DefangLabs/defang/src/pkg/cli/client"
 	"github.com/DefangLabs/defang/src/pkg/cli/client/byoc/aws"
@@ -28,6 +29,15 @@ func ConnectWithTenant(ctx context.Context, fabricAddr string, requestedTenant t
 	if err != nil {
 		term.Debug("Unable to validate tenant with server:", err)
 		return grpcClient, err
+	}
+
+	// A DEFANG_ACCESS_TOKEN is minted for one fixed workspace; the server always resolves it
+	// to that workspace regardless of the tenant header, so a mismatched --workspace/
+	// DEFANG_WORKSPACE would otherwise be silently ignored. Fail instead of proceeding on the
+	// wrong workspace.
+	if requestedTenant.IsSet() && client.UsingAccessTokenEnv() &&
+		string(requestedTenant) != resp.Tenant && string(requestedTenant) != resp.TenantId {
+		return nil, fmt.Errorf("requested workspace %q does not match workspace %q associated with the DEFANG_ACCESS_TOKEN in use", requestedTenant, resp.Tenant)
 	}
 
 	grpcClient.Tenant = types.TenantLabel(resp.Tenant)

--- a/src/pkg/cli/connect_test.go
+++ b/src/pkg/cli/connect_test.go
@@ -151,6 +151,75 @@ func TestConnect(t *testing.T) {
 		}
 	})
 
+	t.Run("access token workspace mismatch errors", func(t *testing.T) {
+		const serverTenant = "server-tenant"
+		handler := &mockWhoAmI{tenant: serverTenant, tenantID: "server-id"}
+		_, h := defangv1connect.NewFabricControllerHandler(handler)
+		server := httptest.NewServer(h)
+		t.Cleanup(server.Close)
+		t.Setenv("DEFANG_ACCESS_TOKEN", "some-fixed-workspace-token")
+
+		_, err := ConnectWithTenant(ctx, strings.TrimPrefix(server.URL, "http://"), "tenant2")
+		if err == nil {
+			t.Fatal("expected an error, got nil")
+		}
+		if !strings.Contains(err.Error(), `"tenant2"`) || !strings.Contains(err.Error(), `"server-tenant"`) {
+			t.Errorf("expected error to mention both workspaces, got: %v", err)
+		}
+	})
+
+	t.Run("access token workspace match by name is allowed", func(t *testing.T) {
+		const serverTenant = "server-tenant"
+		handler := &mockWhoAmI{tenant: serverTenant, tenantID: "server-id"}
+		_, h := defangv1connect.NewFabricControllerHandler(handler)
+		server := httptest.NewServer(h)
+		t.Cleanup(server.Close)
+		t.Setenv("DEFANG_ACCESS_TOKEN", "some-fixed-workspace-token")
+
+		g, err := ConnectWithTenant(ctx, strings.TrimPrefix(server.URL, "http://"), serverTenant)
+		if err != nil {
+			t.Fatalf("expected %v, got: %v", nil, err)
+		}
+		if g.GetTenantName() != serverTenant {
+			t.Errorf("expected tenant %q, got %q", serverTenant, g.GetTenantName())
+		}
+	})
+
+	t.Run("access token workspace match by id is allowed", func(t *testing.T) {
+		const serverTenant = "server-tenant"
+		const serverTenantID = "server-id"
+		handler := &mockWhoAmI{tenant: serverTenant, tenantID: serverTenantID}
+		_, h := defangv1connect.NewFabricControllerHandler(handler)
+		server := httptest.NewServer(h)
+		t.Cleanup(server.Close)
+		t.Setenv("DEFANG_ACCESS_TOKEN", "some-fixed-workspace-token")
+
+		g, err := ConnectWithTenant(ctx, strings.TrimPrefix(server.URL, "http://"), serverTenantID)
+		if err != nil {
+			t.Fatalf("expected %v, got: %v", nil, err)
+		}
+		if g.GetTenantName() != serverTenant {
+			t.Errorf("expected tenant %q, got %q", serverTenant, g.GetTenantName())
+		}
+	})
+
+	t.Run("no access token means mismatch is not an error", func(t *testing.T) {
+		t.Parallel()
+		const serverTenant = "server-tenant"
+		handler := &mockWhoAmI{tenant: serverTenant, tenantID: "server-id"}
+		_, h := defangv1connect.NewFabricControllerHandler(handler)
+		server := httptest.NewServer(h)
+		t.Cleanup(server.Close)
+
+		g, err := ConnectWithTenant(ctx, strings.TrimPrefix(server.URL, "http://"), "tenant2")
+		if err != nil {
+			t.Fatalf("expected %v, got: %v", nil, err)
+		}
+		if g.GetTenantName() != serverTenant {
+			t.Errorf("expected tenant %q, got %q", serverTenant, g.GetTenantName())
+		}
+	})
+
 	t.Run("legacy cluster prefix ignored", func(t *testing.T) {
 		t.Parallel()
 		handler := &mockWhoAmI{tenant: "server-tenant"}

--- a/src/pkg/cli/connect_test.go
+++ b/src/pkg/cli/connect_test.go
@@ -151,60 +151,52 @@ func TestConnect(t *testing.T) {
 		}
 	})
 
-	t.Run("access token workspace mismatch errors", func(t *testing.T) {
-		const serverTenant = "server-tenant"
-		handler := &mockWhoAmI{tenant: serverTenant, tenantID: "server-id"}
-		_, h := defangv1connect.NewFabricControllerHandler(handler)
-		server := httptest.NewServer(h)
-		t.Cleanup(server.Close)
-		t.Setenv("DEFANG_ACCESS_TOKEN", "some-fixed-workspace-token")
-
-		_, err := ConnectWithTenant(ctx, strings.TrimPrefix(server.URL, "http://"), "tenant2")
-		if err == nil {
-			t.Fatal("expected an error, got nil")
-		}
-		if !strings.Contains(err.Error(), `"tenant2"`) || !strings.Contains(err.Error(), `"server-tenant"`) {
-			t.Errorf("expected error to mention both workspaces, got: %v", err)
-		}
-	})
-
-	t.Run("access token workspace match by name is allowed", func(t *testing.T) {
-		const serverTenant = "server-tenant"
-		handler := &mockWhoAmI{tenant: serverTenant, tenantID: "server-id"}
-		_, h := defangv1connect.NewFabricControllerHandler(handler)
-		server := httptest.NewServer(h)
-		t.Cleanup(server.Close)
-		t.Setenv("DEFANG_ACCESS_TOKEN", "some-fixed-workspace-token")
-
-		g, err := ConnectWithTenant(ctx, strings.TrimPrefix(server.URL, "http://"), serverTenant)
-		if err != nil {
-			t.Fatalf("expected %v, got: %v", nil, err)
-		}
-		if g.GetTenantName() != serverTenant {
-			t.Errorf("expected tenant %q, got %q", serverTenant, g.GetTenantName())
-		}
-	})
-
-	t.Run("access token workspace match by id is allowed", func(t *testing.T) {
+	t.Run("access token workspace validation", func(t *testing.T) {
 		const serverTenant = "server-tenant"
 		const serverTenantID = "server-id"
-		handler := &mockWhoAmI{tenant: serverTenant, tenantID: serverTenantID}
-		_, h := defangv1connect.NewFabricControllerHandler(handler)
-		server := httptest.NewServer(h)
-		t.Cleanup(server.Close)
-		t.Setenv("DEFANG_ACCESS_TOKEN", "some-fixed-workspace-token")
 
-		g, err := ConnectWithTenant(ctx, strings.TrimPrefix(server.URL, "http://"), serverTenantID)
-		if err != nil {
-			t.Fatalf("expected %v, got: %v", nil, err)
+		cases := []struct {
+			name         string
+			requested    types.TenantNameOrID
+			wantErrParts []string // non-empty means an error is expected containing all of these
+		}{
+			{name: "mismatch errors", requested: "tenant2", wantErrParts: []string{`"tenant2"`, `"server-tenant"`}},
+			{name: "match by name is allowed", requested: serverTenant},
+			{name: "match by id is allowed", requested: serverTenantID},
 		}
-		if g.GetTenantName() != serverTenant {
-			t.Errorf("expected tenant %q, got %q", serverTenant, g.GetTenantName())
+
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				handler := &mockWhoAmI{tenant: serverTenant, tenantID: serverTenantID}
+				_, h := defangv1connect.NewFabricControllerHandler(handler)
+				server := httptest.NewServer(h)
+				t.Cleanup(server.Close)
+				t.Setenv("DEFANG_ACCESS_TOKEN", "some-fixed-workspace-token")
+
+				g, err := ConnectWithTenant(ctx, strings.TrimPrefix(server.URL, "http://"), tc.requested)
+				if len(tc.wantErrParts) > 0 {
+					if err == nil {
+						t.Fatal("expected an error, got nil")
+					}
+					for _, want := range tc.wantErrParts {
+						if !strings.Contains(err.Error(), want) {
+							t.Errorf("expected error to mention %q, got: %v", want, err)
+						}
+					}
+					return
+				}
+				if err != nil {
+					t.Fatalf("expected %v, got: %v", nil, err)
+				}
+				if g.GetTenantName() != serverTenant {
+					t.Errorf("expected tenant %q, got %q", serverTenant, g.GetTenantName())
+				}
+			})
 		}
 	})
 
 	t.Run("no access token means mismatch is not an error", func(t *testing.T) {
-		t.Parallel()
+		t.Setenv("DEFANG_ACCESS_TOKEN", "") // clear any token inherited from the environment
 		const serverTenant = "server-tenant"
 		handler := &mockWhoAmI{tenant: serverTenant, tenantID: "server-id"}
 		_, h := defangv1connect.NewFabricControllerHandler(handler)


### PR DESCRIPTION
## Summary

Fixes #2253.

A `DEFANG_ACCESS_TOKEN` is minted by `defang token` for one fixed workspace, so it can't be redirected to another workspace via `--workspace`/`DEFANG_WORKSPACE`. Previously the CLI silently proceeded on the token's actual workspace whenever the requested one didn't match. This adds a check in `ConnectWithTenant`: when a `DEFANG_ACCESS_TOKEN` is in use and a workspace was explicitly requested, it must match the workspace (by name or ID) reported by the server's `WhoAmI`, or the CLI now errors out instead of continuing on the wrong workspace.

Interactive/browser-login flows are unaffected — they can legitimately switch among the user's accessible workspaces, so the check only applies when `DEFANG_ACCESS_TOKEN` is set.

## Changes

- `src/pkg/cli/client/cluster.go`: add `UsingAccessTokenEnv()` helper.
- `src/pkg/cli/connect.go`: `ConnectWithTenant` now errors on a workspace mismatch when using an access token.
- `src/pkg/cli/connect_test.go`: new tests for the mismatch/match/no-token cases.

## Test plan

- [x] `go test -short ./pkg/cli/... ./pkg/cli/client/...` passes (a pre-existing, unrelated failure in `./pkg/cli/client/byoc/aws/...` reproduces on `main` too — ambient AWS credentials in this sandbox trip `TestAWSEnv_ConflictingAWSCredentials`, unrelated to this change).
- [x] `golangci-lint run` scoped to the touched packages shows no new findings (only pre-existing gosec noise in unrelated files).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Workspace connections using an access token now verify that the requested workspace matches the workspace associated with the token.
  * Mismatched workspace requests return a clear error identifying the conflicting workspace values.
  * Matching workspace names and IDs continue to connect successfully.
  * Workspace selection remains unrestricted when no access token is configured.
  * Workspace listing commands can now discover and reconcile the active workspace independently of the currently selected workspace.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->