### PR TITLE
ci: retry smoketest gate once when GitHub cancels a queued dispatch

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -295,7 +295,7 @@ jobs:
       group: smoketests-${{ github.ref }}
       cancel-in-progress: false
     environment: smoketest
-    timeout-minutes: 45
+    timeout-minutes: 90
     steps:
       - name: Trigger smoketests and await conclusion
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -321,33 +321,53 @@ jobs:
             const workflow_id = 'cli-smoketests.yml';
             const cliVersion = context.sha; // build the CLI from the exact commit under test
 
-            // Remember the newest existing run: createWorkflowDispatch does not
-            // return the new run's id, so we find ours by id > watermark plus the
-            // CLI version in the run name (see run-name in cli-smoketests.yml).
-            const { data: before } = await github.rest.actions.listWorkflowRuns({ owner, repo, workflow_id, per_page: 1 });
-            const watermark = before.workflow_runs[0]?.id ?? 0;
-
-            await github.rest.actions.createWorkflowDispatch({
-              owner, repo, workflow_id, ref: 'main',
-              inputs: { 'sample-name': 'html-css-js', 'cli-version': cliVersion },
-            });
-
             const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
-            let run;
-            for (let i = 0; i < 30 && !run; i++) {
-              await sleep(10_000);
-              const { data } = await github.rest.actions.listWorkflowRuns({ owner, repo, workflow_id, event: 'workflow_dispatch', per_page: 30 });
-              run = data.workflow_runs.find((wr) => wr.id > watermark && wr.name.includes(cliVersion));
-            }
-            if (!run) {
-              throw new Error('Timed out waiting for the dispatched smoketest run to appear');
-            }
-            core.notice(`Awaiting smoketests: ${run.html_url}`);
+            // cli-smoketests.yml's deployment_smoketests job shares one concurrency
+            // group per provider+sample across every caller (this workflow on every
+            // ref, plus pulumi-up.yml). With cancel-in-progress:false, GitHub still
+            // cancels a *queued* run when a third dispatch arrives while one is
+            // running and one is already queued - it keeps only the running run and
+            // the newest queued one. That cancellation says nothing about this
+            // commit's CLI, so retry the dispatch instead of failing outright.
+            async function dispatchAndAwait() {
+              // Remember the newest existing run: createWorkflowDispatch does not
+              // return the new run's id, so we find ours by id > watermark plus the
+              // CLI version in the run name (see run-name in cli-smoketests.yml).
+              const { data: before } = await github.rest.actions.listWorkflowRuns({ owner, repo, workflow_id, per_page: 1 });
+              const watermark = before.workflow_runs[0]?.id ?? 0;
 
-            while (run.status !== 'completed') {
-              await sleep(30_000);
-              run = (await github.rest.actions.getWorkflowRun({ owner, repo, run_id: run.id })).data;
+              await github.rest.actions.createWorkflowDispatch({
+                owner, repo, workflow_id, ref: 'main',
+                inputs: { 'sample-name': 'html-css-js', 'cli-version': cliVersion },
+              });
+
+              let run;
+              for (let i = 0; i < 30 && !run; i++) {
+                await sleep(10_000);
+                const { data } = await github.rest.actions.listWorkflowRuns({ owner, repo, workflow_id, event: 'workflow_dispatch', per_page: 30 });
+                run = data.workflow_runs.find((wr) => wr.id > watermark && wr.name.includes(cliVersion));
+              }
+              if (!run) {
+                throw new Error('Timed out waiting for the dispatched smoketest run to appear');
+              }
+              core.notice(`Awaiting smoketests: ${run.html_url}`);
+
+              while (run.status !== 'completed') {
+                await sleep(30_000);
+                run = (await github.rest.actions.getWorkflowRun({ owner, repo, run_id: run.id })).data;
+              }
+              return run;
+            }
+
+            const maxAttempts = 2;
+            let run;
+            for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+              run = await dispatchAndAwait();
+              if (run.conclusion !== 'cancelled') {
+                break;
+              }
+              core.notice(`Smoketests were cancelled, likely superseded by a concurrent dispatch to the same provider/sample concurrency group: ${run.html_url} (attempt ${attempt}/${maxAttempts})`);
             }
             if (run.conclusion !== 'success') {
               throw new Error(`Smoketests concluded '${run.conclusion}': ${run.html_url}`);

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -346,7 +346,7 @@ jobs:
               for (let i = 0; i < 30 && !run; i++) {
                 await sleep(10_000);
                 const { data } = await github.rest.actions.listWorkflowRuns({ owner, repo, workflow_id, event: 'workflow_dispatch', per_page: 30 });
-                run = data.workflow_runs.find((wr) => wr.id > watermark && wr.name.includes(cliVersion));
+                run = data.workflow_runs.find((wr) => wr.id > watermark && wr.display_title.includes(cliVersion));
               }
               if (!run) {
                 throw new Error('Timed out waiting for the dispatched smoketest run to appear');


### PR DESCRIPTION
## Summary

The v3.15.4 "Go package" run failed today because its "Trigger CLI smoketests (BYOC)" gate job saw its dispatched `cli-smoketests.yml` run come back `cancelled`:

https://github.com/DefangLabs/defang/actions/runs/34501088879 (job: Trigger CLI smoketests (BYOC))

Root cause: `deployment_smoketests` in `defang-mvp`'s `cli-smoketests.yml` uses one `concurrency` group per provider+sample (`byoc-aws-html-css-js-group` / `byoc-gcp-html-css-js-group`), shared across *every* caller — this workflow on any ref, plus `pulumi-up.yml`. That group has `cancel-in-progress: false`, which protects an in-flight deploy, but GitHub Actions still cancels a *queued* run when a third dispatch arrives while one run is already in progress and another is already queued: it keeps only the running run and the newest queued one, dropping the one in the middle.

That's exactly what happened here: two tags on the same commit (`v3.15.2`, `v3.15.4`) plus a `main` push all dispatched the `html-css-js` smoketest within about 5 minutes of each other. The middle dispatch (v3.15.4's) got cancelled as superseded:

> Canceling since a higher priority waiting request for byoc-aws-html-css-js-group exists

This says nothing about the CLI built from that commit — it's pure scheduling fallout — but the gate treated `cancelled` the same as a real failure and skipped `go-release`/`push-docker`/`post-release`.

## Fix

Wrap the dispatch-and-await logic in a small retry: if the awaited run's conclusion is `cancelled`, dispatch again (up to 2 attempts total) before failing the job. A fresh dispatch after the collision clears should run normally. Bumped the job's `timeout-minutes` from 45 to 90 to leave room for a second attempt (observed a single attempt can already take ~25-30 minutes including its own concurrency queue wait).

## Test plan

- [x] `actionlint .github/workflows/go.yml` passes
- [ ] Next tag/main push exercises the real path; a deliberate collision is impractical to reproduce locally since it depends on `defang-mvp`'s GitHub-side concurrency queue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Smoke tests now allow up to 90 minutes to complete.
  - Automated smoke-test runs retry once if a dispatched run is cancelled, improving the reliability of validation results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->