### PR TITLE
ci(go): fail fast when vendorHash drifts on a tag push

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -171,18 +171,6 @@ jobs:
       - name: Update vendorHash if needed
         if: steps.nix-test.outcome == 'failure'
         run: |
-          # A tag checkout is a detached HEAD with no branch to push a fix
-          # commit to (there's no `origin/<tag>` remote-tracking ref to
-          # rebase against either), and tags shouldn't be amended anyway.
-          # Fail with an actionable message instead of the confusing git
-          # errors that follow from treating $GITHUB_REF_NAME as a branch.
-          if [ "$GITHUB_REF_TYPE" = "tag" ]; then
-            echo "❌ vendorHash is stale for tag $GITHUB_REF_NAME, but a tag has no branch to push a fix to."
-            echo "This is likely nixpkgs channel drift (nix_path uses the floating nixos-unstable channel), not a real code change."
-            echo "Fix vendorHash on the branch this tag was cut from and re-cut the release."
-            exit 1
-          fi
-
           # Extract the correct hash from the error output
           NEW_HASH=$(grep 'got:' /tmp/nix-test-output.log | grep -oP 'sha256-[A-Za-z0-9+/]+=*' | head -1)
 
@@ -194,6 +182,18 @@ jobs:
             fi
 
             echo "Found new hash: $NEW_HASH"
+
+            # A tag checkout is a detached HEAD with no branch to push a fix
+            # commit to (there's no `origin/<tag>` remote-tracking ref to
+            # rebase against either), and tags shouldn't be amended anyway.
+            # Fail with an actionable message instead of the confusing git
+            # errors that follow from treating $GITHUB_REF_NAME as a branch.
+            if [ "$GITHUB_REF_TYPE" = "tag" ]; then
+              echo "❌ vendorHash is stale for tag $GITHUB_REF_NAME (needs $NEW_HASH), but a tag has no branch to push a fix to."
+              echo "This is likely nixpkgs channel drift (nix_path uses the floating nixos-unstable channel), not a real code change."
+              echo "Fix vendorHash on the branch this tag was cut from and re-cut the release."
+              exit 1
+            fi
 
             # Update the vendorHash in cli.nix
             OLD_HASH=$(grep -oP 'vendorHash = "\Ksha256-[A-Za-z0-9+/]+=*' pkgs/defang/cli.nix)

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -171,6 +171,18 @@ jobs:
       - name: Update vendorHash if needed
         if: steps.nix-test.outcome == 'failure'
         run: |
+          # A tag checkout is a detached HEAD with no branch to push a fix
+          # commit to (there's no `origin/<tag>` remote-tracking ref to
+          # rebase against either), and tags shouldn't be amended anyway.
+          # Fail with an actionable message instead of the confusing git
+          # errors that follow from treating $GITHUB_REF_NAME as a branch.
+          if [ "$GITHUB_REF_TYPE" = "tag" ]; then
+            echo "❌ vendorHash is stale for tag $GITHUB_REF_NAME, but a tag has no branch to push a fix to."
+            echo "This is likely nixpkgs channel drift (nix_path uses the floating nixos-unstable channel), not a real code change."
+            echo "Fix vendorHash on the branch this tag was cut from and re-cut the release."
+            exit 1
+          fi
+
           # Extract the correct hash from the error output
           NEW_HASH=$(grep 'got:' /tmp/nix-test-output.log | grep -oP 'sha256-[A-Za-z0-9+/]+=*' | head -1)
 


### PR DESCRIPTION
## Summary

- `nix-shell-test`'s vendorHash auto-fix step assumed `$GITHUB_REF_NAME` is always a branch it can push a fix commit to
- On a release tag push it's a detached HEAD with no branch, and there's no `origin/<tag>` remote-tracking ref to rebase against, so the push/rebase retry loop failed with a confusing `fatal: no rebase in progress` instead of a clear message
- Added a guard: when `$GITHUB_REF_TYPE` is `tag`, fail immediately with an actionable message instead of attempting the push

## Context

Seen on the `v3.15.2` tag push: https://github.com/DefangLabs/defang/actions/runs/34377742732

`nix_path` uses the floating `nixpkgs=channel:nixos-unstable`, so vendorHash can legitimately drift between when a commit was tested on `main` and when it's later tagged for release — no code change involved. That drift can't be fixed by pushing a commit to the tag, so the workflow should fail clearly rather than run through a confusing push/rebase dance.

This doesn't fix the underlying vendorHash for `v3.15.2` itself — that still needs a normal fix on `main` (bump vendorHash there) before cutting the next release, since `nix run .#defang-cli` from that tag will keep failing until then.

## Verification

- `bash -n` on the extracted step script
- Read through the failure logs from run 34377742732 to confirm the push/rebase path is exactly what broke

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved recovery handling for tag-triggered workflow runs by validating replacement dependency hashes before applying corrective actions.
  - Preserved standard error handling when a valid hash mismatch is not detected.
  - Added a clearer, actionable message for confirmed dependency channel mismatches.
  - Branch-based recovery and verification behavior remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->