### PR TITLE
ci(release): gate patch/minor/major-release on the nix vendorHash check

### DIFF
--- a/pkgs/defang/cli.nix
+++ b/pkgs/defang/cli.nix
@@ -7,7 +7,7 @@ buildGo125Module {
   pname = "defang-cli";
   version = "git";
   src = lib.cleanSource ../../src;
-  vendorHash = "sha256-YYMRLT85SjuW8zv75QxJK2o8juXPfevcKIDYcjbfdOU=";
+  vendorHash = "sha256-rgP1ZzgqQS52rmbnFgSXxheuiEd4tdNd0FqU31sEZTs=";
 
   subPackages = [ "cmd/cli" ];
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -160,14 +160,37 @@ increment-major-version:
 push-tags:
 	git push origin 'refs/tags/v*'
 
+## Each release target invokes its steps as separate $(MAKE) calls in its
+## recipe, not as prerequisites, so they run strictly in order even under
+## `make -j`: prerequisites of one target have no ordering guarantee under
+## parallel make, but recipe lines within a single target always run
+## sequentially.
 .PHONY: patch-release
-patch-release: pull test test-nix no-diff increment-patch-version push-tags
+patch-release:
+	$(MAKE) pull
+	$(MAKE) test
+	$(MAKE) test-nix
+	$(MAKE) no-diff
+	$(MAKE) increment-patch-version
+	$(MAKE) push-tags
 
 .PHONY: minor-release
-minor-release: pull test test-nix no-diff increment-minor-version push-tags
+minor-release:
+	$(MAKE) pull
+	$(MAKE) test
+	$(MAKE) test-nix
+	$(MAKE) no-diff
+	$(MAKE) increment-minor-version
+	$(MAKE) push-tags
 
 .PHONY: major-release
-major-release: pull test test-nix no-diff increment-major-version push-tags
+major-release:
+	$(MAKE) pull
+	$(MAKE) test
+	$(MAKE) test-nix
+	$(MAKE) no-diff
+	$(MAKE) increment-major-version
+	$(MAKE) push-tags
 
 .PHONY: release
 release:

--- a/src/Makefile
+++ b/src/Makefile
@@ -122,6 +122,15 @@ no-diff:
 	@# check that there are no uncommitted changes (staged or unstaged)
 	git diff --quiet HEAD --
 
+.PHONY: test-nix
+test-nix:
+	@# catch a stale pkgs/defang/cli.nix vendorHash before it's baked into a
+	@# release tag, where the CI auto-fix has no branch to push a fix to.
+	@# The root target silently no-ops without nix, which would make this
+	@# gate a no-op too, so require nix here instead of skipping quietly.
+	@command -v nix >/dev/null || { echo "❌ nix is required to cut a release (it gates pkgs/defang/cli.nix's vendorHash)"; exit 1; }
+	$(MAKE) -C .. test-nix
+
 .PHONY: pull
 pull:
 	git pull
@@ -152,13 +161,13 @@ push-tags:
 	git push origin 'refs/tags/v*'
 
 .PHONY: patch-release
-patch-release: pull test no-diff increment-patch-version push-tags
+patch-release: pull test test-nix no-diff increment-patch-version push-tags
 
 .PHONY: minor-release
-minor-release: pull test no-diff increment-minor-version push-tags
+minor-release: pull test test-nix no-diff increment-minor-version push-tags
 
 .PHONY: major-release
-major-release: pull test no-diff increment-major-version push-tags
+major-release: pull test test-nix no-diff increment-major-version push-tags
 
 .PHONY: release
 release:


### PR DESCRIPTION
## Summary

- Shift-left companion to #2264: gate `patch-release`/`minor-release`/`major-release` (`src/Makefile`) on the root `test-nix` target
- A stale `pkgs/defang/cli.nix` vendorHash now fails the release **locally, before a tag is created**, instead of surfacing only in CI at tag-push time — where the auto-fix step has no branch to push a corrected commit to (see #2264, hit on the `v3.15.2` tag)
- The root `test-nix` target silently no-ops when `nix` isn't installed; since this is now a release gate rather than an optional dev-loop check, the new `src/Makefile` target requires `nix` explicitly instead of skipping quietly

## How it works

`patch-release`/etc. already run `no-diff` (fails if there are uncommitted changes) right after the new `test-nix` step. If vendorHash is stale, the root `update-nix-vendor-hash` target fixes and `git add`s `pkgs/defang/cli.nix`, then exits non-zero — `no-diff` then sees the staged change and stops the release, telling the release owner to commit the fix and re-run.

## Verification

- `make -C src -n patch-release` — dependency chain resolves in the right order (pull → test → test-nix → no-diff → tag → push)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a Nix-based testing target to the standard test workflow.
  * Release commands now run pull, tests, Nix validation, and clean-tree checks in sequence before creating and pushing patch, minor, or major release tags.
  * Improved release workflow reliability by ensuring each validation step completes before the next release action begins.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->