### PR TITLE
feat(cli): show the active workspace after interactive login

### DIFF
--- a/pkgs/defang/cli.nix
+++ b/pkgs/defang/cli.nix
@@ -7,7 +7,7 @@ buildGo125Module {
   pname = "defang-cli";
   version = "git";
   src = lib.cleanSource ../../src;
-  vendorHash = "sha256-YYMRLT85SjuW8zv75QxJK2o8juXPfevcKIDYcjbfdOU=";
+  vendorHash = "sha256-rgP1ZzgqQS52rmbnFgSXxheuiEd4tdNd0FqU31sEZTs=";
 
   subPackages = [ "cmd/cli" ];
 

--- a/src/cmd/cli/command/login.go
+++ b/src/cmd/cli/command/login.go
@@ -1,9 +1,7 @@
 package command
 
 import (
-	"github.com/DefangLabs/defang/src/pkg/auth"
 	"github.com/DefangLabs/defang/src/pkg/cli"
-	"github.com/DefangLabs/defang/src/pkg/cli/client"
 	"github.com/DefangLabs/defang/src/pkg/login"
 	"github.com/DefangLabs/defang/src/pkg/term"
 	"github.com/DefangLabs/defang/src/pkg/track"
@@ -58,15 +56,7 @@ func printActiveWorkspace(cmd *cobra.Command) {
 	global.Client = fabric
 	track.Tracker = fabric
 
-	var userInfo *auth.UserInfo
-	if global.HasTty {
-		token := client.GetExistingToken(global.FabricAddr)
-		if userInfo, err = auth.FetchUserInfo(ctx, token); err != nil {
-			term.Debug("Workspace information unavailable:", err)
-		}
-	}
-
-	data, err := cli.Whoami(ctx, fabric, nil, userInfo, global.TenantSelection)
+	data, err := cli.FetchAccountInfo(ctx, fabric, nil, global.FabricAddr, global.TenantSelection, global.HasTty)
 	if err != nil {
 		term.Debug("Unable to determine active workspace:", err)
 		return

--- a/src/cmd/cli/command/login.go
+++ b/src/cmd/cli/command/login.go
@@ -1,8 +1,12 @@
 package command
 
 import (
+	"github.com/DefangLabs/defang/src/pkg/auth"
+	"github.com/DefangLabs/defang/src/pkg/cli"
+	"github.com/DefangLabs/defang/src/pkg/cli/client"
 	"github.com/DefangLabs/defang/src/pkg/login"
 	"github.com/DefangLabs/defang/src/pkg/term"
+	"github.com/DefangLabs/defang/src/pkg/track"
 	defangv1 "github.com/DefangLabs/defang/src/protos/io/defang/v1"
 	"github.com/spf13/cobra"
 )
@@ -24,6 +28,8 @@ var loginCmd = &cobra.Command{
 				return err
 			}
 
+			printActiveWorkspace(cmd)
+
 			printDefangHint("To generate a sample service, do:", "generate")
 		}
 
@@ -36,4 +42,37 @@ var loginCmd = &cobra.Command{
 		}
 		return nil
 	},
+}
+
+// printActiveWorkspace shows which workspace will be used by default after a successful
+// interactive login. The client built before login has no access token yet, so reconnect
+// to pick up the one InteractiveLogin just saved.
+func printActiveWorkspace(cmd *cobra.Command) {
+	ctx := cmd.Context()
+
+	fabric, err := cli.ConnectWithTenant(ctx, global.FabricAddr, global.TenantSelection)
+	if err != nil {
+		term.Debug("Unable to determine active workspace:", err)
+		return
+	}
+	global.Client = fabric
+	track.Tracker = fabric
+
+	var userInfo *auth.UserInfo
+	if global.HasTty {
+		token := client.GetExistingToken(global.FabricAddr)
+		if userInfo, err = auth.FetchUserInfo(ctx, token); err != nil {
+			term.Debug("Workspace information unavailable:", err)
+		}
+	}
+
+	data, err := cli.Whoami(ctx, fabric, nil, userInfo, global.TenantSelection)
+	if err != nil {
+		term.Debug("Unable to determine active workspace:", err)
+		return
+	}
+
+	if data.Workspace != "" {
+		term.Infof("Using workspace %q\n", data.Workspace)
+	}
 }

--- a/src/cmd/cli/command/login.go
+++ b/src/cmd/cli/command/login.go
@@ -62,7 +62,7 @@ func printActiveWorkspace(cmd *cobra.Command) {
 		return
 	}
 
-	if data.Workspace != "" {
+	if data.Workspace != "" && !global.Json {
 		term.Infof("Using workspace %q\n", data.Workspace)
 	}
 }

--- a/src/cmd/cli/command/login_test.go
+++ b/src/cmd/cli/command/login_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/DefangLabs/defang/src/pkg/cli/client"
 	"github.com/DefangLabs/defang/src/pkg/term"
 	"github.com/DefangLabs/defang/src/pkg/tokenstore"
+	"github.com/DefangLabs/defang/src/pkg/track"
 	defangv1 "github.com/DefangLabs/defang/src/protos/io/defang/v1/defangv1connect"
 	"github.com/spf13/cobra"
 )
