### PR TITLE
agent: refuse debugger writes when there is no one to confirm them

### DIFF
--- a/src/pkg/agent/tools/deploy.go
+++ b/src/pkg/agent/tools/deploy.go
@@ -21,6 +21,10 @@ type DeployParams struct {
 }
 
 func HandleDeployTool(ctx context.Context, params DeployParams, cli CLIInterface, ec elicitations.Controller, sc StackConfig) (string, error) {
+	if err := requireConfirmable(ec, "deploy the project"); err != nil {
+		return "", err
+	}
+
 	client, provider, loader, err := setupProviderAndLoader(ctx, params.LoaderParams, cli, ec, sc)
 	if err != nil {
 		return setupErrorResult(err)

--- a/src/pkg/agent/tools/deploy_test.go
+++ b/src/pkg/agent/tools/deploy_test.go
@@ -235,6 +235,27 @@ func TestHandleDeployTool(t *testing.T) {
 	}
 }
 
+func TestHandleDeployToolRefusesWhenNotConfirmable(t *testing.T) {
+	t.Chdir("testdata")
+	os.Unsetenv("DEFANG_PROVIDER")
+	os.Unsetenv("AWS_PROFILE")
+	os.Unsetenv("AWS_REGION")
+
+	mockCLI := &MockDeployCLI{}
+	ec := elicitations.NewController(&mockElicitationsClient{})
+	ec.SetSupported(false)
+
+	stack := &stacks.Parameters{Name: "production", Provider: client.ProviderAWS}
+	_, err := HandleDeployTool(t.Context(), DeployParams{}, mockCLI, ec, StackConfig{
+		FabricAddr: "test-cluster",
+		Stack:      stack,
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "refusing to deploy the project")
+	assert.Empty(t, mockCLI.CallLog, "no CLI calls should be made when the write is refused")
+}
+
 func TestHandleDeployToolUsesPreselectedContext(t *testing.T) {
 	dir := t.TempDir()
 	t.Chdir(dir)

--- a/src/pkg/agent/tools/destroy.go
+++ b/src/pkg/agent/tools/destroy.go
@@ -16,6 +16,10 @@ type DestroyParams struct {
 }
 
 func HandleDestroyTool(ctx context.Context, params DestroyParams, cli CLIInterface, ec elicitations.Controller, sc StackConfig) (string, error) {
+	if err := requireConfirmable(ec, "destroy the deployed project"); err != nil {
+		return "", err
+	}
+
 	client, provider, loader, err := setupProviderAndLoader(ctx, params.LoaderParams, cli, ec, sc)
 	if err != nil {
 		return setupErrorResult(err)

--- a/src/pkg/agent/tools/destroy_test.go
+++ b/src/pkg/agent/tools/destroy_test.go
@@ -74,6 +74,27 @@ func (m *MockDestroyCLI) InteractiveLoginMCP(ctx context.Context, fabricAddr str
 	return nil
 }
 
+func TestHandleDestroyToolRefusesWhenNotConfirmable(t *testing.T) {
+	t.Chdir("testdata")
+	os.Unsetenv("DEFANG_PROVIDER")
+	os.Unsetenv("AWS_PROFILE")
+	os.Unsetenv("AWS_REGION")
+
+	mockCLI := &MockDestroyCLI{CallLog: []string{}}
+	ec := elicitations.NewController(&mockElicitationsClient{})
+	ec.SetSupported(false)
+
+	stack := stacks.Parameters{Name: "test-stack", Provider: client.ProviderAWS}
+	_, err := HandleDestroyTool(t.Context(), DestroyParams{}, mockCLI, ec, StackConfig{
+		FabricAddr: "test-cluster",
+		Stack:      &stack,
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "refusing to destroy the deployed project")
+	assert.Empty(t, mockCLI.CallLog, "no CLI calls should be made when the write is refused")
+}
+
 func TestHandleDestroyTool(t *testing.T) {
 	tests := []struct {
 		name                 string

--- a/src/pkg/agent/tools/provider.go
+++ b/src/pkg/agent/tools/provider.go
@@ -12,6 +12,7 @@ import (
 	"github.com/DefangLabs/defang/src/pkg/elicitations"
 	"github.com/DefangLabs/defang/src/pkg/stacks"
 	"github.com/DefangLabs/defang/src/pkg/term"
+	"github.com/DefangLabs/defang/src/pkg/track"
 )
 
 const CreateNewStack = "Create new stack"
@@ -111,6 +112,21 @@ func setupProviderAndLoader(ctx context.Context, params common.LoaderParams, cli
 	}
 
 	return fabric, provider, loader, nil
+}
+
+// requireConfirmable guards a mutating tool (deploy, destroy, set_config,
+// remove_config) against running unattended. ec.IsSupported() is false only
+// when there is no user to elicit a response from (e.g. the CI-auto-invoked
+// debugger); in that case a misdiagnosis has no one to catch it before it
+// mutates live state, so the tool must refuse instead of proceeding on a
+// default. Interactive sessions and any run where elicitation is otherwise
+// supported are unaffected.
+func requireConfirmable(ec elicitations.Controller, action string) error {
+	if ec.IsSupported() {
+		return nil
+	}
+	track.Evt("Debug Write Refused", track.P("action", action))
+	return fmt.Errorf("refusing to %s: no user available to confirm this change; rerun interactively or make the change yourself", action)
 }
 
 // setupErrorResult converts a setupProviderAndLoader error into a tool result:

--- a/src/pkg/agent/tools/removeConfig.go
+++ b/src/pkg/agent/tools/removeConfig.go
@@ -17,6 +17,10 @@ type RemoveConfigParams struct {
 
 // HandleRemoveConfigTool handles the remove config tool logic
 func HandleRemoveConfigTool(ctx context.Context, params RemoveConfigParams, cli CLIInterface, ec elicitations.Controller, sc StackConfig) (string, error) {
+	if err := requireConfirmable(ec, fmt.Sprintf("remove config variable %q", params.Name)); err != nil {
+		return "", err
+	}
+
 	_, provider, loader, err := setupProviderAndLoader(ctx, params.LoaderParams, cli, ec, sc)
 	if err != nil {
 		return setupErrorResult(err)

--- a/src/pkg/agent/tools/removeConfig_test.go
+++ b/src/pkg/agent/tools/removeConfig_test.go
@@ -64,6 +64,27 @@ func (m *MockRemoveConfigCLI) InteractiveLoginMCP(ctx context.Context, fabricAdd
 	return nil
 }
 
+func TestHandleRemoveConfigToolRefusesWhenNotConfirmable(t *testing.T) {
+	t.Chdir("testdata")
+	os.Unsetenv("DEFANG_PROVIDER")
+	os.Unsetenv("AWS_PROFILE")
+	os.Unsetenv("AWS_REGION")
+
+	mockCLI := &MockRemoveConfigCLI{CallLog: []string{}}
+	ec := elicitations.NewController(&mockElicitationsClient{})
+	ec.SetSupported(false)
+
+	stack := stacks.Parameters{Name: "test-stack", Provider: client.ProviderAWS}
+	_, err := HandleRemoveConfigTool(t.Context(), RemoveConfigParams{Name: "DATABASE_URL"}, mockCLI, ec, StackConfig{
+		FabricAddr: "test-cluster",
+		Stack:      &stack,
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `refusing to remove config variable "DATABASE_URL"`)
+	assert.Empty(t, mockCLI.CallLog, "no CLI calls should be made when the write is refused")
+}
+
 func TestHandleRemoveConfigTool(t *testing.T) {
 	tests := []struct {
 		name                 string

--- a/src/pkg/agent/tools/setConfig.go
+++ b/src/pkg/agent/tools/setConfig.go
@@ -20,6 +20,10 @@ type SetConfigParams struct {
 }
 
 func HandleSetConfig(ctx context.Context, params SetConfigParams, cliInterface CLIInterface, ec elicitations.Controller, sc StackConfig) (string, error) {
+	if err := requireConfirmable(ec, fmt.Sprintf("set config variable %q", params.Name)); err != nil {
+		return "", err
+	}
+
 	_, provider, loader, err := setupProviderAndLoader(ctx, params.LoaderParams, cliInterface, ec, sc)
 	if err != nil {
 		return setupErrorResult(err)

--- a/src/pkg/agent/tools/setConfig_test.go
+++ b/src/pkg/agent/tools/setConfig_test.go
@@ -95,6 +95,27 @@ func (m *MockSetConfigCLI) InteractiveLoginMCP(ctx context.Context, fabricAddr s
 	return nil
 }
 
+func TestHandleSetConfigRefusesWhenNotConfirmable(t *testing.T) {
+	t.Chdir("testdata")
+	os.Unsetenv("DEFANG_PROVIDER")
+	os.Unsetenv("AWS_PROFILE")
+	os.Unsetenv("AWS_REGION")
+
+	mockCLI := &MockSetConfigCLI{}
+	ec := elicitations.NewController(&mockElicitationsClient{})
+	ec.SetSupported(false)
+
+	stack := stacks.Parameters{Name: "test-stack", Provider: client.ProviderAWS}
+	_, err := HandleSetConfig(t.Context(), SetConfigParams{Name: "test-config", Value: "test-value"}, mockCLI, ec, StackConfig{
+		FabricAddr: "test-cluster",
+		Stack:      &stack,
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `refusing to set config variable "test-config"`)
+	assert.False(t, mockCLI.ConfigSetCalled, "no config write should happen when the write is refused")
+}
+
 func TestHandleSetConfig(t *testing.T) {
 	// Common test data
 	const (

--- a/src/pkg/agent/tools/setConfig_test.go
+++ b/src/pkg/agent/tools/setConfig_test.go
@@ -113,6 +113,9 @@ func TestHandleSetConfigRefusesWhenNotConfirmable(t *testing.T) {
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), `refusing to set config variable "test-config"`)
+	assert.False(t, mockCLI.ConnectCalled, "no connect should happen when the write is refused")
+	assert.False(t, mockCLI.NewProviderCalled, "no provider setup should happen when the write is refused")
+	assert.False(t, mockCLI.LoadProjectNameCalled, "no project name lookup should happen when the write is refused")
 	assert.False(t, mockCLI.ConfigSetCalled, "no config write should happen when the write is refused")
 }
 

--- a/src/pkg/agent/tools/tools.go
+++ b/src/pkg/agent/tools/tools.go
@@ -6,16 +6,17 @@ import (
 	"github.com/firebase/genkit/go/ai"
 )
 
-func CollectDefangTools(ec elicitations.Controller, sc StackConfig) []ai.Tool {
+// mutatingTools are only handed to the model when ec.IsSupported() — i.e. when
+// there is a user who could be asked to confirm a change. Where that isn't known
+// synchronously (e.g. the MCP server negotiates elicitation support per-connection
+// after tools are already registered), requireConfirmable in each handler is the
+// actual enforcement; leaving these out here is the defense that also applies where
+// support is known up front, such as the non-interactive CI debugger.
+func mutatingTools(ec elicitations.Controller, sc StackConfig) []ai.Tool {
+	if !ec.IsSupported() {
+		return nil
+	}
 	return []ai.Tool{
-		ai.NewTool(
-			"services",
-			"List deployed services for the selected project stack in the current working directory",
-			func(ctx *ai.ToolContext, params ServicesParams) (string, error) {
-				var cli CLIInterface = &DefaultToolCLI{}
-				return HandleServicesTool(ctx.Context, params, cli, ec, sc)
-			},
-		),
 		ai.NewTool("deploy",
 			"Initiate deployment of the application stack defined in the docker-compose files in the current working directory",
 			func(ctx *ai.ToolContext, params DeployParams) (string, error) {
@@ -28,6 +29,33 @@ func CollectDefangTools(ec elicitations.Controller, sc StackConfig) []ai.Tool {
 			func(ctx *ai.ToolContext, params DestroyParams) (string, error) {
 				cli := &DefaultToolCLI{}
 				return HandleDestroyTool(ctx.Context, params, cli, ec, sc)
+			},
+		),
+		ai.NewTool("set_config",
+			"Set a config variable for the currently selected stack in the Defang project",
+			func(ctx *ai.ToolContext, params SetConfigParams) (string, error) {
+				cli := &DefaultToolCLI{}
+				return HandleSetConfig(ctx.Context, params, cli, ec, sc)
+			},
+		),
+		ai.NewTool("remove_config",
+			"Remove a config variable from the currently selected stack in the Defang project",
+			func(ctx *ai.ToolContext, params RemoveConfigParams) (string, error) {
+				cli := &DefaultToolCLI{}
+				return HandleRemoveConfigTool(ctx.Context, params, cli, ec, sc)
+			},
+		),
+	}
+}
+
+func CollectDefangTools(ec elicitations.Controller, sc StackConfig) []ai.Tool {
+	toolList := []ai.Tool{
+		ai.NewTool(
+			"services",
+			"List deployed services for the selected project stack in the current working directory",
+			func(ctx *ai.ToolContext, params ServicesParams) (string, error) {
+				var cli CLIInterface = &DefaultToolCLI{}
+				return HandleServicesTool(ctx.Context, params, cli, ec, sc)
 			},
 		),
 		ai.NewTool("logs",
@@ -46,13 +74,6 @@ func CollectDefangTools(ec elicitations.Controller, sc StackConfig) []ai.Tool {
 				}
 				cli := &DefaultToolCLI{}
 				return HandleEstimateTool(ctx.Context, loader, params, cli, sc)
-			},
-		),
-		ai.NewTool("set_config",
-			"Set a config variable for the currently selected stack in the Defang project",
-			func(ctx *ai.ToolContext, params SetConfigParams) (string, error) {
-				cli := &DefaultToolCLI{}
-				return HandleSetConfig(ctx.Context, params, cli, ec, sc)
 			},
 		),
 		ai.NewTool("select_stack",
@@ -91,13 +112,6 @@ func CollectDefangTools(ec elicitations.Controller, sc StackConfig) []ai.Tool {
 				return HandleCurrentStackTool(ctx.Context, sc)
 			},
 		),
-		ai.NewTool("remove_config",
-			"Remove a config variable from the currently selected stack in the Defang project",
-			func(ctx *ai.ToolContext, params RemoveConfigParams) (string, error) {
-				cli := &DefaultToolCLI{}
-				return HandleRemoveConfigTool(ctx.Context, params, cli, ec, sc)
-			},
-		),
 		ai.NewTool("list_configs",
 			"List config variables for the currently selected stack in the Defang project",
 			func(ctx *ai.ToolContext, params ListConfigParams) (string, error) {
@@ -116,4 +130,5 @@ func CollectDefangTools(ec elicitations.Controller, sc StackConfig) []ai.Tool {
 			},
 		),
 	}
+	return append(toolList, mutatingTools(ec, sc)...)
 }

--- a/src/pkg/agent/tools/tools_test.go
+++ b/src/pkg/agent/tools/tools_test.go
@@ -1,0 +1,42 @@
+package tools
+
+import (
+	"testing"
+
+	"github.com/DefangLabs/defang/src/pkg/elicitations"
+	"github.com/stretchr/testify/assert"
+)
+
+func toolNames(t *testing.T, ec elicitations.Controller) map[string]bool {
+	t.Helper()
+	names := map[string]bool{}
+	for _, tool := range CollectDefangTools(ec, StackConfig{}) {
+		names[tool.Name()] = true
+	}
+	return names
+}
+
+func TestCollectDefangTools_OmitsMutatingToolsWhenUnsupported(t *testing.T) {
+	ec := elicitations.NewController(&mockElicitationsClient{})
+	ec.SetSupported(false)
+
+	names := toolNames(t, ec)
+
+	for _, mutating := range []string{"deploy", "destroy", "set_config", "remove_config"} {
+		assert.False(t, names[mutating], "expected %q to be omitted when elicitation is unsupported", mutating)
+	}
+	for _, readOnly := range []string{"services", "logs", "estimate", "list_configs", "current_stack"} {
+		assert.True(t, names[readOnly], "expected %q to still be offered when elicitation is unsupported", readOnly)
+	}
+}
+
+func TestCollectDefangTools_IncludesMutatingToolsWhenSupported(t *testing.T) {
+	ec := elicitations.NewController(&mockElicitationsClient{})
+	ec.SetSupported(true)
+
+	names := toolNames(t, ec)
+
+	for _, mutating := range []string{"deploy", "destroy", "set_config", "remove_config"} {
+		assert.True(t, names[mutating], "expected %q to be offered when elicitation is supported", mutating)
+	}
+}


### PR DESCRIPTION
## Summary

The auto-approved, unattended debugger (`agent.WithNonInteractive()`, used only by the CI-auto-invoked debugger — see `debug.NewDebugger`) holds the full write toolset — `deploy`, `destroy`, `set_config`, `remove_config` — with no confirmation gate. A misdiagnosis can silently mutate production, and the tool reports success either way. This happened: during a failed production deploy of Defang Station on 2026-09-09, the debugger called `set_config` with a random `POSTGRES_PASSWORD` against the production stack while diagnosing an unrelated Pulumi provider error (DefangLabs/station#45, DefangLabs/defang#2269).

This takes the **root-cause** path from #2269's "Additional notes": each write-capable tool handler now refuses up front when `elicitations.Controller.IsSupported()` is false — i.e. when there is no user to confirm with. That's true only for the unattended CI debugger; interactive sessions (`ec.SetSupported(true)`, the default) are unaffected, and normal `defang compose up`/`deploy` CLI commands don't go through these agent tool handlers at all. Read tools (`services`, `logs`, `list_configs`, `current_stack`, ...) are untouched, so the debugger keeps full read access to diagnose.

- Added `requireConfirmable(ec, action)` in `src/pkg/agent/tools/provider.go`, called at the top of `HandleDeployTool`, `HandleDestroyTool`, `HandleSetConfig`, `HandleRemoveConfigTool`, before any provider/network setup.
- Fires a `track.Evt("Debug Write Refused", ...)` on refusal, so this becomes observable in analytics going forward (answers the thread's "has this fired elsewhere" question, for future occurrences).

## Not in this PR

Flagging back to the issue thread rather than folding into this diff:
- Widening constitution §VII ("Destructive operations require confirmation") beyond MCP/IDE integration to cover this agent surface.
- §II.3's audit-logging gap — the write is currently a `term.Debug` line, not a structured audit event.

## Test plan

- [x] `go test -short ./pkg/agent/tools/... ./pkg/agent/... ./pkg/debug/... ./pkg/elicitations/...` — added a refusal-path test per handler (asserts the underlying CLI is never called) plus full existing suite, all green.
- [x] `golangci-lint run ./pkg/agent/... ./pkg/elicitations/... ./pkg/debug/...` — 0 issues.
- [x] `go vet` / `gofmt` clean on touched files.

Fixes #2269

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Ajfh9i3kHCZW4Us2k7k1Ah

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added confirmation prompts before deployments, project destruction, and configuration changes.
  - Mutating actions are blocked when confirmation is unavailable or declined, preventing unintended changes.
  - Users receive actionable errors when confirmation cannot be requested.

- **Bug Fixes**
  - Prevented deployment, destruction, and configuration updates from proceeding without confirmation.

- **Tests**
  - Added coverage verifying blocked operations do not invoke underlying actions when confirmation is unsupported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->