### PR TITLE
fix(azure): honor LogType filter in QueryLogs

### DIFF
--- a/src/pkg/cli/client/byoc/azure/byoc.go
+++ b/src/pkg/cli/client/byoc/azure/byoc.go
@@ -859,19 +859,21 @@ func (b *ByocAzure) QueryLogs(ctx context.Context, req *defangv1.TailRequest) (i
 		return nil, err
 	}
 
+	// etag tags every response entry (CD, service, and build alike), so it's resolved
+	// unconditionally; only the CD run LOOKUP below is gated on LogTypeCD.
+	runID := b.cdRunID
+	etag := b.cdEtag
+	if req.Etag != "" && req.Etag != b.cdEtag {
+		runID, etag = "", req.Etag
+	}
+
 	// Resolve the CD job execution for this request. The deploying process caches
 	// the run ID in memory; a standalone `defang logs` has none, so recover it by
 	// matching the request etag against each execution's recorded ETAG env var.
 	// Skip this entirely when CD logs weren't requested (e.g. `defang cd preview`
-	// asking for build+CD only): a service/build-only tail shouldn't warn about a
-	// CD run it was never going to show.
-	var runID, etag string
+	// asking for build+CD only): a service/build-only tail shouldn't look up, or
+	// warn about, a CD run it was never going to show.
 	if logType.Has(logs.LogTypeCD) {
-		runID = b.cdRunID
-		etag = b.cdEtag
-		if req.Etag != "" && req.Etag != b.cdEtag {
-			runID, etag = "", req.Etag
-		}
 		if runID == "" && etag != "" {
 			found, err := b.job.FindExecutionByEtag(ctx, etag)
 			if err != nil {
@@ -884,6 +886,8 @@ func (b *ByocAzure) QueryLogs(ctx context.Context, req *defangv1.TailRequest) (i
 			// by resource group rather than the CD execution, so still surface those.
 			term.Warnf("No CD logs found for etag %q; showing service and build logs only", req.Etag)
 		}
+	} else {
+		runID = ""
 	}
 
 	// CD logs. cdCh stays nil when there's no CD run, which makes the select below skip

--- a/src/pkg/cli/client/byoc/azure/byoc.go
+++ b/src/pkg/cli/client/byoc/azure/byoc.go
@@ -26,6 +26,7 @@ import (
 	azuredns "github.com/DefangLabs/defang/src/pkg/clouds/azure/dns"
 	"github.com/DefangLabs/defang/src/pkg/clouds/azure/keyvault"
 	defanghttp "github.com/DefangLabs/defang/src/pkg/http"
+	"github.com/DefangLabs/defang/src/pkg/logs"
 	"github.com/DefangLabs/defang/src/pkg/term"
 	"github.com/DefangLabs/defang/src/pkg/tokenstore"
 	"github.com/DefangLabs/defang/src/pkg/types"
@@ -846,6 +847,11 @@ func splitCDLogSnapshot(content string) []string {
 func (b *ByocAzure) QueryLogs(ctx context.Context, req *defangv1.TailRequest) (iter.Seq2[*defangv1.TailResponse, error], error) {
 	const cdServiceName = "defang-cd"
 
+	logType := logs.LogType(req.LogType)
+	if logType == logs.LogTypeUnspecified {
+		logType = logs.LogTypeAll
+	}
+
 	// setUpLocation resolves AZURE_LOCATION/AZURE_SUBSCRIPTION_ID onto the driver and
 	// job (no API calls). The service and build watchers below use b.driver.Azure, so
 	// this must run even when there's no etag to look up a CD run by.
@@ -856,22 +862,28 @@ func (b *ByocAzure) QueryLogs(ctx context.Context, req *defangv1.TailRequest) (i
 	// Resolve the CD job execution for this request. The deploying process caches
 	// the run ID in memory; a standalone `defang logs` has none, so recover it by
 	// matching the request etag against each execution's recorded ETAG env var.
-	runID := b.cdRunID
-	etag := b.cdEtag
-	if req.Etag != "" && req.Etag != b.cdEtag {
-		runID, etag = "", req.Etag
-	}
-	if runID == "" && etag != "" {
-		found, err := b.job.FindExecutionByEtag(ctx, etag)
-		if err != nil {
-			return nil, fmt.Errorf("failed to find CD deployment for etag %q: %w", etag, err)
+	// Skip this entirely when CD logs weren't requested (e.g. `defang cd preview`
+	// asking for build+CD only): a service/build-only tail shouldn't warn about a
+	// CD run it was never going to show.
+	var runID, etag string
+	if logType.Has(logs.LogTypeCD) {
+		runID = b.cdRunID
+		etag = b.cdEtag
+		if req.Etag != "" && req.Etag != b.cdEtag {
+			runID, etag = "", req.Etag
 		}
-		runID = found
-	}
-	if runID == "" {
-		// Unknown or empty etag: no CD run to tail. Service and build logs are keyed
-		// by resource group rather than the CD execution, so still surface those.
-		term.Warnf("No CD logs found for etag %q; showing service and build logs only", req.Etag)
+		if runID == "" && etag != "" {
+			found, err := b.job.FindExecutionByEtag(ctx, etag)
+			if err != nil {
+				return nil, fmt.Errorf("failed to find CD deployment for etag %q: %w", etag, err)
+			}
+			runID = found
+		}
+		if runID == "" {
+			// Unknown or empty etag: no CD run to tail. Service and build logs are keyed
+			// by resource group rather than the CD execution, so still surface those.
+			term.Warnf("No CD logs found for etag %q; showing service and build logs only", req.Etag)
+		}
 	}
 
 	// CD logs. cdCh stays nil when there's no CD run, which makes the select below skip
@@ -931,8 +943,10 @@ func (b *ByocAzure) QueryLogs(ctx context.Context, req *defangv1.TailRequest) (i
 	// group may be created mid-session (deploy-then-tail), so the watchers poll for it.
 	var acaCh <-chan aca.ServiceLogEntry
 	var buildCh <-chan acr.BuildLogEntry
-	startWatchers := true
-	if !req.Follow {
+	wantRun := logType.Has(logs.LogTypeRun)
+	wantBuild := logType.Has(logs.LogTypeBuild)
+	startWatchers := wantRun || wantBuild
+	if startWatchers && !req.Follow {
 		exists, err := b.driver.ResourceGroupExists(ctx, projectRG)
 		if err != nil {
 			return nil, err
@@ -943,17 +957,21 @@ func (b *ByocAzure) QueryLogs(ctx context.Context, req *defangv1.TailRequest) (i
 		}
 	}
 	if startWatchers {
-		acaClient := &aca.ContainerApp{
-			Azure:         b.driver.Azure,
-			ResourceGroup: projectRG,
+		if wantRun {
+			acaClient := &aca.ContainerApp{
+				Azure:         b.driver.Azure,
+				ResourceGroup: projectRG,
+			}
+			acaCh = acaClient.WatchLogs(ctx, req.Follow)
 		}
-		acaCh = acaClient.WatchLogs(ctx, req.Follow)
 
-		buildWatcher := &acr.BuildLogWatcher{
-			Azure:         b.driver.Azure,
-			ResourceGroup: projectRG,
+		if wantBuild {
+			buildWatcher := &acr.BuildLogWatcher{
+				Azure:         b.driver.Azure,
+				ResourceGroup: projectRG,
+			}
+			buildCh = buildWatcher.WatchBuildLogs(ctx, req.Follow)
 		}
-		buildCh = buildWatcher.WatchBuildLogs(ctx, req.Follow)
 	}
 
 	return func(yield func(*defangv1.TailResponse, error) bool) {

--- a/src/pkg/cli/client/byoc/azure/byoc_test.go
+++ b/src/pkg/cli/client/byoc/azure/byoc_test.go
@@ -523,39 +523,54 @@ func TestSplitCDLogSnapshot(t *testing.T) {
 	}
 }
 
-func TestQueryLogsCDOnlySkipsServiceWatchers(t *testing.T) {
+func TestQueryLogsRoutesByLogType(t *testing.T) {
 	// `defang cd preview` (and any other CD-only tail) asks for LogTypeBuild|LogTypeCD;
-	// requesting bare LogTypeCD here isolates that QueryLogs must not also start the
-	// service-log (ACA) watcher, which is what made #2259 tail the whole project's
-	// running logs instead of just the CD task's own output.
-	useFakeCred(t, "", errors.New("denied"))
-	b := newTestProvider(t, cloudazure.LocationEastUS, "sub")
-	b.cdRunID = "run-1"
-	b.cdEtag = "etag"
-	ctx, cancel := context.WithTimeout(t.Context(), 3*time.Second)
-	defer cancel()
-	_, err := b.QueryLogs(ctx, &defangv1.TailRequest{Etag: "etag", Follow: false, LogType: uint32(logs.LogTypeCD)})
-	if err == nil || !strings.Contains(err.Error(), "getting log analytics workspace") {
-		t.Errorf("expected CD-log lookup failure, got: %v", err)
+	// QueryLogs must not also start the service-log (ACA) watcher for it, which is what
+	// made #2259 tail the whole project's running logs instead of just the CD task's
+	// own output. Conversely, a service/build-only tail must not look up or warn about
+	// a CD run it was never going to show, even when the request etag is unmatched.
+	tests := []struct {
+		name        string
+		setup       func(b *ByocAzure)
+		req         *defangv1.TailRequest
+		wantErr     string // substring that must appear in the error
+		unwantedErr string // substring that must NOT appear in the error
+	}{
+		{
+			name: "CD-only skips the service resource-group check",
+			setup: func(b *ByocAzure) {
+				b.cdRunID = "run-1"
+				b.cdEtag = "etag"
+			},
+			req:         &defangv1.TailRequest{Etag: "etag", Follow: false, LogType: uint32(logs.LogTypeCD)},
+			wantErr:     "getting log analytics workspace",
+			unwantedErr: "checking resource group",
+		},
+		{
+			name:        "Run-only skips the CD run lookup",
+			req:         &defangv1.TailRequest{Etag: "some-etag", Follow: false, LogType: uint32(logs.LogTypeRun)},
+			wantErr:     "checking resource group",
+			unwantedErr: "failed to find CD deployment",
+		},
 	}
-	if strings.Contains(err.Error(), "checking resource group") {
-		t.Errorf("CD-only request should never touch the service resource group, got: %v", err)
-	}
-}
 
-func TestQueryLogsRunOnlySkipsCDLookup(t *testing.T) {
-	// A request for LogTypeRun only (no CD bit) must not look up or warn about a CD
-	// run, even when the request etag doesn't match anything cached.
-	useFakeCred(t, "", errors.New("denied"))
-	b := newTestProvider(t, cloudazure.LocationEastUS, "sub")
-	ctx, cancel := context.WithTimeout(t.Context(), 3*time.Second)
-	defer cancel()
-	_, err := b.QueryLogs(ctx, &defangv1.TailRequest{Etag: "some-etag", Follow: false, LogType: uint32(logs.LogTypeRun)})
-	if err == nil || !strings.Contains(err.Error(), "checking resource group") {
-		t.Errorf("expected resource-group check failure, got: %v", err)
-	}
-	if strings.Contains(err.Error(), "failed to find CD deployment") {
-		t.Errorf("Run-only request should never look up a CD deployment, got: %v", err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			useFakeCred(t, "", errors.New("denied"))
+			b := newTestProvider(t, cloudazure.LocationEastUS, "sub")
+			if tt.setup != nil {
+				tt.setup(b)
+			}
+			ctx, cancel := context.WithTimeout(t.Context(), 3*time.Second)
+			defer cancel()
+			_, err := b.QueryLogs(ctx, tt.req)
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("expected error containing %q, got: %v", tt.wantErr, err)
+			}
+			if err != nil && strings.Contains(err.Error(), tt.unwantedErr) {
+				t.Errorf("error should not contain %q, got: %v", tt.unwantedErr, err)
+			}
+		})
 	}
 }
 

--- a/src/pkg/cli/client/byoc/azure/byoc_test.go
+++ b/src/pkg/cli/client/byoc/azure/byoc_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/DefangLabs/defang/src/pkg/cli/client"
 	cloudazure "github.com/DefangLabs/defang/src/pkg/clouds/azure"
+	"github.com/DefangLabs/defang/src/pkg/logs"
 	defangv1 "github.com/DefangLabs/defang/src/protos/io/defang/v1"
 	composeTypes "github.com/compose-spec/compose-go/v2/types"
 )
@@ -519,6 +520,42 @@ func TestSplitCDLogSnapshot(t *testing.T) {
 				t.Errorf("splitCDLogSnapshot(%q) = %v, want %v", tt.content, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestQueryLogsCDOnlySkipsServiceWatchers(t *testing.T) {
+	// `defang cd preview` (and any other CD-only tail) asks for LogTypeBuild|LogTypeCD;
+	// requesting bare LogTypeCD here isolates that QueryLogs must not also start the
+	// service-log (ACA) watcher, which is what made #2259 tail the whole project's
+	// running logs instead of just the CD task's own output.
+	useFakeCred(t, "", errors.New("denied"))
+	b := newTestProvider(t, cloudazure.LocationEastUS, "sub")
+	b.cdRunID = "run-1"
+	b.cdEtag = "etag"
+	ctx, cancel := context.WithTimeout(t.Context(), 3*time.Second)
+	defer cancel()
+	_, err := b.QueryLogs(ctx, &defangv1.TailRequest{Etag: "etag", Follow: false, LogType: uint32(logs.LogTypeCD)})
+	if err == nil || !strings.Contains(err.Error(), "getting log analytics workspace") {
+		t.Errorf("expected CD-log lookup failure, got: %v", err)
+	}
+	if strings.Contains(err.Error(), "checking resource group") {
+		t.Errorf("CD-only request should never touch the service resource group, got: %v", err)
+	}
+}
+
+func TestQueryLogsRunOnlySkipsCDLookup(t *testing.T) {
+	// A request for LogTypeRun only (no CD bit) must not look up or warn about a CD
+	// run, even when the request etag doesn't match anything cached.
+	useFakeCred(t, "", errors.New("denied"))
+	b := newTestProvider(t, cloudazure.LocationEastUS, "sub")
+	ctx, cancel := context.WithTimeout(t.Context(), 3*time.Second)
+	defer cancel()
+	_, err := b.QueryLogs(ctx, &defangv1.TailRequest{Etag: "some-etag", Follow: false, LogType: uint32(logs.LogTypeRun)})
+	if err == nil || !strings.Contains(err.Error(), "checking resource group") {
+		t.Errorf("expected resource-group check failure, got: %v", err)
+	}
+	if strings.Contains(err.Error(), "failed to find CD deployment") {
+		t.Errorf("Run-only request should never look up a CD deployment, got: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

`ByocAzure.QueryLogs` unconditionally started the Container Apps
service-log watcher and the ACR build-log watcher, and always looked up
the CD run by etag — regardless of the requested `LogType`. `cli.Preview`
(and thus `defang cd preview`) asks for `LogTypeBuild|LogTypeCD` only, so
a preview on Azure tailed the whole project's running service logs next
to the CD diff. On `portal-production` that was ~19,000 lines, of which
~85 were the Pulumi diff and the rest were live Hasura query logs.

## Fix

Gate each source in `QueryLogs` behind its own `LogType` bit:
- CD run lookup/tail only when `LogTypeCD` is requested (an unmatched
  etag with CD not requested no longer warns about a CD run it was
  never going to show)
- ACA service-log watcher only when `LogTypeRun` is requested
- ACR build-log watcher only when `LogTypeBuild` is requested

This mirrors the AWS provider's existing `getLogGroupInputs`, which
already filters CloudWatch log groups by `LogType`.

## Test plan

- [x] `go build ./...`
- [x] `go test -short ./pkg/cli/client/byoc/azure/...` — added
      `TestQueryLogsCDOnlySkipsServiceWatchers` and
      `TestQueryLogsRunOnlySkipsCDLookup` to cover the regression
- [x] `go test -short ./pkg/cli/...` (pre-existing, unrelated
      `TestAWSEnv_ConflictingAWSCredentials` failure confirmed present
      on `main` too — ambient AWS env in this sandbox)
- [x] `make lint` — same 25 pre-existing issues present on a clean
      `main` checkout (all in unrelated files); none in the changed
      files

Fixes #2259

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016tmxjjgx64jmLi8sqiYqgs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Log queries now support selecting specific log types, including CD, service, and build logs.
  - Requests without a specified log type continue to include all available log sources.
  - Log streaming now initializes only the sources relevant to the selected log types.
  - CD-only, service-only, and build-only log tails provide more focused results without unrelated log activity.
  - Log responses consistently preserve the requested or previously cached ETag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->