@@ -66,7 +67,11 @@ func TestPrintActiveWorkspace(t *testing.T) {
 	clusterURL := setupLoginTestServers(t)
 
 	oldGlobal := global
-	t.Cleanup(func() { global = oldGlobal })
+	oldTracker := track.Tracker
+	t.Cleanup(func() {
+		global = oldGlobal
+		track.Tracker = oldTracker
+	})
 	global.Stack.Name = "" // prevent loading stack files
 	global.FabricAddr = strings.TrimPrefix(clusterURL, "http://")
 	global.HasTty = true
@@ -97,6 +102,30 @@ func TestPrintActiveWorkspace(t *testing.T) {
 
 		if output := stdout.String(); !strings.Contains(output, "Workspace One") {
 			t.Fatalf("expected selected workspace name in output, got: %q", output)
+		}
+	})
+
+	t.Run("userinfo fetch failure falls back to the raw tenant id", func(t *testing.T) {
+		stdout.Reset()
+		global.TenantSelection = ""
+
+		failingUserinfo := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// A 4xx status (unlike 5xx) isn't retried by the retryablehttp client underneath
+			// auth.FetchUserInfo, keeping this test fast.
+			http.Error(w, "userinfo unavailable", http.StatusBadRequest)
+		}))
+		t.Cleanup(failingUserinfo.Close)
+
+		originalAuthClient := auth.OpenAuthClient
+		auth.OpenAuthClient = auth.NewClient("testclient", failingUserinfo.URL)
+		t.Cleanup(func() { auth.OpenAuthClient = originalAuthClient })
+
+		cmd := &cobra.Command{}
+		cmd.SetContext(t.Context())
+		printActiveWorkspace(cmd)
+
+		if output := stdout.String(); !strings.Contains(output, "ws-2") {
+			t.Fatalf("expected fallback to the raw tenant id in output, got: %q", output)
 		}
 	})
 }

