### PR TITLE
ci(go): fail fast when GITHUB_TOKEN can't push a vendorHash fix

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -223,9 +223,18 @@ jobs:
               # before giving up.
               pushed=false
               for attempt in 1 2 3 4 5; do
-                if git push; then
-                  pushed=true
-                  break
+                PUSH_OUTPUT=$(git push 2>&1) && { pushed=true; break; }
+                echo "$PUSH_OUTPUT"
+
+                # GITHUB_TOKEN can never push a ref whose commit range
+                # touches .github/workflows/* (e.g. this PR also edits a
+                # workflow file) - there's no permission to grant for this,
+                # "workflows" isn't a valid permission scope - so retrying
+                # would just fail identically 5 times. Fail fast instead.
+                if echo "$PUSH_OUTPUT" | grep -q "without \`workflows\` permission"; then
+                  echo "❌ GITHUB_TOKEN can't push this vendorHash fix: this branch's commit range touches a workflow file, which GITHUB_TOKEN is never allowed to push regardless of granted permissions."
+                  echo "Fix vendorHash on pkgs/defang/cli.nix manually and push it with your own credentials."
+                  exit 1
                 fi
 
                 echo "Push rejected (attempt $attempt/5); fetching origin/$GITHUB_REF_NAME"

--- a/pkgs/defang/cli.nix
+++ b/pkgs/defang/cli.nix
@@ -7,7 +7,7 @@ buildGo125Module {
   pname = "defang-cli";
   version = "git";
   src = lib.cleanSource ../../src;
-  vendorHash = "sha256-YYMRLT85SjuW8zv75QxJK2o8juXPfevcKIDYcjbfdOU=";
+  vendorHash = "sha256-rgP1ZzgqQS52rmbnFgSXxheuiEd4tdNd0FqU31sEZTs=";
 
   subPackages = [ "cmd/cli" ];
 


### PR DESCRIPTION
## Summary

- GitHub rejects any `GITHUB_TOKEN` push to a ref whose commit range touches `.github/workflows/*` with `refusing to allow a GitHub App to create or update workflow ... without \`workflows\` permission` — and there's no `permissions:` entry to grant this: `workflows` isn't a valid GITHUB_TOKEN permission scope (confirmed with `actionlint`, which lists the full valid set and rejects it)
- So any PR/branch that itself edits a workflow file makes the `nix-shell-test` vendorHash auto-fix step's push **permanently** fail on that branch, even when the fix commit only touches `pkgs/defang/cli.nix`
- The retry loop treated this like the ordinary non-fast-forward race it's designed for (concurrent pushes to the same branch): it fetched the ref, found nothing to rebase, and hard-failed on a confusing "no rebase in progress" after burning through all 5 retry attempts
- Detect the specific rejection message and fail immediately with an actionable explanation instead

## Context

Flagged by another Claude agent session that picked up a CI-failure webhook on run https://github.com/DefangLabs/defang/actions/runs/34385394775 — that run was on PR #2264's own branch (since merged/deleted, so that specific instance is moot), but the bug is live on `main`'s `go.yml` now, and will hit the next PR that both (a) edits a workflow file and (b) triggers a vendorHash-drift auto-fix push on the same branch. That session yielded to this one rather than duplicating the fix since this area was already in progress here (#2264, #2265).

## Verification

- `actionlint .github/workflows/go.yml` — clean
- `bash -n` on the extracted step script
- Read through run 34385394775's log to confirm the exact rejection message and retry-loop behavior this addresses

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved automated update handling when workflow-related changes are rejected by GitHub.
  - Provides clearer failure guidance when the available authentication token cannot apply the update.

- **Chores**
  - Updated package metadata to keep Go module dependencies reproducible and current.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->