--- a/src/cmd/cli/command/login_test.go
+++ b/src/cmd/cli/command/login_test.go
@@ -1,0 +1,101 @@
+package command
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/DefangLabs/defang/src/pkg/auth"
+	"github.com/DefangLabs/defang/src/pkg/cli/client"
+	"github.com/DefangLabs/defang/src/pkg/term"
+	"github.com/DefangLabs/defang/src/pkg/tokenstore"
+	defangv1 "github.com/DefangLabs/defang/src/protos/io/defang/v1/defangv1connect"
+	"github.com/spf13/cobra"
+)
+
+// setupLoginTestServers is like setupWorkspaceTestServers, but stores the access token via
+// client.TokenStore instead of DEFANG_ACCESS_TOKEN, so a tenant selection that differs from the
+// server's default tenant is not rejected as a fixed-workspace mismatch (see
+// client.UsingAccessTokenEnv).
+func setupLoginTestServers(t *testing.T) (clusterURL string) {
+	t.Helper()
+
+	mockService := &mockFabricService{tenantId: "ws-2"}
+	_, handler := defangv1.NewFabricControllerHandler(mockService)
+
+	fabricServer := httptest.NewServer(handler)
+	t.Cleanup(fabricServer.Close)
+
+	userinfoServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/userinfo" {
+			t.Fatalf("unexpected path %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"allTenants":[
+				{"id":"ws-1","name":"Workspace One"},
+				{"id":"ws-2","name":"Workspace Two"}
+			],
+			"userinfo":{"email":"cli@example.com","name":"CLI Tester"}
+		}`))
+	}))
+	t.Cleanup(userinfoServer.Close)
+
+	openAuthClient := auth.OpenAuthClient
+	t.Cleanup(func() { auth.OpenAuthClient = openAuthClient })
+	auth.OpenAuthClient = auth.NewClient("testclient", userinfoServer.URL)
+
+	originalTokenStore := client.TokenStore
+	client.TokenStore = &tokenstore.LocalDirTokenStore{Dir: t.TempDir()}
+	t.Cleanup(func() { client.TokenStore = originalTokenStore })
+
+	fabricAddr := strings.TrimPrefix(fabricServer.URL, "http://")
+	if err := client.TokenStore.Save(client.TokenStorageName(fabricAddr), "test-token"); err != nil {
+		t.Fatalf("failed to seed token store: %v", err)
+	}
+
+	return fabricServer.URL
+}
+
+func TestPrintActiveWorkspace(t *testing.T) {
+	stdout, _ := term.SetupTestTerm(t)
+	term.DefaultTerm.ForceColor(false)
+
+	clusterURL := setupLoginTestServers(t)
+
+	oldGlobal := global
+	t.Cleanup(func() { global = oldGlobal })
+	global.Stack.Name = "" // prevent loading stack files
+	global.FabricAddr = strings.TrimPrefix(clusterURL, "http://")
+	global.HasTty = true
+
+	t.Run("no explicit selection resolves to the server's default tenant", func(t *testing.T) {
+		stdout.Reset()
+		global.TenantSelection = ""
+
+		cmd := &cobra.Command{}
+		cmd.SetContext(t.Context())
+		printActiveWorkspace(cmd)
+
+		if global.Client == nil {
+			t.Fatal("expected global.Client to be reconnected with the new token")
+		}
+		if output := stdout.String(); !strings.Contains(output, "Workspace Two") {
+			t.Fatalf("expected active workspace name in output, got: %q", output)
+		}
+	})
+
+	t.Run("explicit selection is resolved by name", func(t *testing.T) {
+		stdout.Reset()
+		global.TenantSelection = "Workspace One"
+
+		cmd := &cobra.Command{}
+		cmd.SetContext(t.Context())
+		printActiveWorkspace(cmd)
+
+		if output := stdout.String(); !strings.Contains(output, "Workspace One") {
+			t.Fatalf("expected selected workspace name in output, got: %q", output)
+		}
+	})
+}

--- a/src/cmd/cli/command/login_test.go
+++ b/src/cmd/cli/command/login_test.go
@@ -20,6 +20,7 @@ import (
 // client.UsingAccessTokenEnv).
 func setupLoginTestServers(t *testing.T) (clusterURL string) {
 	t.Helper()
+	t.Setenv("DEFANG_ACCESS_TOKEN", "") // GetExistingToken prefers this env var over TokenStore
 
 	mockService := &mockFabricService{tenantId: "ws-2"}
 	_, handler := defangv1.NewFabricControllerHandler(mockService)

--- a/src/cmd/cli/command/login_test.go
+++ b/src/cmd/cli/command/login_test.go
@@ -105,6 +105,26 @@ func TestPrintActiveWorkspace(t *testing.T) {
 		}
 	})
 
+	t.Run("json mode omits the workspace message", func(t *testing.T) {
+		stdout.Reset()
+		global.TenantSelection = ""
+
+		oldJSON := global.Json
+		global.Json = true
+		t.Cleanup(func() { global.Json = oldJSON })
+
+		cmd := &cobra.Command{}
+		cmd.SetContext(t.Context())
+		printActiveWorkspace(cmd)
+
+		if global.Client == nil {
+			t.Fatal("expected global.Client to be reconnected with the new token")
+		}
+		if output := stdout.String(); output != "" {
+			t.Fatalf("expected no output in json mode, got: %q", output)
+		}
+	})
+
 	t.Run("userinfo fetch failure falls back to the raw tenant id", func(t *testing.T) {
 		stdout.Reset()
 		global.TenantSelection = ""

--- a/src/cmd/cli/command/whoami.go
+++ b/src/cmd/cli/command/whoami.go
@@ -1,7 +1,6 @@
 package command
 
 import (
-	"github.com/DefangLabs/defang/src/pkg/auth"
 	"github.com/DefangLabs/defang/src/pkg/cli"
 	"github.com/DefangLabs/defang/src/pkg/cli/client"
 	"github.com/DefangLabs/defang/src/pkg/term"
@@ -28,19 +27,7 @@ var whoamiCmd = &cobra.Command{
 			provider = session.Provider
 		}
 
-		token := client.GetExistingToken(global.FabricAddr)
-
-		var userInfo *auth.UserInfo
-		// Skip userinfo fetch in non-interactive mode (CI environments)
-		if global.HasTty {
-			userInfo, err = auth.FetchUserInfo(ctx, token)
-			if err != nil {
-				// Either the auth service is down, or we're using a Fabric JWT: skip workspace information
-				term.Warn("Workspace information unavailable:", err)
-			}
-		}
-
-		data, err := cli.Whoami(ctx, global.Client, provider, userInfo, global.TenantSelection)
+		data, err := cli.FetchAccountInfo(ctx, global.Client, provider, global.FabricAddr, global.TenantSelection, global.HasTty)
 		if err != nil {
 			return err
 		}

--- a/src/pkg/cli/whoami.go
+++ b/src/pkg/cli/whoami.go
@@ -64,3 +64,23 @@ func Whoami(ctx context.Context, fabric client.FabricClient, maybeProvider clien
 
 	return showData, nil
 }
+
+// FetchAccountInfo fetches userinfo from the auth service when hasTty is true, then resolves the
+// account/workspace info for fabric. This is the shared sequence behind both the `whoami` command
+// and the post-login workspace summary shown by `login`.
+func FetchAccountInfo(ctx context.Context, fabric client.FabricClient, maybeProvider client.Provider, fabricAddr string, tenantSelection types.TenantNameOrID, hasTty bool) (ShowAccountData, error) {
+	var userInfo *auth.UserInfo
+	// Skip userinfo fetch in non-interactive mode (CI environments)
+	if hasTty {
+		token := client.GetExistingToken(fabricAddr)
+		info, err := auth.FetchUserInfo(ctx, token)
+		if err != nil {
+			// Either the auth service is down, or we're using a Fabric JWT: skip workspace information
+			term.Warn("Workspace information unavailable:", err)
+		} else {
+			userInfo = info
+		}
+	}
+
+	return Whoami(ctx, fabric, maybeProvider, userInfo, tenantSelection)
+}

--- a/src/pkg/cli/whoami_test.go
+++ b/src/pkg/cli/whoami_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
@@ -9,6 +10,7 @@ import (
 	"connectrpc.com/connect"
 	"github.com/DefangLabs/defang/src/pkg/auth"
 	"github.com/DefangLabs/defang/src/pkg/cli/client"
+	"github.com/DefangLabs/defang/src/pkg/tokenstore"
 	"github.com/DefangLabs/defang/src/pkg/types"
 	defangv1 "github.com/DefangLabs/defang/src/protos/io/defang/v1"
 	"github.com/DefangLabs/defang/src/protos/io/defang/v1/defangv1connect"
@@ -70,4 +72,58 @@ func TestWhoami(t *testing.T) {
 	if got != want {
 		t.Errorf("Whoami() = %v, \nwant: %v", got, want)
 	}
+}
+
+func TestFetchAccountInfo(t *testing.T) {
+	mockService := &grpcWhoamiMockHandler{}
+	_, handler := defangv1connect.NewFabricControllerHandler(mockService)
+
+	fabricServer := httptest.NewServer(handler)
+	t.Cleanup(fabricServer.Close)
+
+	ctx := t.Context()
+	fabricAddr := strings.TrimPrefix(fabricServer.URL, "http://")
+	grpcClient, _ := ConnectWithTenant(ctx, fabricAddr, "tenant-1")
+
+	t.Run("non-interactive skips the userinfo fetch", func(t *testing.T) {
+		got, err := FetchAccountInfo(ctx, grpcClient, nil, fabricAddr, "tenant-1", false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.Workspace != "tenant-1" || got.Email != "" {
+			t.Errorf("expected the raw tenant id with no userinfo, got: %+v", got)
+		}
+	})
+
+	t.Run("interactive fetches userinfo and resolves the workspace name", func(t *testing.T) {
+		t.Setenv("DEFANG_ACCESS_TOKEN", "") // GetExistingToken prefers this env var over TokenStore
+
+		userinfoServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{
+				"allTenants":[{"id":"tenant-1","name":"Tenant One"}],
+				"userinfo":{"email":"user@example.com","name":"Test User"}
+			}`))
+		}))
+		t.Cleanup(userinfoServer.Close)
+
+		originalAuthClient := auth.OpenAuthClient
+		auth.OpenAuthClient = auth.NewClient("testclient", userinfoServer.URL)
+		t.Cleanup(func() { auth.OpenAuthClient = originalAuthClient })
+
+		originalTokenStore := client.TokenStore
+		client.TokenStore = &tokenstore.LocalDirTokenStore{Dir: t.TempDir()}
+		t.Cleanup(func() { client.TokenStore = originalTokenStore })
+		if err := client.TokenStore.Save(client.TokenStorageName(fabricAddr), "test-token"); err != nil {
+			t.Fatalf("failed to seed token store: %v", err)
+		}
+
+		got, err := FetchAccountInfo(ctx, grpcClient, nil, fabricAddr, "tenant-1", true)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.Workspace != "Tenant One" || got.Email != "user@example.com" {
+			t.Errorf("expected the resolved workspace name and userinfo, got: %+v", got)
+		}
+	})
 }


### PR DESCRIPTION
## Summary

Closes #2267.

After a successful `defang login`, the CLI now reconnects with the token just saved and prints which workspace will be used by default (e.g. `Using workspace "Acme Corp"`), resolved to a human-readable name via the userinfo service when available and falling back to the raw tenant ID otherwise.

This does not depend on #1856 (the still-open "workspace select + persisted state" PR): today's default workspace comes from `--workspace`/`DEFANG_WORKSPACE`/token subject, resolved the same way `defang whoami` and `defang workspace ls` already do. Once #1856 lands and a selection is persisted to state, it will show up here too since it flows into the same `TenantSelection`/`WhoAmI` resolution.

Non-interactive login (`--non-interactive`, GitHub Actions flow) is unaffected; the new behavior only runs on the interactive path.

## Test plan
- [x] `go build ./...`
- [x] `go test -short ./cmd/cli/command/... ./pkg/cli/... ./pkg/login/...` (new `TestPrintActiveWorkspace` covers default-tenant and explicit-selection resolution against a mocked Fabric + userinfo server)
- [x] `make lint` (pre-existing gosec findings elsewhere on `main` are unrelated to this change; verified via `git stash`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Login displays the active workspace after authentication in interactive mode.
  * Explicitly selected workspaces are resolved and shown during login.
  * Workspace information is retrieved using the current login session.
  * The identity command retrieves account and workspace details.
  * Workspace lookup failures no longer prevent login; the tenant ID may be shown as a fallback.
  * Non-interactive and JSON modes avoid displaying interactive workspace messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->